### PR TITLE
Add more details about how to dereference path and query of a DID URL.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1016,6 +1016,7 @@ dereference(didUrl, dereferenceOptions) →
 						<li><b>contentStream</b>: <code>null</code></li>
 						<li><b>contentMetadata</b>: <code>«[ ]»</code></li>
 					</ol>
+				</li>
 
 				<li>Obtain the <a>DID document</a> for the <var>input <a>DID</a></var> by executing the
 					<a>DID resolution</a> algorithm as defined in <a href="#resolving"></a>. All
@@ -1023,7 +1024,6 @@ dereference(didUrl, dereferenceOptions) →
 						DID parameters</a> of the <var>input <a>DID URL</a></var> MUST be passed as <var>resolution options</var> to the
 						<a>DID Resolution</a> algorithm. If the <var>input <a>DID</a></var> does not exist, return a null result.
 						Otherwise, the result is called the <var>resolved <a>DID document</a></var>.</li>
-				</li>
 
 				<li>If present, separate the <a>DID fragment</a> from the <var>input <a>DID URL</a></var> and continue
 					with the adjusted <var>input <a>DID URL</a></var>.</li>

--- a/index.html
+++ b/index.html
@@ -1035,7 +1035,31 @@ dereference(didUrl, dereferenceOptions) →
 					</ol>
 				</li>
 
-				<li>Otherwise, if the <var>input <a>DID URL</a></var> contains the
+				<li>If the <var>input <a>DID URL</a></var> contains the
+					<a href="https://www.w3.org/TR/did-core/#did-parameters">DID parameter</a> <code>hl</code>:
+					<pre class="example nohighlight">did:example:1234?hl=zQmWvQxTqbG2Z9HPJgG57jjwR154cKhbtJenbyYTWkjgF3e</pre>
+					<ol class="algorithm"><li>
+						<p class="issue">TODO: Specify the algorithm for processing the `hl` DID parameter.</p>
+					</li></ol>
+				</li>
+
+				<li>If the <var>input <a>DID URL</a></var> contains the
+					<a href="https://www.w3.org/TR/did-core/#did-parameters">DID parameter</a> <code>versionId</code>:
+					<pre class="example nohighlight">did:example:1234?versionId=1</pre>
+					<ol class="algorithm"><li>
+						<p class="issue">TODO: Specify the algorithm for processing the `versionId` DID parameter.</p>
+					</li></ol>
+				</li>
+
+				<li>If the <var>input <a>DID URL</a></var> contains the
+					<a href="https://www.w3.org/TR/did-core/#did-parameters">DID parameter</a> <code>versionTime</code>:
+					<pre class="example nohighlight">did:example:1234??versionTime=2021-05-10T17:00:00Z</pre>
+					<ol class="algorithm"><li>
+						<p class="issue">TODO: Specify the algorithm for processing the `versionTime` DID parameter.</p>
+					</li></ol>
+				</li>
+
+				<li>If the <var>input <a>DID URL</a></var> contains the
 				<a href="https://www.w3.org/TR/did-core/#did-parameters">
 				DID parameter</a> <code>service</code> and optionally the <code>relativeRef</code> DID parameter:
 				<pre class="example nohighlight">did:example:1234?service=files&relativeRef=%2Fmyresume%2Fdoc%3Fversion%3Dlatest</pre>
@@ -1056,16 +1080,28 @@ dereference(didUrl, dereferenceOptions) →
 					<li>Return the <var>output <a>service endpoint</a> URL</var>.</li>
 				</ol>
 				</li>
+
 				<li>Otherwise, if the <var>input <a>DID URL</a></var> contains a <a>DID path</a> and/or <a>DID query</a>:
 				<pre class="example nohighlight">did:example:1234/custom/path?customquery</pre>
 				<ol class="algorithm">
 					<li>The applicable <a>DID method</a> MAY specify how to dereference
-					the <var>input <a>DID URL</a></var>.</li>
+						the <a>DID path</a> and/or <a>DID query</a> of the
+						<var>input <a>DID URL</a></var>.</li>
+						<pre class="example nohighlight">did:example:1234/resources/1234</pre>
+					<li>An extension specification MAY specify how to dereference
+						the <a>DID path</a> of the <var>input <a>DID URL</a></var>.
+						<pre class="example nohighlight">did:example:1234/whois</pre>
+					</li>
+					<li>An extension specification MAY specify how to dereference
+						the <a>DID query</a> of the <var>input <a>DID URL</a></var>.
+						<pre class="example nohighlight">did:example:1234?transformKey=JsonWebKey</pre>
+					</li>
 					<li>The client MAY be able to dereference the <var>input <a>DID URL</a></var>
 					in an application-specific way.</li>
 				</ol>
 				</li>
-				<li>If neither this algorithm, nor the applicable <a>DID method</a>, nor the client
+
+				<li>If neither this algorithm, nor the applicable <a>DID method</a>, nor an extension, nor the client
 				is able to dereference the <var>input <a>DID URL</a></var>, return the following result:
 				<ol class="algorithm">
 					<li><b>dereferencingMetadata</b>: <code>«[ "error" → "notFound" ]»</code></li>

--- a/index.html
+++ b/index.html
@@ -1085,9 +1085,9 @@ dereference(didUrl, dereferenceOptions) →
 				<pre class="example nohighlight">did:example:1234/custom/path?customquery</pre>
 				<ol class="algorithm">
 					<li>The applicable <a>DID method</a> MAY specify how to dereference
-						the <a>DID path</a> and/or <a>DID query</a> of the
-						<var>input <a>DID URL</a></var>.</li>
+						the <a>DID path</a> and/or <a>DID query</a> of the <var>input <a>DID URL</a></var>.
 						<pre class="example nohighlight">did:example:1234/resources/1234</pre>
+					</li>
 					<li>An extension specification MAY specify how to dereference
 						the <a>DID path</a> of the <var>input <a>DID URL</a></var>.
 						<pre class="example nohighlight">did:example:1234/whois</pre>

--- a/index.html
+++ b/index.html
@@ -1053,7 +1053,7 @@ dereference(didUrl, dereferenceOptions) →
 
 				<li>If the <var>input <a>DID URL</a></var> contains the
 					<a href="https://www.w3.org/TR/did-core/#did-parameters">DID parameter</a> <code>versionTime</code>:
-					<pre class="example nohighlight">did:example:1234??versionTime=2021-05-10T17:00:00Z</pre>
+					<pre class="example nohighlight">did:example:1234?versionTime=2021-05-10T17:00:00Z</pre>
 					<ol class="algorithm"><li>
 						<p class="issue">TODO: Specify the algorithm for processing the `versionTime` DID parameter.</p>
 					</li></ol>


### PR DESCRIPTION
This adds details to the dereferencing algorithm about how to dereference a DID path and/or DID query, including what roles methods and extensions can play.

Need to discuss this first, don't merge yet.

This topic of extensibility of DID URL dereferencing is related to all open issues that potentially introduce a new DID parameter, e.g. https://github.com/w3c/did-resolution/issues/85, https://github.com/w3c/did-resolution/issues/90, https://github.com/w3c/did-resolution/issues/39, https://github.com/w3c/did-resolution/issues/40, https://github.com/w3c/did-resolution/issues/5, https://github.com/w3c/did-resolution/issues/43.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-resolution/pull/104.html" title="Last updated on Jan 15, 2025, 11:32 PM UTC (1220915)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-resolution/104/0ed6db3...1220915.html" title="Last updated on Jan 15, 2025, 11:32 PM UTC (1220915)">Diff</a>