### PR TITLE
Add details to results of the dereferencing algorithm.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1016,13 +1016,22 @@ dereference(didUrl, dereferenceOptions) →
 						<li><b>contentStream</b>: <code>null</code></li>
 						<li><b>contentMetadata</b>: <code>«[ ]»</code></li>
 					</ol>
+				</li>
 
 				<li>Obtain the <a>DID document</a> for the <var>input <a>DID</a></var> by executing the
 					<a>DID resolution</a> algorithm as defined in <a href="#resolving"></a>. All
 					<a href="https://www.w3.org/TR/did-core/#did-parameters">
 						DID parameters</a> of the <var>input <a>DID URL</a></var> MUST be passed as <var>resolution options</var> to the
-						<a>DID Resolution</a> algorithm. If the <var>input <a>DID</a></var> does not exist, return a null result.
-						Otherwise, the result is called the <var>resolved <a>DID document</a></var>.</li>
+						<a>DID Resolution</a> algorithm. If the <var>input <a>DID</a></var> does not exist, the <a>DID URL dereferencer</a>
+						MUST return the following result:
+
+						<ol class="algorithm">
+							<li><b>dereferencingMetadata</b>: <code>«[ "error" → "notFound" ]»</code></li>
+							<li><b>contentStream</b>: <code>null</code></li>
+							<li><b>contentMetadata</b>: <code>«[ ]»</code></li>
+						</ol>
+
+						Otherwise, the result is called the <var>resolved <a>DID document</a></var>.
 				</li>
 
 				<li>If present, separate the <a>DID fragment</a> from the <var>input <a>DID URL</a></var> and continue
@@ -1030,8 +1039,13 @@ dereference(didUrl, dereferenceOptions) →
 
 				<li>If the <var>input <a>DID URL</a></var> contains no <a>DID path</a> and no <a>DID query</a>:
 					<pre class="example nohighlight">did:example:1234</pre>
+					The <a>DID URL dereferencer</a> MUST return the <var>resolved <a>DID document</a></var> and
+					<var>resolved <a href="#did-document-metadata"></a> as follows:
+
 					<ol class="algorithm">
-						<li>Return the <var>resolved <a>DID document</a></var>.</li>
+						<li><b>dereferencingMetadata</b>: <code>«[ derefencingMetadata ]»</code></li>
+						<li><b>contentStream</b>: <code>resolved didDocumentStream</code></li>
+						<li><b>contentMetadata</b>: <code>«[ resolved didDocumentMetadata ]»</code></li>
 					</ol>
 				</li>
 

--- a/index.html
+++ b/index.html
@@ -690,7 +690,7 @@ string">ASCII string</a>.
 			<a href="https://www.w3.org/TR/did-core/#did-syntax">DID Syntax</a>.
 			If not, the <a>DID resolver</a> MUST return the following result:
 			<ol class="algorithm">
-				<li><b>didResolutionMetadata</b>: <code>«[ "error" → "invalidDid" ]»</code></li>
+				<li><b>didResolutionMetadata</b>: <code>«[ "error" → "invalidDid", ... ]»</code></li>
 				<li><b>didDocument</b>: <code>null</code></li>
 				<li><b>didDocumentMetadata</b>: <code>«[ ]»</code></li>
 			</ol>
@@ -698,7 +698,7 @@ string">ASCII string</a>.
 			<li>Determine whether the DID method of the <var>input <a>DID</a></var> is supported by the <a>DID resolver</a>
 			that implements this algorithm. If not, the <a>DID resolver</a> MUST return the following result:
 			<ol class="algorithm">
-				<li><b>didResolutionMetadata</b>: <code>«[ "error" → "methodNotSupported" ]»</code></li>
+				<li><b>didResolutionMetadata</b>: <code>«[ "error" → "methodNotSupported", ... ]»</code></li>
 				<li><b>didDocument</b>: <code>null</code></li>
 				<li><b>didDocumentMetadata</b>: <code>«[ ]»</code></li>
 			</ol>
@@ -713,26 +713,31 @@ string">ASCII string</a>.
 				<var>input <a>DID method</a></var>.</li>
 				<li>If the <var>input <a>DID</a></var> does not exist, return the following result:
 				<ol class="algorithm">
-					<li><b>didResolutionMetadata</b>: <code>«[ "error" → "notFound" ]»</code></li>
+					<li><b>didResolutionMetadata</b>: <code>«[ "error" → "notFound", ... ]»</code></li>
 					<li><b>didDocument</b>: <code>null</code></li>
 					<li><b>didDocumentMetadata</b>: <code>«[ ]»</code></li>
 				</ol>
 				</li>
 				<li>If the <var>input <a>DID</a></var> has been deactivated, return the following result:
 				<ol class="algorithm">
-					<li><b>didResolutionMetadata</b>: <code>«[ ]»</code></li>
+					<li><b>didResolutionMetadata</b>: <code>«[ ... ]»</code></li>
 					<li><b>didDocument</b>: <code>null</code></li>
