### PR TITLE
Create w3c.json

### DIFF
--- a/w3c.json
+++ b/w3c.json
@@ -1,0 +1,10 @@
+{
+    "group": [
+        117488
+    ],
+    "contacts": [
+        "pchampin"
+    ],
+    "repo-type": "rec-track",
+    "shortName": "did-resolution"
+}


### PR DESCRIPTION
This is necessary for W3C repository; it formally "anchors" this repository for the DID Working Group