### PR TITLE
add audience section to introduction

### DIFF
--- a/index.html
+++ b/index.html
@@ -175,6 +175,23 @@ and dereferencing DID URLs.
 
 	</section>
 
+	<section class="informative">
+		<h2>
+		  Audience
+		</h2>
+		<p>
+This specification has three primary audiences: implementers of conformant DID methods;
+implementers of conformant DID resolvers; and implementers of systems and services 
+that wish to resolve DIDs using DID resolvers. The intended audience includes, 
+but is not limited to, software architects,  data modelers, application developers, 
+service developers, testers, operators,  and user experience (UX) specialists. 
+Other people involved in a broad range  of standards efforts related to decentralized 
+identity, verifiable credentials,  and secure storage might also be interested in 
+reading this specification.
+		</p>
+  
+	  </section>
+
 </section>
 
 <section id="terminology">

--- a/index.html
+++ b/index.html
@@ -183,10 +183,10 @@ and dereferencing DID URLs.
 This specification has three primary audiences: implementers of conformant DID methods;
 implementers of conformant DID resolvers; and implementers of systems and services 
 that wish to resolve DIDs using DID resolvers. The intended audience includes, 
-but is not limited to, software architects,  data modelers, application developers, 
-service developers, testers, operators,  and user experience (UX) specialists. 
-Other people involved in a broad range  of standards efforts related to decentralized 
-identity, verifiable credentials,  and secure storage might also be interested in 
+but is not limited to, software architects, data modelers, application developers, 
+service developers, testers, operators, and user experience (UX) specialists. 
+Other people involved in a broad range of standards efforts related to decentralized 
+identity, verifiable credentials, and secure storage might also be interested in 
 reading this specification.
 		</p>
   


### PR DESCRIPTION
This addresses #19.

The text is similar to the DID Core audience PR - https://github.com/w3c/did-core/pull/876/. Accept I tweaked the first sentence slightly to include DID resolvers.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wip-abramson/did-resolution/pull/107.html" title="Last updated on Jan 7, 2025, 4:09 PM UTC (e47588e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-resolution/107/c982825...wip-abramson:e47588e.html" title="Last updated on Jan 7, 2025, 4:09 PM UTC (e47588e)">Diff</a>