-					<li><b>didDocumentMetadata</b>: <code>«[ "deactivated" → true ]»</code></li>
+					<li><b>didDocumentMetadata</b>: <code>«[ "deactivated" → true, ... ]»</code></li>
 				</ol>
 				</li>
-				<li>The result of the <a href="https://www.w3.org/TR/did-core/#method-operations">Read</a> operation
-				is called the <var>output <a>DID document</a></var>.</li>
+				<li>Otherwise, the result of the <a href="https://www.w3.org/TR/did-core/#method-operations">Read</a> operation
+					is called the <var>output <a>DID document</a></var>. This result MUST be represented in a
+					<a href="https://www.w3.org/TR/did-core/#representations">conformant representation</a> that
+					corresponds to the <b>accept</b> <var>resolution option</var>.</li>
+				<li>Return the following result:
+					<ol class="algorithm">
+						<li><b>didResolutionMetadata</b>: <code>«[ ... ]»</code></li>
+						<li><b>didDocument</b>: <var>output DID document</var></li>
+						<li><b>didDocumentMetadata</b>: <code>«[ "contentType" → </code><var>output DID document media type</var><code>, ... ]»</code></li>
+					</ol>
+				</li>
 			</ol>
 			</li>
-			<li>Validate that the <var>output <a>DID document</a></var> conforms to a
-			<a href="https://www.w3.org/TR/did-core/#representations">conformant representation</a> of the <a>DID document</a>
-			<a href="https://www.w3.org/TR/did-core/#data-model">data model</a>. If not,
-			the <a>DID resolver</a> MUST raise an error.</li>
 		</ol>
 
 		<p class="issue" data-number="5">There is discussion how a DID that has been
@@ -1010,45 +1015,38 @@ dereference(didUrl, dereferenceOptions) →
 				<li>Validate that the <var>input <a>DID URL</a></var> conforms to the `did-url` rule of the
 					<a href="https://www.w3.org/TR/did-core/#did-url-syntax">DID URL Syntax</a>.
 					If not, the <a>DID URL dereferencer</a> MUST return the following result:
-
 					<ol class="algorithm">
 						<li><b>dereferencingMetadata</b>: <code>«[ "error" → "invalidDidUrl" ]»</code></li>
 						<li><b>contentStream</b>: <code>null</code></li>
 						<li><b>contentMetadata</b>: <code>«[ ]»</code></li>
 					</ol>
 				</li>
-
 				<li>Obtain the <a>DID document</a> for the <var>input <a>DID</a></var> by executing the
 					<a>DID resolution</a> algorithm as defined in <a href="#resolving"></a>. All
 					<a href="https://www.w3.org/TR/did-core/#did-parameters">
 						DID parameters</a> of the <var>input <a>DID URL</a></var> MUST be passed as <var>resolution options</var> to the
-						<a>DID Resolution</a> algorithm. If the <var>input <a>DID</a></var> does not exist in the VDR, the <a>DID URL dereferencer</a>
+						<a>DID Resolution</a> algorithm.</li>
+				<li>If the <var>input <a>DID</a></var> does not exist in the VDR, the <a>DID URL dereferencer</a>
 						MUST return the following result:
-
 						<ol class="algorithm">
-							<li><b>dereferencingMetadata</b>: <code>«[ "error" → "notFound" ]»</code></li>
+							<li><b>dereferencingMetadata</b>: <code>«[ "error" → "notFound", ... ]»</code></li>
 							<li><b>contentStream</b>: <code>null</code></li>
 							<li><b>contentMetadata</b>: <code>«[ ]»</code></li>
 						</ol>
-
-						Otherwise, the result is called the <var>resolved <a>DID document</a></var>.
 				</li>
-
+				<li>Otherwise, the <b>didDocument</b> result of the <a>DID resolution</a> algorithm is called the <var>resolved <a>DID document</a></var>.</li>
 				<li>If present, separate the <a>DID fragment</a> from the <var>input <a>DID URL</a></var> and continue
 					with the adjusted <var>input <a>DID URL</a></var>.</li>
-
 				<li>If the <var>input <a>DID URL</a></var> contains no <a>DID path</a> and no <a>DID query</a>:
 					<pre class="example nohighlight">did:example:1234</pre>
 					The <a>DID URL dereferencer</a> MUST return the <var>resolved <a>DID document</a></var> and
 					<var>resolved <a href="#did-document-metadata"></a></var> as follows:
-
 					<ol class="algorithm">
-						<li><b>dereferencingMetadata</b>: <code>«[ derefencingMetadata ]»</code></li>
-						<li><b>contentStream</b>: <code>resolved didDocumentStream</code></li>
-						<li><b>contentMetadata</b>: <code>«[ resolved didDocumentMetadata ]»</code></li>
+						<li><b>dereferencingMetadata</b>: <code>«[ ... ]»</code></li>
+						<li><b>contentStream</b>: <code>resolved DID document</code></li>
+						<li><b>contentMetadata</b>: <code>«[ <code>resolved DID document metadata</code> ]»</code></li>
 					</ol>
 				</li>
