### PR TITLE
Clarify headings for dereferencing primary/secondary resource

### DIFF
--- a/index.html
+++ b/index.html
@@ -1028,7 +1028,7 @@ dereference(didUrl, dereferenceOptions) →
 		</ol>
 
 		<section id="dereferencing-algorithm-primary">
-			<h2>Dereferencing the Primary Resource</h2>
+			<h2>Dereferencing the Primary Resource (DID document or other resource)</h2>
 			<ol class="algorithm">
 				<li>If the <var>input <a>DID URL</a></var> contains the
 				<a href="https://www.w3.org/TR/did-core/#did-parameters">
@@ -1086,7 +1086,7 @@ dereference(didUrl, dereferenceOptions) →
 		</section>
 
 		<section id="dereferencing-algorithm-secondary">
-			<h2>Dereferencing the Secondary Resource</h2>
+			<h2>Dereferencing the Secondary Resource (fragment)</h2>
 			<p>If the <var>input <a>DID URL</a></var> contains a <a>DID fragment</a>,
 			then dereferencing of the secondary resource identified by the URL is dependent not on the URI scheme, but
 			on the media type ([[RFC2046]]) of the primary resource, i.e., on the result of


### PR DESCRIPTION
This expands the names of the sections about dereferencing the primary/secondary resources.

I'm actually not sure if I am in favor of merging this, since it results in longer headning. But I wanted to capture this since it has been brought up in last week's DID WG meeting.