-
 				<li>Otherwise, if the <var>input <a>DID URL</a></var> contains the
 				<a href="https://www.w3.org/TR/did-core/#did-parameters">
 				DID parameter</a> <code>service</code> and optionally the <code>relativeRef</code> DID parameter:
@@ -1067,7 +1065,13 @@ dereference(didUrl, dereferenceOptions) →
 						<li>The result is called the <var>output <a>service endpoint</a> URL</var>.</li>
 					</ol>
 					</li>
-					<li>Return the <var>output <a>service endpoint</a> URL</var>.</li>
+					<li>Return the following result:
+						<ol class="algorithm">
+							<li><b>dereferencingMetadata</b>: <code>«[ ... ]»</code></li>
+							<li><b>content</b>: <var>output service endpoint URL</var></li>
+							<li><b>contentMetadata</b>: <code>«[ "contentType" → "text/uri-list", ... ]»</code></li>
+						</ol>
+					</li>
 				</ol>
 				</li>
 				<li>Otherwise, if the <var>input <a>DID URL</a></var> contains a <a>DID path</a> and/or <a>DID query</a>:

--- a/index.html
+++ b/index.html
@@ -1022,7 +1022,7 @@ dereference(didUrl, dereferenceOptions) →
 					<a>DID resolution</a> algorithm as defined in <a href="#resolving"></a>. All
 					<a href="https://www.w3.org/TR/did-core/#did-parameters">
 						DID parameters</a> of the <var>input <a>DID URL</a></var> MUST be passed as <var>resolution options</var> to the
-						<a>DID Resolution</a> algorithm. If the <var>input <a>DID</a></var> does not exist, the <a>DID URL dereferencer</a>
+						<a>DID Resolution</a> algorithm. If the <var>input <a>DID</a></var> does not exist in the VDR, the <a>DID URL dereferencer</a>
 						MUST return the following result:
 
 						<ol class="algorithm">

--- a/index.html
+++ b/index.html
@@ -1078,12 +1078,22 @@ dereference(didUrl, dereferenceOptions) →
 				<pre class="example nohighlight">did:example:1234/custom/path?customquery</pre>
 				<ol class="algorithm">
 					<li>The applicable <a>DID method</a> MAY specify how to dereference
-					the <var>input <a>DID URL</a></var>.</li>
+						the <a>DID path</a> and/or <a>DID query</a> of the <var>input <a>DID URL</a></var>.
+						<pre class="example nohighlight">did:example:1234/resources/1234</pre>
+					</li>
+					<li>An extension specification MAY specify how to dereference
+						the <a>DID path</a> of the <var>input <a>DID URL</a></var>.
+						<pre class="example nohighlight">did:example:1234/whois</pre>
+					</li>
+					<li>An extension specification MAY specify how to dereference
+						the <a>DID query</a> of the <var>input <a>DID URL</a></var>.
+						<pre class="example nohighlight">did:example:1234?transformKey=JsonWebKey</pre>
+					</li>
 					<li>The client MAY be able to dereference the <var>input <a>DID URL</a></var>
-					in an application-specific way.</li>
+						in an application-specific way.</li>
 				</ol>
 				</li>
-				<li>If neither this algorithm, nor the applicable <a>DID method</a>, nor the client
+				<li>If neither this algorithm, nor the applicable <a>DID method</a>, nor an extension, nor the client
 				is able to dereference the <var>input <a>DID URL</a></var>, return the following result:
 				<ol class="algorithm">
 					<li><b>dereferencingMetadata</b>: <code>«[ "error" → "notFound" ]»</code></li>

--- a/index.html
+++ b/index.html
@@ -1040,7 +1040,7 @@ dereference(didUrl, dereferenceOptions) →
 				<li>If the <var>input <a>DID URL</a></var> contains no <a>DID path</a> and no <a>DID query</a>:
 					<pre class="example nohighlight">did:example:1234</pre>
 					The <a>DID URL dereferencer</a> MUST return the <var>resolved <a>DID document</a></var> and
-					<var>resolved <a href="#did-document-metadata"></a> as follows:
+					<var>resolved <a href="#did-document-metadata"></a></var> as follows:
 
 					<ol class="algorithm">
 						<li><b>dereferencingMetadata</b>: <code>«[ derefencingMetadata ]»</code></li>


### PR DESCRIPTION
This adds more detailed information about the result of the dereferencing algorithm in the common cases 1. when the DID is not found, and 2. when the dereferenced resource is simply a DID document.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-resolution/pull/103.html" title="Last updated on Jan 9, 2025, 2:02 PM UTC (8f64678)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-resolution/103/231a0f3...8f64678.html" title="Last updated on Jan 9, 2025, 2:02 PM UTC (8f64678)">Diff</a>