### PR TITLE
Add details about HTTPS binding.

### DIFF
--- a/ED-did-resolution-20250109.html
+++ b/ED-did-resolution-20250109.html
@@ -1,0 +1,4047 @@
+<!DOCTYPE html><html lang="en" dir="ltr"><head>
+<meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+<meta name="generator" content="ReSpec 35.2.2">
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+<style>
+span.example-title{text-transform:none}
+:is(aside,div).example,div.illegal-example{padding:.5em;margin:1em 0;position:relative;clear:both}
+div.illegal-example{color:red}
+div.illegal-example p{color:#000}
+aside.example div.example{border-left-width:.1em;border-color:#999;background:#fff}
+</style>
+<style>
+.issue-label{text-transform:initial}
+.warning>p:first-child{margin-top:0}
+.warning{padding:.5em;border-left-width:.5em;border-left-style:solid}
+span.warning{padding:.1em .5em .15em}
+.issue.closed span.issue-number{text-decoration:line-through}
+.issue.closed span.issue-number::after{content:" (Closed)";font-size:smaller}
+.warning{border-color:#f11;border-color:var(--warning-border,#f11);border-width:.2em;border-style:solid;background:#fbe9e9;background:var(--warning-bg,#fbe9e9);color:#000;color:var(--text,#000)}
+.warning-title:before{content:"⚠";font-size:1.3em;float:left;padding-right:.3em;margin-top:-.3em}
+li.task-list-item{list-style:none}
+input.task-list-item-checkbox{margin:0 .35em .25em -1.6em;vertical-align:middle}
+.issue a.respec-gh-label{padding:5px;margin:0 2px 0 2px;font-size:10px;text-transform:none;text-decoration:none;font-weight:700;border-radius:4px;position:relative;bottom:2px;border:none;display:inline-block}
+</style>
+<style>
+dfn{cursor:pointer}
+.dfn-panel{position:absolute;z-index:35;min-width:300px;max-width:500px;padding:.5em .75em;margin-top:.6em;font-family:"Helvetica Neue",sans-serif;font-size:small;background:#fff;background:var(--indextable-hover-bg,#fff);color:#000;color:var(--text,#000);box-shadow:0 1em 3em -.4em rgba(0,0,0,.3),0 0 1px 1px rgba(0,0,0,.05);box-shadow:0 1em 3em -.4em var(--tocsidebar-shadow,rgba(0,0,0,.3)),0 0 1px 1px var(--tocsidebar-shadow,rgba(0,0,0,.05));border-radius:2px}
+.dfn-panel:not(.docked)>.caret{position:absolute;top:-9px}
+.dfn-panel:not(.docked)>.caret::after,.dfn-panel:not(.docked)>.caret::before{content:"";position:absolute;border:10px solid transparent;border-top:0;border-bottom:10px solid #fff;border-bottom-color:var(--indextable-hover-bg,#fff);top:0}
+.dfn-panel:not(.docked)>.caret::before{border-bottom:9px solid #a2a9b1;border-bottom-color:var(--indextable-hover-bg,#a2a9b1)}
+.dfn-panel *{margin:0}
+.dfn-panel b{display:block;color:#000;color:var(--text,#000);margin-top:.25em}
+.dfn-panel ul a[href]{color:#333;color:var(--text,#333)}
+.dfn-panel>div{display:flex}
+.dfn-panel a.self-link{font-weight:700;margin-right:auto}
+.dfn-panel .marker{padding:.1em;margin-left:.5em;border-radius:.2em;text-align:center;white-space:nowrap;font-size:90%;color:#040b1c}
+.dfn-panel .marker.dfn-exported{background:#d1edfd;box-shadow:0 0 0 .125em #1ca5f940}
+.dfn-panel .marker.idl-block{background:#8ccbf2;box-shadow:0 0 0 .125em #0670b161}
+.dfn-panel a:not(:hover){text-decoration:none!important;border-bottom:none!important}
+.dfn-panel a[href]:hover{border-bottom-width:1px}
+.dfn-panel ul{padding:0}
+.dfn-panel li{margin-left:1em}
+.dfn-panel.docked{position:fixed;left:.5em;top:unset;bottom:2em;margin:0 auto;max-width:calc(100vw - .75em * 2 - .5em - .2em * 2);max-height:30vh;overflow:auto}
+</style>
+    
+<title>Decentralized Identifier Resolution (DID Resolution) v0.3</title>
+    
+    
+	
+    
+<script src="./common.js"></script>
+    
+    
+<style type="text/css">
+
+      ol.algorithm {
+        counter-reset: numsection;
+        list-style-type: none;
+      }
+      ol.algorithm li {
+        margin: 0.5em 0;
+      }
+      ol.algorithm li:before {
+        font-weight: bold;
+        counter-increment: numsection;
+        content: counters(numsection, ".") ") ";
+      }
+	  .longdesc {
+		  display: none;
+	  }
+	  .longdesc:target {
+		  display: block;
+		  background-color: #ff9;
+	  }
+    
+</style>
+  
+<style id="respec-mainstyle">
+@keyframes pop{
+0%{transform:scale(1,1)}
+25%{transform:scale(1.25,1.25);opacity:.75}
+100%{transform:scale(1,1)}
+}
+a.internalDFN{color:inherit;border-bottom:1px solid #99c;text-decoration:none}
+a.externalDFN{color:inherit;border-bottom:1px dotted #ccc;text-decoration:none}
+a.bibref{text-decoration:none}
+.respec-offending-element:target{animation:pop .25s ease-in-out 0s 1}
+.respec-offending-element,a[href].respec-offending-element{text-decoration:red wavy underline}
+@supports not (text-decoration:red wavy underline){
+.respec-offending-element:not(pre){display:inline-block}
+.respec-offending-element{background:url(data:image/gif;base64,R0lGODdhBAADAPEAANv///8AAP///wAAACwAAAAABAADAEACBZQjmIAFADs=) bottom repeat-x}
+}
+#references :target{background:#eaf3ff;animation:pop .4s ease-in-out 0s 1}
+cite .bibref{font-style:normal}
+a[href].orcid{padding-left:4px;padding-right:4px}
+a[href].orcid>svg{margin-bottom:-2px}
+ol.tof,ul.tof{list-style:none outside none}
+.caption{margin-top:.5em;font-style:italic}
+#issue-summary>ul{column-count:2}
+#issue-summary li{list-style:none;display:inline-block}
+details.respec-tests-details{margin-left:1em;display:inline-block;vertical-align:top}
+details.respec-tests-details>*{padding-right:2em}
+details.respec-tests-details[open]{z-index:999999;position:absolute;border:thin solid #cad3e2;border-radius:.3em;background-color:#fff;padding-bottom:.5em}
+details.respec-tests-details[open]>summary{border-bottom:thin solid #cad3e2;padding-left:1em;margin-bottom:1em;line-height:2em}
+details.respec-tests-details>ul{width:100%;margin-top:-.3em}
+details.respec-tests-details>li{padding-left:1em}
+.self-link:hover{opacity:1;text-decoration:none;background-color:transparent}
+aside.example .marker>a.self-link{color:inherit}
+.header-wrapper{display:flex;align-items:baseline}
+:is(h2,h3,h4,h5,h6):not(#toc>h2,#abstract>h2,#sotd>h2,.head>h2){position:relative;left:-.5em}
+:is(h2,h3,h4,h5,h6):not(#toch2)+a.self-link{color:inherit;order:-1;position:relative;left:-1.1em;font-size:1rem;opacity:.5}
+:is(h2,h3,h4,h5,h6)+a.self-link::before{content:"§";text-decoration:none;color:var(--heading-text)}
+:is(h2,h3)+a.self-link{top:-.2em}
+:is(h4,h5,h6)+a.self-link::before{color:#000}
+@media (max-width:767px){
+dd{margin-left:0}
+}
+@media print{
+.removeOnSave{display:none}
+}
+</style>
+<meta name="color-scheme" content="light">
+<meta name="description" content="Decentralized identifiers (DIDs) are a new type of identifier for
+verifiable, &quot;self-sovereign&quot; digital identity. DIDs are fully under the
+control of the DID controller, independent from any centralized registry,
+identity provider, or certificate authority. DIDs resolve to DID
+Documents — simple documents that describe how to use that specific DID.">
+<style>
+.hljs{--base:#fafafa;--mono-1:#383a42;--mono-2:#686b77;--mono-3:#717277;--hue-1:#0b76c5;--hue-2:#336ae3;--hue-3:#a626a4;--hue-4:#42803c;--hue-5:#ca4706;--hue-5-2:#c91243;--hue-6:#986801;--hue-6-2:#9a6a01}
+@media (prefers-color-scheme:dark){
+.hljs{--base:#282c34;--mono-1:#abb2bf;--mono-2:#818896;--mono-3:#5c6370;--hue-1:#56b6c2;--hue-2:#61aeee;--hue-3:#c678dd;--hue-4:#98c379;--hue-5:#e06c75;--hue-5-2:#be5046;--hue-6:#d19a66;--hue-6-2:#e6c07b}
+}
+.hljs{display:block;overflow-x:auto;padding:.5em;color:#383a42;color:var(--mono-1,#383a42);background:#fafafa;background:var(--base,#fafafa)}
+.hljs-comment,.hljs-quote{color:#717277;color:var(--mono-3,#717277);font-style:italic}
+.hljs-doctag,.hljs-formula,.hljs-keyword{color:#a626a4;color:var(--hue-3,#a626a4)}
+.hljs-deletion,.hljs-name,.hljs-section,.hljs-selector-tag,.hljs-subst{color:#ca4706;color:var(--hue-5,#ca4706);font-weight:700}
+.hljs-literal{color:#0b76c5;color:var(--hue-1,#0b76c5)}
+.hljs-addition,.hljs-attribute,.hljs-meta-string,.hljs-regexp,.hljs-string{color:#42803c;color:var(--hue-4,#42803c)}
+.hljs-built_in,.hljs-class .hljs-title{color:#9a6a01;color:var(--hue-6-2,#9a6a01)}
+.hljs-attr,.hljs-number,.hljs-selector-attr,.hljs-selector-class,.hljs-selector-pseudo,.hljs-template-variable,.hljs-type,.hljs-variable{color:#986801;color:var(--hue-6,#986801)}
+.hljs-bullet,.hljs-link,.hljs-meta,.hljs-selector-id,.hljs-symbol,.hljs-title{color:#336ae3;color:var(--hue-2,#336ae3)}
+.hljs-emphasis{font-style:italic}
+.hljs-strong{font-weight:700}
+.hljs-link{text-decoration:underline}
+</style>
+<style>
+var{position:relative;cursor:pointer}
+var[data-type]::after,var[data-type]::before{position:absolute;left:50%;top:-6px;opacity:0;transition:opacity .4s;pointer-events:none}
+var[data-type]::before{content:"";transform:translateX(-50%);border-width:4px 6px 0 6px;border-style:solid;border-color:transparent;border-top-color:#222}
+var[data-type]::after{content:attr(data-type);transform:translateX(-50%) translateY(-100%);background:#222;text-align:center;font-family:"Dank Mono","Fira Code",monospace;font-style:normal;padding:6px;border-radius:3px;color:#daca88;text-indent:0;font-weight:400}
+var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
+</style>
+<script id="initialUserConfig" type="application/json">{
+  "specStatus": "ED",
+  "shortName": "did-resolution",
+  "subtitle": "Algorithms and guidelines for resolving DIDs and dereferencing DID URLs",
+  "localBiblio": {
+    "REST": {
+      "title": "Architectural Styles and the Design of Network-based Software Architectures",
+      "date": "2000",
+      "href": "http://www.ics.uci.edu/~fielding/pubs/dissertation/",
+      "authors": [
+        "Fielding, Roy Thomas"
+      ],
+      "publisher": "University of California, Irvine."
+    },
+    "DID-METHOD-REGISTRY": {
+      "title": "The Decentralized Identifier Method Registry",
+      "href": "https://w3c-ccg.github.io/did-method-registry/",
+      "authors": [
+        "Manu Sporny",
+        "Drummond Reed"
+      ],
+      "status": "CG-DRAFT",
+      "publisher": "Digital Verification Community Group"
+    },
+    "DATA-INTEGRITY": {
+      "title": "Verifiable Credential Data Integrity 1.0",
+      "href": "https://www.w3.org/TR/vc-data-integrity/",
+      "authors": [
+        "Dave Longley",
+        "Manu Sporny"
+      ],
+      "status": "CRD",
+      "publisher": "W3C Verifiable Credentials Working Group",
+      "id": "data-integrity"
+    },
+    "MATRIX-URIS": {
+      "title": "Matrix URIs - Ideas about Web Architecture",
+      "date": "December 1996",
+      "href": "https://www.w3.org/DesignIssues/MatrixURIs.html",
+      "authors": [
+        "Tim Berners-Lee"
+      ],
+      "status": "Personal View"
+    },
+    "COOL-URIS": {
+      "title": "Cool URIs for the Semantic Web",
+      "date": "December 2008",
+      "href": "https://www.w3.org/TR/cooluris/",
+      "authors": [
+        "Leo Sauermann",
+        "Richard Cyganiak"
+      ],
+      "status": "Interest Group Note"
+    },
+    "KERI": {
+      "title": "Key Event Receipt Infrastructure (KERI)",
+      "date": "July 2019",
+      "href": "https://arxiv.org/abs/1907.02143",
+      "authors": [
+        "Samuel M. Smith"
+      ],
+      "id": "keri"
+    },
+    "DID-PEER": {
+      "title": "Peer DID Method Specification",
+      "subtitle": "blockchain-independent decentralized identifiers",
+      "date": "10 July 2020",
+      "href": "https://identity.foundation/peer-did-method-spec/",
+      "editors": [
+        "Daniel Hardman"
+      ],
+      "authors": [
+        "Oskar Deventer",
+        "Christian Lundkvist",
+        "Márton Csernai",
+        "Kyle Den Hartog",
+        "Markus Sabadello",
+        "Sam Curren",
+        "Dan Gisolfi",
+        "Mike Varley",
+        "Sven Hammann",
+        "John Jordan",
+        "Lovesh Harchandani",
+        "Devin Fisher",
+        "Tobias Looker",
+        "Brent Zundel",
+        "Stephen Curran"
+      ],
+      "status": "ED",
+      "id": "did-peer"
+    },
+    "DID-KEY": {
+      "title": "The did:key Method",
+      "subtitle": "A DID Method for Static Cryptographic Keys",
+      "date": " 09 June 2020",
+      "href": "https://w3c-ccg.github.io/did-method-key/",
+      "editors": [
+        "Manu Sporny",
+        "Dmitri Zagidulin",
+        "Dave Longley"
+      ],
+      "authors": [
+        "Manu Sporny",
+        "Dmitri Zagidulin",
+        "Dave Longley"
+      ],
+      "status": "unofficial",
+      "id": "did-key"
+    }
+  },
+  "github": "https://github.com/w3c/did-resolution",
+  "includePermalinks": false,
+  "edDraftURI": "https://w3c.github.io/did-resolution/",
+  "editors": [
+    {
+      "name": "Markus Sabadello",
+      "url": "https://www.linkedin.com/in/markus-sabadello-353a0821",
+      "company": "Danube Tech",
+      "companyURL": "https://danubetech.com/",
+      "w3cid": 46729
+    },
+    {
+      "name": "Dmitri Zagidulin",
+      "url": "https://www.linkedin.com/in/dzagidulin",
+      "company": "MIT CSAIL",
+      "companyURL": "http://computingjoy.com/",
+      "w3cid": 86708
+    }
+  ],
+  "authors": [
+    {
+      "name": "Markus Sabadello",
+      "url": "https://www.linkedin.com/in/markus-sabadello-353a0821",
+      "company": "Danube Tech",
+      "companyURL": "https://danubetech.com/",
+      "w3cid": 46729
+    },
+    {
+      "name": "Dmitri Zagidulin",
+      "url": "https://www.linkedin.com/in/dzagidulin",
+      "company": "MIT CSAIL",
+      "companyURL": "http://computingjoy.com/",
+      "w3cid": 86708
+    }
+  ],
+  "group": "did",
+  "wgPublicList": "public-did-wg",
+  "maxTocLevel": 4,
+  "inlineCSS": true,
+  "publishISODate": "2025-01-09T00:00:00.000Z",
+  "generatedSubtitle": "W3C Editor's Draft 09 January 2025"
+}</script>
+<link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2021/W3C-ED"></head>
+  <body data-cite="infra rfc3986" class="h-entry"><div class="head">
+    <p class="logos"><a class="logo" href="https://www.w3.org/"><img crossorigin="" alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72">
+  </a></p>
+    <h1 id="title" class="title">Decentralized Identifier Resolution (DID Resolution) v0.3</h1> <h2 id="subtitle" class="subtitle">Algorithms and guidelines for resolving DIDs and dereferencing DID URLs</h2>
+    <p id="w3c-state"><a href="https://www.w3.org/standards/types#ED">W3C Editor's Draft</a> <time class="dt-published" datetime="2025-01-09">09 January 2025</time></p>
+    <details open="">
+      <summary>More details about this document</summary>
+      <dl>
+        <dt>This version:</dt><dd>
+                <a class="u-url" href="https://w3c.github.io/did-resolution/">https://w3c.github.io/did-resolution/</a>
+              </dd>
+        <dt>Latest published version:</dt><dd>
+                <a href="https://www.w3.org/TR/did-resolution/">https://www.w3.org/TR/did-resolution/</a>
+              </dd>
+        <dt>Latest editor's draft:</dt><dd><a href="https://w3c.github.io/did-resolution/">https://w3c.github.io/did-resolution/</a></dd>
+        <dt>History:</dt><dd>
+                    <a href="https://www.w3.org/standards/history/did-resolution/">https://www.w3.org/standards/history/did-resolution/</a>
+                  </dd><dd>
+                    <a href="https://github.com/w3c/did-resolution/commits/">Commit history</a>
+                  </dd>
+        
+        
+        
+        
+        
+        <dt>Editors:</dt><dd class="editor p-author h-card vcard" data-editor-id="46729">
+    <a class="u-url url p-name fn" href="https://www.linkedin.com/in/markus-sabadello-353a0821">Markus Sabadello</a> (<a class="p-org org h-org" href="https://danubetech.com/">Danube Tech</a>)
+  </dd><dd class="editor p-author h-card vcard" data-editor-id="86708">
+    <a class="u-url url p-name fn" href="https://www.linkedin.com/in/dzagidulin">Dmitri Zagidulin</a> (<a class="p-org org h-org" href="http://computingjoy.com/">MIT CSAIL</a>)
+  </dd>
+        
+        <dt>Authors:</dt><dd class="editor p-author h-card vcard" data-editor-id="46729">
+    <a class="u-url url p-name fn" href="https://www.linkedin.com/in/markus-sabadello-353a0821">Markus Sabadello</a> (<a class="p-org org h-org" href="https://danubetech.com/">Danube Tech</a>)
+  </dd><dd class="editor p-author h-card vcard" data-editor-id="86708">
+    <a class="u-url url p-name fn" href="https://www.linkedin.com/in/dzagidulin">Dmitri Zagidulin</a> (<a class="p-org org h-org" href="http://computingjoy.com/">MIT CSAIL</a>)
+  </dd>
+        <dt>Feedback:</dt><dd>
+        <a href="https://github.com/w3c/did-resolution/">GitHub w3c/did-resolution</a>
+        (<a href="https://github.com/w3c/did-resolution/pulls/">pull requests</a>,
+        <a href="https://github.com/w3c/did-resolution/issues/new/choose">new issue</a>,
+        <a href="https://github.com/w3c/did-resolution/issues/">open issues</a>)
+      </dd><dd><a href="mailto:public-did-wg@w3.org?subject=%5Bdid-resolution%5D%20YOUR%20TOPIC%20HERE">public-did-wg@w3.org</a> with subject line <kbd>[did-resolution] <em>… message topic …</em></kbd> (<a rel="discussion" href="https://lists.w3.org/Archives/Public/public-did-wg">archives</a>)</dd>
+        
+        
+      </dl>
+    </details>
+    
+    
+    <p class="copyright">
+    <a href="https://www.w3.org/policies/#copyright">Copyright</a>
+    ©
+    2025
+    
+    <a href="https://www.w3.org/">World Wide Web Consortium</a>.
+    <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup>
+    <a href="https://www.w3.org/policies/#Legal_Disclaimer">liability</a>,
+    <a href="https://www.w3.org/policies/#W3C_Trademarks">trademark</a> and
+    <a rel="license" href="https://www.w3.org/copyright/software-license-2023/" title="W3C Software and Document Notice and License">permissive document license</a> rules apply.
+  </p>
+    <hr title="Separator for header">
+  </div>
+    <section id="abstract" class="introductory"><h2>Abstract</h2>
+      <p>
+Decentralized identifiers (DIDs) are a new type of identifier for
+verifiable, "self-sovereign" digital identity. DIDs are fully under the
+control of the DID controller, independent from any centralized registry,
+identity provider, or certificate authority. DIDs resolve to DID
+Documents — simple documents that describe how to use that specific DID.
+      </p>
+
+      <p>
+This document specifies the algorithms and guidelines for resolving DIDs
+and dereferencing DID URLs.
+      </p>
+    </section>
+
+    <section id="sotd" class="introductory"><h2>Status of This Document</h2><p><em>This section describes the status of this
+      document at the time of its publication. A list of current <abbr title="World Wide Web Consortium">W3C</abbr>
+      publications and the latest revision of this technical report can be found
+      in the <a href="https://www.w3.org/TR/"><abbr title="World Wide Web Consortium">W3C</abbr> technical reports index</a> at
+      https://www.w3.org/TR/.</em></p>
+    <p>
+      Comments regarding this document are welcome. Please file issues
+      directly on <a href="https://github.com/w3c/did-resolution/issues/">GitHub</a>,
+      or send them to
+      <a href="mailto:public-did-wg@w3.org">public-did-wg@w3.org</a>
+      (<a href="mailto:public-did-wg-request@w3.org?subject=subscribe">subscribe</a>,
+      <a href="https://lists.w3.org/Archives/Public/public-did-wg/">archives</a>).
+      </p>
+
+      <p>
+      Portions of the work on this specification have been funded by the
+      United States Department of Homeland Security's Science and Technology
+      Directorate under contracts HSHQDC-17-C-00019. The content of this
+      specification does not necessarily reflect the position or the policy of
+      the U.S. Government and no official endorsement should be inferred.
+      </p>
+
+      <p>
+      Work on this specification has also been supported by the Rebooting the
+      Web of Trust community facilitated by Christopher Allen, Shannon
+      Appelcline, Kiara Robles, Brian Weller, Betty Dhamers, Kaliya Young, Kim
+      Hamilton Duffy, Manu Sporny, Drummond Reed, Joe Andrieu, and Heather
+      Vescent.
+      </p>
+    <p>
+    This document was published by the <a href="https://www.w3.org/groups/wg/did">Decentralized Identifier Working Group</a> as
+    an Editor's Draft. 
+  </p><p>Publication as an Editor's Draft does not
+  imply endorsement by <abbr title="World Wide Web Consortium">W3C</abbr> and its Members. </p><p>
+    This is a draft document and may be updated, replaced or obsoleted by other
+    documents at any time. It is inappropriate to cite this document as other
+    than work in progress.
+    
+  </p><p>
+    
+        This document was produced by a group
+        operating under the
+        <a href="https://www.w3.org/policies/patent-policy/"><abbr title="World Wide Web Consortium">W3C</abbr> Patent
+          Policy</a>.
+      
+    
+                <abbr title="World Wide Web Consortium">W3C</abbr> maintains a
+                <a rel="disclosure" href="https://www.w3.org/groups/wg/did/ipr">public list of any patent disclosures</a>
+          made in connection with the deliverables of
+          the group; that page also includes
+          instructions for disclosing a patent. An individual who has actual
+          knowledge of a patent which the individual believes contains
+          <a href="https://www.w3.org/policies/patent-policy/#def-essential">Essential Claim(s)</a>
+          must disclose the information in accordance with
+          <a href="https://www.w3.org/policies/patent-policy/#sec-Disclosure">section 6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
+        
+  </p><p>
+                      This document is governed by the
+                      <a id="w3c_process_revision" href="https://www.w3.org/policies/process/20231103/">03 November 2023 <abbr title="World Wide Web Consortium">W3C</abbr> Process Document</a>.
+                    </p></section><nav id="toc"><h2 class="introductory" id="table-of-contents">Table of Contents</h2><ol class="toc"><li class="tocline"><a class="tocxref" href="#abstract">Abstract</a></li><li class="tocline"><a class="tocxref" href="#sotd">Status of This Document</a></li><li class="tocline"><a class="tocxref" href="#introduction"><bdi class="secno">1. </bdi>Introduction</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#conformance"><bdi class="secno">1.1 </bdi>Conformance</a></li></ol></li><li class="tocline"><a class="tocxref" href="#terminology"><bdi class="secno">2. </bdi>Terminology</a></li><li class="tocline"><a class="tocxref" href="#resolving"><bdi class="secno">3. </bdi>DID Resolution</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#did-resolution-options"><bdi class="secno">3.1 </bdi>DID Resolution Options</a></li><li class="tocline"><a class="tocxref" href="#did-resolution-metadata"><bdi class="secno">3.2 </bdi>DID Resolution Metadata</a></li><li class="tocline"><a class="tocxref" href="#did-document-metadata"><bdi class="secno">3.3 </bdi>DID Document Metadata</a></li><li class="tocline"><a class="tocxref" href="#resolving-algorithm"><bdi class="secno">3.4 </bdi>Algorithm</a></li></ol></li><li class="tocline"><a class="tocxref" href="#dereferencing"><bdi class="secno">4. </bdi>DID URL Dereferencing</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#did-url-dereferencing-options"><bdi class="secno">4.1 </bdi>DID URL Dereferencing Options</a></li><li class="tocline"><a class="tocxref" href="#did-url-dereferencing-metadata"><bdi class="secno">4.2 </bdi>DID URL Dereferencing Metadata</a></li><li class="tocline"><a class="tocxref" href="#dereferencing-algorithm"><bdi class="secno">4.3 </bdi>Algorithm</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#dereferencing-algorithm-resource"><bdi class="secno">4.3.1 </bdi>Dereferencing the Resource</a></li><li class="tocline"><a class="tocxref" href="#dereferencing-algorithm-fragment"><bdi class="secno">4.3.2 </bdi>Dereferencing the Fragment</a></li></ol></li><li class="tocline"><a class="tocxref" href="#examples"><bdi class="secno">4.4 </bdi>Examples</a></li></ol></li><li class="tocline"><a class="tocxref" href="#metadata-structure"><bdi class="secno">5. </bdi>Metadata Structure</a></li><li class="tocline"><a class="tocxref" href="#architectures"><bdi class="secno">6. </bdi>DID Resolution Architectures</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#method-architectures"><bdi class="secno">6.1 </bdi>Method Architectures</a></li><li class="tocline"><a class="tocxref" href="#resolver-architectures"><bdi class="secno">6.2 </bdi>Resolver Architectures</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#resolver-architectures-proxied"><bdi class="secno">6.2.1 </bdi>Proxied Resolution</a></li><li class="tocline"><a class="tocxref" href="#resolver-architectures-client-side"><bdi class="secno">6.2.2 </bdi>Client-Side Dereferencing</a></li></ol></li></ol></li><li class="tocline"><a class="tocxref" href="#did-resolution-result"><bdi class="secno">7. </bdi>DID Resolution Result</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#example"><bdi class="secno">7.1 </bdi>Example</a></li><li class="tocline"><a class="tocxref" href="#output-diddocument"><bdi class="secno">7.2 </bdi>DID Document</a></li><li class="tocline"><a class="tocxref" href="#output-resolutionmetadata"><bdi class="secno">7.3 </bdi>DID Resolution Metadata</a></li><li class="tocline"><a class="tocxref" href="#output-documentmetadata"><bdi class="secno">7.4 </bdi>DID Document Metadata</a></li></ol></li><li class="tocline"><a class="tocxref" href="#did-url-dereferencing-result"><bdi class="secno">8. </bdi>DID URL Dereferencing Result</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#example-0"><bdi class="secno">8.1 </bdi>Example</a></li><li class="tocline"><a class="tocxref" href="#output-content"><bdi class="secno">8.2 </bdi>Content</a></li><li class="tocline"><a class="tocxref" href="#output-dereferencingmetadata"><bdi class="secno">8.3 </bdi>DID URL Dereferencing Metadata</a></li><li class="tocline"><a class="tocxref" href="#output-contentmetadata"><bdi class="secno">8.4 </bdi>Content Metadata</a></li></ol></li><li class="tocline"><a class="tocxref" href="#errors"><bdi class="secno">9. </bdi>Errors</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#invaliddid"><bdi class="secno">9.1 </bdi>invalidDid</a></li><li class="tocline"><a class="tocxref" href="#invaliddidurl"><bdi class="secno">9.2 </bdi>invalidDidUrl</a></li><li class="tocline"><a class="tocxref" href="#notfound"><bdi class="secno">9.3 </bdi>notFound</a></li><li class="tocline"><a class="tocxref" href="#representationnotsupported"><bdi class="secno">9.4 </bdi>representationNotSupported</a></li><li class="tocline"><a class="tocxref" href="#methodnotsupported"><bdi class="secno">9.5 </bdi>methodNotSupported</a></li><li class="tocline"><a class="tocxref" href="#internalerror"><bdi class="secno">9.6 </bdi>internalError</a></li><li class="tocline"><a class="tocxref" href="#invalidpublickey"><bdi class="secno">9.7 </bdi>invalidPublicKey</a></li><li class="tocline"><a class="tocxref" href="#invalidpublickeylength"><bdi class="secno">9.8 </bdi>invalidPublicKeyLength</a></li><li class="tocline"><a class="tocxref" href="#invalidpublickeytype"><bdi class="secno">9.9 </bdi>invalidPublicKeyType</a></li><li class="tocline"><a class="tocxref" href="#unsupportedpublickeytype"><bdi class="secno">9.10 </bdi>unsupportedPublicKeyType</a></li></ol></li><li class="tocline"><a class="tocxref" href="#bindings"><bdi class="secno">10. </bdi>Bindings</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#bindings-https"><bdi class="secno">10.1 </bdi>HTTP(S) Binding</a></li><li class="tocline"><a class="tocxref" href="#did-resolution-examples"><bdi class="secno">10.2 </bdi>DID Resolution Examples</a></li><li class="tocline"><a class="tocxref" href="#did-url-dereferencing-examples"><bdi class="secno">10.3 </bdi>DID URL Dereferencing Examples</a></li></ol></li><li class="tocline"><a class="tocxref" href="#service-endpoint-construction"><bdi class="secno">11. </bdi>Service Endpoint Construction</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#input"><bdi class="secno">11.1 </bdi>Input</a></li><li class="tocline"><a class="tocxref" href="#algorithm"><bdi class="secno">11.2 </bdi>Algorithm</a></li><li class="tocline"><a class="tocxref" href="#example-10"><bdi class="secno">11.3 </bdi>Example</a></li></ol></li><li class="tocline"><a class="tocxref" href="#security-privacy-considerations"><bdi class="secno">12. </bdi>Security and Privacy Considerations</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#authentication"><bdi class="secno">12.1 </bdi>Authentication/Authorization</a></li><li class="tocline"><a class="tocxref" href="#caching"><bdi class="secno">12.2 </bdi>Caching</a></li><li class="tocline"><a class="tocxref" href="#versioning"><bdi class="secno">12.3 </bdi>Versioning</a></li><li class="tocline"><a class="tocxref" href="#non-did-identifiers"><bdi class="secno">12.4 </bdi>Non-DID Identifiers</a></li><li class="tocline"><a class="tocxref" href="#did-method-governance"><bdi class="secno">12.5 </bdi>DID Method Governance</a></li></ol></li><li class="tocline"><a class="tocxref" href="#future-work"><bdi class="secno">13. </bdi>Future Work</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#redirect"><bdi class="secno">13.1 </bdi>Redirect</a></li><li class="tocline"><a class="tocxref" href="#proxy"><bdi class="secno">13.2 </bdi>Proxy</a></li><li class="tocline"><a class="tocxref" href="#json-pointer"><bdi class="secno">13.3 </bdi>JSON Pointer</a></li></ol></li><li class="tocline"><a class="tocxref" href="#did-resolution-resources"><bdi class="secno">A. </bdi>DID Resolution Resources</a></li><li class="tocline"><a class="tocxref" href="#references"><bdi class="secno">B. </bdi>References</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#normative-references"><bdi class="secno">B.1 </bdi>Normative references</a></li><li class="tocline"><a class="tocxref" href="#informative-references"><bdi class="secno">B.2 </bdi>Informative references</a></li></ol></li></ol></nav>
+
+<section id="introduction"><div class="header-wrapper"><h2 id="x1-introduction"><bdi class="secno">1. </bdi>Introduction</h2><a class="self-link" href="#introduction" aria-label="Permalink for Section 1."></a></div>
+
+
+	<p><a href="#dfn-did-resolution" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolution-1">DID resolution</a> is the process of obtaining a <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-1">DID document</a> for a given <a href="#dfn-decentralized-identifiers" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-decentralized-identifiers-1">DID</a>. This is one
+	of four required operations that can be performed on any DID ("Read"; the other ones being "Create", "Update",
+	and "Deactivate"). The details of these operations differ depending on the <a href="#dfn-did-method-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-method-s-1">DID method</a>.
+	Building on top of <a href="#dfn-did-resolution" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolution-2">DID resolution</a>, <a href="#dfn-did-url-dereferencing" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-url-dereferencing-1">DID URL dereferencing</a> is the process of retrieving a representation
+	of a resource for a given <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-1">DID URL</a>. Software and/or hardware that is able to execute these processes is called
+	a <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-1">DID resolver</a>.
+	
+	</p><p>This
+	specification defines common
+	requirements, algorithms including their inputs and results, architectural options, and various considerations for the
+	<a href="#dfn-did-resolution" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolution-3">DID resolution</a> and <a href="#dfn-did-url-dereferencing" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-url-dereferencing-2">DID URL dereferencing</a> processes.</p>
+
+	<p>Note that while this specification defines some base-level functionality for DID resolution, the actual steps
+	required to communicate with a DID's <a href="#dfn-verifiable-data-registry" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-verifiable-data-registry-1">verifiable data registry</a> are defined by the applicable
+	<a href="#dfn-did-method-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-method-s-2">DID method</a> specification.</p>
+
+	<div class="note" role="note" id="issue-container-generatedID"><div role="heading" class="note-title marker" id="h-note" aria-level="3"><span>Note</span></div><p class="">The difference between "resolving" a <a href="#dfn-decentralized-identifiers" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-decentralized-identifiers-2">DID</a> and "dereferencing" a <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-2">DID URL</a>
+	is being thoroughly discussed by the community. For example, see
+	<a href="https://github.com/w3c/did-spec/issues/166#issuecomment-464502719">this comment</a>.</p></div>
+
+	<section id="conformance"><div class="header-wrapper"><h3 id="x1-1-conformance"><bdi class="secno">1.1 </bdi>Conformance</h3><a class="self-link" href="#conformance" aria-label="Permalink for Section 1.1"></a></div><p>As well as sections marked as non-normative, all authoring guidelines, diagrams, examples, and notes in this specification are non-normative. Everything else in this specification is normative.</p><p>
+        The key words <em class="rfc2119">MAY</em>, <em class="rfc2119">MUST</em>, <em class="rfc2119">MUST NOT</em>, <em class="rfc2119">OPTIONAL</em>, <em class="rfc2119">RECOMMENDED</em>, <em class="rfc2119">REQUIRED</em>, and <em class="rfc2119">SHOULD</em> in this document
+        are to be interpreted as described in
+        <a href="https://datatracker.ietf.org/doc/html/bcp14">BCP 14</a>
+        [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc2119" title="Key words for use in RFCs to Indicate Requirement Levels">RFC2119</a></cite>] [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc8174" title="Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words">RFC8174</a></cite>]
+        when, and only when, they appear in all capitals, as shown here.
+      </p>
+
+		<p>
+			A <dfn class="lint-ignore" id="dfn-conforming-did-resolver" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">conforming DID resolver</dfn> is any algorithm
+			realized as software and/or hardware that complies with the relevant normative
+			statements in <a href="#resolving" class="sec-ref"><bdi class="secno">3. </bdi>DID Resolution</a>.
+		</p>
+
+		<p>
+			A <dfn class="lint-ignore" id="dfn-conforming-did-url-dereferencer" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">conforming DID URL dereferencer</dfn> is any
+			algorithm realized as software and/or hardware that complies with the relevant
+			normative statements in <a href="#dereferencing" class="sec-ref"><bdi class="secno">4. </bdi>DID URL Dereferencing</a>.
+		</p>
+
+	</section>
+
+</section>
+
+<section id="terminology"><div class="header-wrapper"><h2 id="x2-terminology"><bdi class="secno">2. </bdi>Terminology</h2><a class="self-link" href="#terminology" aria-label="Permalink for Section 2."></a></div>
+	
+
+	<div><p>
+This section defines the terms used in this specification and throughout
+<a href="#dfn-decentralized-identifiers" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-decentralized-identifiers-3">decentralized identifier</a> infrastructure. A link to these terms is
+included whenever they appear in this specification.
+</p>
+
+<dl class="termlist">
+
+  <dt><dfn data-lt="authenticated|authenticate" id="dfn-authenticated" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">authenticate</dfn></dt>
+  <dd>
+    Authentication is a process by which an entity can prove it has a specific
+    attribute or controls a specific secret using one or more <a href="#dfn-verification-method" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-verification-method-1">verification
+    methods</a>. With <a href="#dfn-decentralized-identifiers" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-decentralized-identifiers-4">DIDs</a>, a common example would be proving control of the
+    cryptographic private key associated with a public key published in a <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-2">DID
+    document</a>.
+  </dd>
+
+  <dt><dfn data-plurals="bindings" id="dfn-binding" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">binding</dfn></dt>
+  <dd>A concrete mechanism through which a <a href="#dfn-client" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-client-1">client</a> invokes a <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-2">DID resolver</a>. This could be a <a href="#dfn-local-binding" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-local-binding-1">local binding</a> such as a local command line tool or library API, or a <a href="#dfn-remote-binding" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-remote-binding-1">remote binding</a> such as the <a href="#bindings-https">HTTP(S) binding</a>. See Section <a href="#resolver-architectures" class="sec-ref"><bdi class="secno">6.2 </bdi>Resolver Architectures</a>.</dd>
+
+  <dt><dfn id="dfn-client" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">client</dfn></dt>
+  <dd>Software and/or hardware that invokes a <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-3">DID resolver</a> in order to execute the <a href="#dfn-did-resolution" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolution-4">DID resolution</a> and/or <a href="#dfn-did-url-dereferencing" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-url-dereferencing-3">DID URL dereferencing</a> algorithms. This invocation is done via a <a href="#dfn-binding" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-binding-1">binding</a>. The term <a href="#dfn-client" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-client-2">client</a> does not imply any specific network topology.</dd>
+
+  <dt><dfn data-lt="decentralized identifiers|DID|DIDs|decentralized identifier" data-plurals="dids|did" id="dfn-decentralized-identifiers" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">decentralized identifier</dfn> (DID)</dt>
+  <dd>
+    A globally unique persistent identifier that does not require a centralized
+    registration authority and is often generated and/or registered
+    cryptographically. The generic format of a DID is defined in <a href="https://w3c.github.io/did-core/#did-syntax"></a>. A specific <a href="#dfn-did-schemes" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-schemes-1">DID scheme</a> is defined in a <a href="#dfn-did-method-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-method-s-3">DID
+    method</a> specification. Many—but not all—DID methods make use of
+    <a href="#dfn-distributed-ledger-technology" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-distributed-ledger-technology-1">distributed ledger technology</a> (DLT) or some other form of decentralized
+    network.
+  </dd>
+
+  <dt><dfn data-lt="did controllers|did controller(s)|DID controller" id="dfn-did-controllers" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">DID controller</dfn></dt>
+  <dd>
+    An entity that has the capability to make changes to a <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-3">DID document</a>. A
+    <a href="#dfn-decentralized-identifiers" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-decentralized-identifiers-5">DID</a> might have more than one DID controller. The DID controller(s)
+    can be denoted by the optional <code>controller</code> property at the top level of the
+    <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-4">DID document</a>. Note that a DID controller might be the <a href="#dfn-did-subjects" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-subjects-1">DID
+    subject</a>.
+  </dd>
+
+  <dt><dfn id="dfn-did-delegate" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">DID delegate</dfn></dt>
+  <dd>
+    An entity to whom a <a href="#dfn-did-controllers" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-controllers-1">DID controller</a> has granted permission to use a
+    <a href="#dfn-verification-method" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-verification-method-2">verification method</a> associated with a <a href="#dfn-decentralized-identifiers" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-decentralized-identifiers-6">DID</a> via a <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-5">DID
+    document</a>. For example, a parent who controls a child's <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-6">DID document</a>
+    might permit the child to use their personal device in order to
+    <a href="#dfn-authenticated" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-authenticated-1">authenticate</a>. In this case, the child is the <a href="#dfn-did-delegate" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-delegate-1">DID delegate</a>. The
+    child's personal device would contain the private cryptographic material
+    enabling the child to <a href="#dfn-authenticated" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-authenticated-2">authenticate</a> using the <a href="#dfn-decentralized-identifiers" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-decentralized-identifiers-7">DID</a>. However, the child
+    might not be permitted to add other personal devices without the parent's
+    permission.
+  </dd>
+
+  <dt><dfn data-lt="DID documents|DID document" data-plurals="did documents" id="dfn-did-documents" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">DID document</dfn></dt>
+  <dd>
+    A set of data describing the <a href="#dfn-did-subjects" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-subjects-2">DID subject</a>, including mechanisms, such as
+    cryptographic public keys, that the <a href="#dfn-did-subjects" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-subjects-3">DID subject</a> or a <a href="#dfn-did-delegate" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-delegate-2">DID delegate</a>
+    can use to <a href="#dfn-authenticated" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-authenticated-3">authenticate</a> itself and prove its association with the
+    <a href="#dfn-decentralized-identifiers" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-decentralized-identifiers-8">DID</a>.
+  </dd>
+
+  <dt><dfn data-lt="DID fragments|DID fragment" id="dfn-did-fragments" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">DID fragment</dfn></dt>
+  <dd>
+    The portion of a <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-3">DID URL</a> that follows the first hash sign character
+    (<code>#</code>). DID fragment syntax is identical to URI fragment syntax.
+  </dd>
+
+  <dt><dfn data-lt="DID method's|DID method" data-plurals="did methods" id="dfn-did-method-s" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">DID method</dfn></dt>
+  <dd>
+    A definition of how a specific <a href="#dfn-did-schemes" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-schemes-2">DID method scheme</a> is implemented. A DID method is
+    defined by a DID method specification, which specifies the precise operations by
+    which <a href="#dfn-decentralized-identifiers" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-decentralized-identifiers-9">DIDs</a> and <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-7">DID documents</a> are created, resolved, updated,
+    and deactivated. See <a href="https://w3c.github.io/did-core/#methods"></a>.
+  </dd>
+
+  <dt><dfn data-lt="DID paths|DID path" id="dfn-did-paths" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">DID path</dfn></dt>
+  <dd>
+    The portion of a <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-4">DID URL</a> that begins with and includes the first forward
+    slash (<code>/</code>) character and ends with either a question mark
+    (<code>?</code>) character, a fragment hash sign (<code>#</code>) character,
+    or the end of the <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-5">DID URL</a>. DID path syntax is identical to URI path syntax.
+    See <a href="https://w3c.github.io/did-core/#path"></a>.
+  </dd>
+
+  <dt><dfn data-lt="DID queries|DID query" id="dfn-did-queries" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">DID query</dfn></dt>
+  <dd>
+    The portion of a <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-6">DID URL</a> that follows and includes the first question
+    mark character (<code>?</code>). DID query syntax is identical to URI query
+    syntax. See <a href="https://w3c.github.io/did-core/#query"></a>.
+  </dd>
+
+  <dt><dfn id="dfn-did-resolution" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">DID resolution</dfn></dt>
+  <dd>
+    The process that takes as its input a <a href="#dfn-decentralized-identifiers" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-decentralized-identifiers-10">DID</a> and a set of resolution
+    options and returns a <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-8">DID document</a> in a conforming <a href="#dfn-representations" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-representations-1">representation</a>
+    plus additional metadata. This process relies on the "Read" operation of the
+    applicable <a href="#dfn-did-method-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-method-s-4">DID method</a>. The inputs and outputs of this process are
+    defined in <a href="#resolving" class="sec-ref"><bdi class="secno">3. </bdi>DID Resolution</a>.
+  </dd>
+
+  <dt><dfn data-lt="DID resolver's|DID resolver" data-plurals="did resolvers" id="dfn-did-resolver-s" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">DID resolver</dfn></dt>
+  <dd>
+    A <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-4">DID resolver</a> is a software and/or hardware component that performs the
+    <a href="#dfn-did-resolution" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolution-5">DID resolution</a> function by taking a <a href="#dfn-decentralized-identifiers" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-decentralized-identifiers-11">DID</a> as input and producing a
+    conforming <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-9">DID document</a> as output.
+  </dd>
+
+  <dt><dfn data-lt="" id="dfn-did-resolution-result" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">DID resolution result</dfn></dt>
+  <dd>A data structure that represents the result of the <a href="#dfn-did-resolution" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolution-6">DID resolution</a> algorithm.
+    May contain a <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-10">DID document</a>. See Section <a href="#did-resolution-result" class="sec-ref"><bdi class="secno">7. </bdi>DID Resolution Result</a>.</dd>
+
+  <dt><dfn data-lt="DID schemes|DID method scheme|DID scheme" id="dfn-did-schemes" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">DID scheme</dfn></dt>
+
+  <dd>
+    The formal syntax of a <a href="#dfn-decentralized-identifiers" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-decentralized-identifiers-12">decentralized identifier</a>. The generic DID scheme
+    begins with the prefix <code>did:</code> as defined in <a href="https://w3c.github.io/did-core/#did-syntax"></a>. Each <a href="#dfn-did-method-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-method-s-5">DID method</a> specification defines a specific
+    DID method scheme that works with that specific <a href="#dfn-did-method-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-method-s-6">DID method</a>. In a specific DID
+    method scheme, the DID method name follows the first colon and terminates with
+    the second colon, e.g., <code>did:example:</code>
+  </dd>
+
+  <dt><dfn data-lt="DID subjects|DID subject" id="dfn-did-subjects" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">DID subject</dfn></dt>
+
+  <dd>
+    The entity identified by a <a href="#dfn-decentralized-identifiers" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-decentralized-identifiers-13">DID</a> and described by a <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-11">DID document</a>.
+    Anything can be a DID subject: person, group, organization, physical thing,
+    digital thing, logical thing, etc.
+  </dd>
+
+  <dt><dfn data-lt="DID URLs|DID URL" id="dfn-did-urls" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">DID URL</dfn></dt>
+  <dd>
+    A <a href="#dfn-decentralized-identifiers" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-decentralized-identifiers-14">DID</a> plus any additional syntactic component that conforms to the
+    definition in <a href="https://w3c.github.io/did-core/#did-url-syntax"></a>. This includes an optional <a href="#dfn-did-paths" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-paths-1">DID
+    path</a> (with its leading <code>/</code> character), optional <a href="#dfn-did-queries" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-queries-1">DID query</a>
+    (with its leading <code>?</code> character), and optional <a href="#dfn-did-fragments" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-fragments-1">DID fragment</a>
+    (with its leading <code>#</code> character).
+  </dd>
+
+  <dt><dfn id="dfn-did-url-dereferencing" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">DID URL dereferencing</dfn></dt>
+  <dd>
+    The process that takes as its input a <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-7">DID URL</a> and a set of input
+    metadata, and returns a <a href="#dfn-resources" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-resources-1">resource</a>. This resource might be a <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-12">DID
+    document</a> plus additional metadata, a secondary resource
+    contained within the <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-13">DID document</a>, or a resource entirely
+    external to the <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-14">DID document</a>. The process uses <a href="#dfn-did-resolution" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolution-7">DID resolution</a> to
+    fetch a <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-15">DID document</a> indicated by the <a href="#dfn-decentralized-identifiers" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-decentralized-identifiers-15">DID</a> contained within the
+    <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-8">DID URL</a>. The dereferencing process can then perform additional processing
+    on the <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-16">DID document</a> to return the dereferenced resource indicated by the
+    <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-9">DID URL</a>. The inputs and outputs of this process are defined in
+    <a href="#dereferencing" class="sec-ref"><bdi class="secno">4. </bdi>DID URL Dereferencing</a>.
+  </dd>
+
+  <dt><dfn data-lt="DID URL dereferencers|DID URL dereferencer" id="dfn-did-url-dereferencers" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">DID URL dereferencer</dfn></dt>
+  <dd>
+    A software and/or hardware system that performs the <a href="#dfn-did-url-dereferencing" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-url-dereferencing-4">DID URL dereferencing</a>
+    function for a given <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-10">DID URL</a> or <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-17">DID document</a>.
+  </dd>
+
+  <dt><dfn data-lt="" id="dfn-did-url-dereferencing-result" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">DID URL dereferencing result</dfn></dt>
+  <dd>A data structure that represents the result of the <a href="#dfn-did-url-dereferencing" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-url-dereferencing-5">DID URL dereferencing</a> algorithm.
+    May contain a <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-18">DID document</a> or other content. See Section <a href="#did-url-dereferencing-result" class="sec-ref"><bdi class="secno">8. </bdi>DID URL Dereferencing Result</a>.</dd>
+
+  <dt><dfn data-lt="distributed ledger technology|DLT|distributed ledger" id="dfn-distributed-ledger-technology" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">distributed ledger</dfn> (DLT)</dt>
+  <dd>
+    A non-centralized system for recording events. These systems establish
+    sufficient confidence for participants to rely upon the data recorded by others
+    to make operational decisions. They typically use distributed databases where
+    different nodes use a consensus protocol to confirm the ordering of
+    cryptographically signed transactions. The linking of digitally signed
+    transactions over time often makes the history of the ledger effectively
+    immutable.
+  </dd>
+
+  <dt><dfn data-lt="resources|resource" id="dfn-resources" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">resource</dfn></dt>
+  <dd>
+    As defined by [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc3986" title="Uniform Resource Identifier (URI): Generic Syntax">RFC3986</a></cite>]: "...the term 'resource' is used in a general sense
+    for whatever might be identified by a URI." Similarly, any resource might serve
+    as a <a href="#dfn-did-subjects" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-subjects-4">DID subject</a> identified by a <a href="#dfn-decentralized-identifiers" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-decentralized-identifiers-16">DID</a>.
+  </dd>
+
+  <dt><dfn data-lt="representations|representation" id="dfn-representations" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">representation</dfn></dt>
+  <dd>
+    As defined for HTTP by [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7231" title="Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content">RFC7231</a></cite>]: "information that is intended to reflect a
+    past, current, or desired state of a given resource, in a format that can be
+    readily communicated via the protocol, and that consists of a set of
+    representation metadata and a potentially unbounded stream of representation
+    data." A <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-19">DID document</a> is a representation of information describing a
+    <a href="#dfn-did-subjects" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-subjects-5">DID subject</a>. See <a href="https://w3c.github.io/did-core/#representations"></a>.
+  </dd>
+
+  <dt><dfn data-lt="" data-plurals="local bindings" id="dfn-local-binding" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">local binding</dfn></dt>
+  <dd>A <a href="#dfn-binding" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-binding-2">binding</a> where the <a href="#dfn-client" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-client-3">client</a> invokes a <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-5">DID resolver</a> that runs on the same network host, e.g., via a local command line tool or library API.
+    In this case, the <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-6">DID resolver</a> is sometimes also called a "local <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-7">DID resolver</a>".
+    See Section <a href="#resolver-architectures" class="sec-ref"><bdi class="secno">6.2 </bdi>Resolver Architectures</a>.</dd>
+
+  <dt><dfn data-lt="" data-plurals="remote bindings" id="dfn-remote-binding" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">remote binding</dfn></dt>
+  <dd>A <a href="#dfn-binding" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-binding-3">binding</a> where the <a href="#dfn-client" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-client-4">client</a> invokes a <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-8">DID resolver</a> that runs on a different network host, e.g., via the <a href="#bindings-https">HTTP(S) binding</a>.
+    In this case, the <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-9">DID resolver</a> is sometimes also called a "remote <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-10">DID resolver</a>".
+    See Section <a href="#resolver-architectures" class="sec-ref"><bdi class="secno">6.2 </bdi>Resolver Architectures</a>.</dd>
+
+  <dt><dfn data-lt="service|services" id="dfn-service" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">services</dfn></dt>
+  <dd>
+    Means of communicating or interacting with the <a href="#dfn-did-subjects" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-subjects-6">DID subject</a> or
+    associated entities via one or more <a href="#dfn-service-endpoints" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-service-endpoints-1">service endpoints</a>.
+    Examples include discovery services, agent services, social networking
+    services, file storage services, and verifiable credential repository services.
+  </dd>
+
+  <dt><dfn data-lt="service endpoints|service endpoint" id="dfn-service-endpoints" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">service endpoint</dfn></dt>
+  <dd>
+    A network address, such as an HTTP URL, at which <a href="#dfn-service" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-service-1">services</a> operate on
+    behalf of a <a href="#dfn-did-subjects" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-subjects-7">DID subject</a>.
+  </dd>
+
+  <dt><dfn data-lt="" id="dfn-service-endpoint-construction" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">service endpoint construction</dfn></dt>
+  <dd>An algorithm that takes a <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-11">DID URL</a> and a service, and constructs
+    a <a href="#dfn-service-endpoints" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-service-endpoints-2">service endpoint</a> URL See Section <a href="#service-endpoint-construction" class="sec-ref"><bdi class="secno">11. </bdi>Service Endpoint Construction</a>.</dd>
+
+  <dt><dfn data-lt="" id="dfn-unverifiable-read" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">unverifiable read</dfn></dt>
+  <dd> A low confidence implementation of a <a href="#dfn-did-method-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-method-s-7">DID method's</a> "Read" operation between the
+    <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-11">DID resolver</a> and the <a href="#dfn-verifiable-data-registry" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-verifiable-data-registry-2">verifiable data registry</a>, to obtain the <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-20">DID document</a>.
+    There is no guarantee about the integrity and correctness of the result. See Section <a href="#method-architectures" class="sec-ref"><bdi class="secno">6.1 </bdi>Method Architectures</a>.</dd>
+
+  <dt>
+    <dfn data-lt="verifiable data registry|verifiable data registries" id="dfn-verifiable-data-registry" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">
+      verifiable data registry</dfn>
+  </dt>
+  <dd>
+    A system that facilitates the creation, verification, updating, and/or
+    deactivation of <a href="#dfn-decentralized-identifiers" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-decentralized-identifiers-17">decentralized identifiers</a> and <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-21">DID documents</a>. A
+    verifiable data registry might also be used for other
+    cryptographically-verifiable data structures such as <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model/#dfn-verifiable-credential">verifiable
+    credentials</a>. For more information, see the <abbr title="World Wide Web Consortium">W3C</abbr> Verifiable Credentials
+    specification [<cite><a class="bibref" data-link-type="biblio" href="#bib-vc-data-model" title="Verifiable Credentials Data Model v1.1">VC-DATA-MODEL</a></cite>].
+  </dd>
+
+  <dt><dfn data-lt="" data-plurals="verification methods" id="dfn-verification-method" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">verification method</dfn></dt>
+  <dd>
+    <p>
+      A set of parameters that can be used together with a process to independently
+      verify a proof. For example, a cryptographic public key can be used as a
+      verification method with respect to a digital signature; in such usage, it
+      verifies that the signer possessed the associated cryptographic private key.
+    </p>
+    <p>
+      "Verification" and "proof" in this definition are intended to apply broadly. For
+      example, a cryptographic public key might be used during Diffie-Hellman key
+      exchange to negotiate a shared symmetric key for encryption. This guarantees the
+      integrity of the key agreement process. It is thus another type of verification
+      method, even though descriptions of the process might not use the words
+      "verification" or "proof."
+    </p>
+  </dd>
+
+  <dt><dfn data-lt="" id="dfn-verifiable-read" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">verifiable read</dfn></dt>
+  <dd> A high confidence implementation of a <a href="#dfn-did-method-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-method-s-8">DID method's</a> "Read" operation between the
+    <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-12">DID resolver</a> and the <a href="#dfn-verifiable-data-registry" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-verifiable-data-registry-3">verifiable data registry</a>, to obtain the <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-22">DID document</a>.
+    There are guarantees about the integrity and correctness of the result to the extent possible under the applicable <a href="#dfn-did-method-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-method-s-9">DID method</a>.
+    See Section <a href="#method-architectures" class="sec-ref"><bdi class="secno">6.1 </bdi>Method Architectures</a>.</dd>
+
+</dl>
+</div>
+
+</section>
+
+<section id="resolving"><div class="header-wrapper"><h2 id="x3-did-resolution"><bdi class="secno">3. </bdi>DID Resolution</h2><a class="self-link" href="#resolving" aria-label="Permalink for Section 3."></a></div>
+	
+
+	<p>
+		The <a href="#dfn-did-resolution" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolution-8">DID resolution</a> functions resolve a <a href="#dfn-decentralized-identifiers" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-decentralized-identifiers-18">DID</a> into a <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-23">DID
+		document</a> by using the "Read" operation of the applicable <a href="#dfn-did-method-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-method-s-10">DID method</a>
+		as described in <a href="https://w3c.github.io/did-core/#method-operations">Method Operations</a>. All
+		conforming <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-13">DID resolvers</a> implement the functions below, which have the
+		following abstract forms:
+	</p>
+
+	<pre title="Abstract functions for DID Resolution" aria-busy="false"><code class="hljs">resolve(did, resolutionOptions) →
+   « didResolutionMetadata, didDocument, didDocumentMetadata »
+
+resolveRepresentation(did, resolutionOptions) →
+   « didResolutionMetadata, didDocumentStream, didDocumentMetadata »</code></pre>
+
+	<p>
+		The <code>resolve</code> function returns the <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-24">DID document</a> in its
+		abstract form (a <a href="https://infra.spec.whatwg.org/#maps">map</a>). The
+		<code>resolveRepresentation</code> function returns a byte stream of the <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-25">DID
+		Document</a> formatted in the corresponding representation.
+	</p>
+
+	<figure id="resolve-resolverepresentation">
+		<img style="margin: auto; display: block;" src="diagrams/diagram-resolve-resolverepresentation.svg" alt="
+Diagram illustrating how resolve() returns the DID document data model in
+its abstract form and resolveRepresenation() returns it in one of the
+conformant representations; conversion is possible using production and
+consumption rules.">
+		<figcaption><a class="self-link" href="#resolve-resolverepresentation">Figure <bdi class="figno">1</bdi></a> <span class="fig-title">
+			Functions resolve() and resolveRepresentation().
+			See also: <a class="longdesc-link" href="#resolve-resolverepresentation-longdesc">narrative description</a>.
+		</span></figcaption>
+	</figure>
+
+	<div class="longdesc" id="resolve-resolverepresentation-longdesc">
+		<p>
+			The upper middle part of the diagram contains a rectangle with dashed grey outline, containing two
+			blue-outlined rectangles, one above the other.
+			The upper, larger rectangle is labeled, in blue, "Core Properties", and contains the following
+			<a href="https://infra.spec.whatwg.org/#maps">INFRA</a> notation:
+		</p>
+		<pre aria-busy="false"><code class="hljs javascript">«[
+  <span class="hljs-string">"id"</span> → <span class="hljs-string">"example:123"</span>,
+  <span class="hljs-string">"verificationMethod"</span> → « «[
+    <span class="hljs-string">"id"</span>: <span class="hljs-string">"did:example:123#keys-1"</span>,
+    <span class="hljs-string">"controller"</span>: <span class="hljs-string">"did:example:123"</span>,
+    <span class="hljs-string">"type"</span>: <span class="hljs-string">"Ed25519VerificationKey2018"</span>,
+    <span class="hljs-string">"publicKeyBase58"</span>: <span class="hljs-string">"H3C2AVvLMv6gmMNam3uVA"</span>
+  ]» »,
+  <span class="hljs-string">"authentication"</span> → «
+    <span class="hljs-string">"did:example:123#keys-1"</span>
+  »
+]»</code></pre>
+		<p>
+			The lower, smaller rectangle is labeled, in blue, "Core Representation-specific Entries (JSON-LD)", and
+			contains the following monospaced <a href="https://infra.spec.whatwg.org/#maps">INFRA</a> notation:
+		</p>
+		<pre aria-busy="false"><code class="hljs css">«<span class="hljs-selector-attr">[ <span class="hljs-string">"@context"</span> → <span class="hljs-string">"https://www.w3.org/ns/did/v1"</span> ]</span>»</code></pre>
+		<p>
+			From the grey-outlined rectangle, three pairs of arrows extend to three
+			different black-outlined rectangles, aligned in a horizontal row side-by-side, in the bottom half
+			of the diagram. Each pair of arrows consists of
+			one blue arrow pointing from the grey-outlined rectangle to the respective
+			black-outlined rectangle, labeled "produce", and one red arrow pointing in the
+			reverse direction, labeled "consume". The first black-outlined rectangle in the row
+			is labeled "application/did+ld+json", and contains
+			the following JSON-LD data:
+		</p>
+		<pre aria-busy="false"><code class="hljs json"><span class="hljs-punctuation">{</span>
+  <span class="hljs-attr">"@context"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"https://www.w3.org/ns/did/v1"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"did:example:123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"verificationMethod"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-punctuation">{</span>
+    <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"did:example:123#keys-1"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"controller"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"did:example:123"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"type"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"Ed25519VerificationKey2018"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"publicKeyBase58"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"H3C2AVvLMv6gmMNam3uVA"</span>
+  <span class="hljs-punctuation">}</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"authentication"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span>
+    <span class="hljs-string">"did:example:123#keys-1"</span>
+  <span class="hljs-punctuation">]</span>
+<span class="hljs-punctuation">}</span></code></pre>
+		<p>
+			The second rectangle in the row is labeled "application/did+json" and contains the following
+			JSON data:
+		</p>
+		<pre aria-busy="false"><code class="hljs json"><span class="hljs-punctuation">{</span>
+  <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"did:example:123"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"verificationMethod"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-punctuation">{</span>
+    <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"did:example:123#keys-1"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"controller"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"did:example:123"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"type"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"Ed25519VerificationKey2018"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"publicKeyBase58"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"H3C2AVvLMv6gmMNam3uVA"</span>
+  <span class="hljs-punctuation">}</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"authentication"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span>
+    <span class="hljs-string">"did:example:123#keys-1"</span>
+  <span class="hljs-punctuation">]</span>
+<span class="hljs-punctuation">}</span></code></pre>
+		<p>
+			The third rectangle in the row is labeled "application/did+cbor", and contains hexadecimal data.
+		</p>
+		<p>
+			In the left part of the diagram, in the middle, there is a box, with black outline and light gray
+			background. This box is labeled "VERIFIABLE DATA REGISTRY" and contains a symbol representing a graph
+			with nodes and arcs. From this box, one arrow, labeled "resolve()", extends upwards and points to the
+			top half of the diagram where the grey-outlined rectangle is located. Another arrow, labeled
+			"resolveRepresentation()", extends downwards and points to the bottom half of the diagram, where the
+			row of three black-outlined rectangles is located.
+		</p>
+	</div>
+
+	<p>
+		All conformant <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-14">DID resolvers</a> <em class="rfc2119">MUST</em> implement the <a href="#dfn-did-resolution" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolution-9">DID resolution</a>
+		functions for at least one <a href="#dfn-did-method-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-method-s-11">DID method</a> and <em class="rfc2119">MUST</em> be able to return a
+		<a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-26">DID document</a> in at least one conformant <a href="#dfn-representations" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-representations-2">representation</a>.
+	</p>
+
+	<p>
+		Conforming <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-15">DID resolver</a> implementations do not alter the signature of
+		these functions in any way. <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-16">DID resolver</a> implementations might map the
+		<code>resolve</code> and <code>resolveRepresentation</code> functions to a
+		method-specific internal function to perform the actual <a href="#dfn-did-resolution" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolution-10">DID resolution</a>
+		process. <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-17">DID resolver</a> implementations might implement and expose
+		additional functions with different signatures in addition to the
+		<code>resolve</code> and <code>resolveRepresentation</code> functions specified
+		here.
+	</p>
+
+	<p>
+		The input variables
+		of the <code>resolve</code> and <code>resolveRepresentation</code> functions are
+		as follows:
+	</p>
+
+	<dl>
+		<dt>
+			did
+		</dt>
+		<dd>
+			This is the <a href="#dfn-decentralized-identifiers" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-decentralized-identifiers-19">DID</a> to resolve. This input is <em class="rfc2119">REQUIRED</em> and the value <em class="rfc2119">MUST</em>
+			be a conformant <a href="#dfn-decentralized-identifiers" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-decentralized-identifiers-20">DID</a> as defined in <a href="https://w3c.github.io/did-core/#did-syntax"></a>.
+		</dd>
+		<dt>
+			resolutionOptions
+		</dt>
+		<dd>
+			A <a href="#metadata-structure">metadata structure</a> containing properties
+			defined in <a href="#did-resolution-options" class="sec-ref"><bdi class="secno">3.1 </bdi>DID Resolution Options</a>. This input is
+			<em class="rfc2119">REQUIRED</em>, but the structure <em class="rfc2119">MAY</em> be empty.
+		</dd>
+	</dl>
+
+	<p>
+		These functions each return multiple values, and no limitations
+		are placed on how these values are returned together.
+		The return values of <code>resolve</code> are
+		<a href="#dfn-didresolutionmetadata" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-didresolutionmetadata-1">didResolutionMetadata</a>, <a href="#dfn-diddocument" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-diddocument-1">didDocument</a>, and
+		<a href="#dfn-diddocumentmetadata" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-diddocumentmetadata-1">didDocumentMetadata</a>. The return values of
+		<code>resolveRepresentation</code> are
+		<a href="#dfn-didresolutionmetadata" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-didresolutionmetadata-2">didResolutionMetadata</a>, <a href="#dfn-diddocumentstream" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-diddocumentstream-1">didDocumentStream</a>, and
+		<a href="#dfn-diddocumentmetadata" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-diddocumentmetadata-2">didDocumentMetadata</a>. These values are described below:
+	</p>
+
+	<dl>
+		<dt>
+			<dfn id="dfn-didresolutionmetadata" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">didResolutionMetadata</dfn>
+		</dt>
+		<dd>
+			A <a href="#metadata-structure">metadata structure</a> consisting of values
+			relating to the results of the <a href="#dfn-did-resolution" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolution-11">DID resolution</a> process which typically
+			changes between invocations of the <code>resolve</code> and
+			<code>resolveRepresentation</code> functions, as it represents data about the
+			resolution process itself. This structure is <em class="rfc2119">REQUIRED</em>, and in the case of an
+			error in the resolution process, this <em class="rfc2119">MUST NOT</em> be empty. This metadata is
+			defined by <a href="#did-resolution-metadata" class="sec-ref"><bdi class="secno">3.2 </bdi>DID Resolution Metadata</a>. If
+			<code>resolveRepresentation</code> was called, this structure <em class="rfc2119">MUST</em> contain a
+			<code>contentType</code> property containing the Media Type of the
+			representation found in the <code>didDocumentStream</code>. If the resolution is
+			not successful, this structure <em class="rfc2119">MUST</em> contain an <code>error</code> property
+			describing the error.
+		</dd>
+		<dt>
+			<dfn id="dfn-diddocument" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">didDocument</dfn>
+		</dt>
+		<dd>
+			If the resolution is successful, and if the <code>resolve</code> function was
+			called, this <em class="rfc2119">MUST</em> be a <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-27">DID document</a> abstract data model (a <a href="https://infra.spec.whatwg.org/#maps">map</a>) as described in <a href="https://w3c.github.io/did-core/#data-model"></a> that
+			is capable of being transformed into a <a href="https://w3c.github.io/did-core/#dfn-did-documents">conforming DID Document</a>
+			(representation), using the production rules specified by the representation.
+			The value of <code><a href="https://w3c.github.io/did-core/#dfn-id">id</a></code> in the resolved <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-28">DID document</a> <em class="rfc2119">MUST</em>
+			match the <a href="#dfn-decentralized-identifiers" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-decentralized-identifiers-21">DID</a> that was resolved. If the resolution is unsuccessful, this
+			value <em class="rfc2119">MUST</em> be empty.
+		</dd>
+		<dt>
+			<dfn id="dfn-diddocumentstream" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">didDocumentStream</dfn>
+		</dt>
+		<dd>
+			If the resolution is successful, and if the <code>resolveRepresentation</code>
+			function was called, this <em class="rfc2119">MUST</em> be a byte stream of the resolved <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-29">DID
+			document</a> in one of the conformant
+			<a href="https://w3c.github.io/did-core/#representations">representations</a>. The byte stream might then be
+			parsed by the caller of the <code>resolveRepresentation</code> function into a
+			<a href="https://w3c.github.io/did-core/#data-model">data model</a>, which can in turn be validated and
+			processed. If the resolution is unsuccessful, this value <em class="rfc2119">MUST</em> be an empty
+			stream.
+		</dd>
+		<dt>
+			<dfn id="dfn-diddocumentmetadata" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">didDocumentMetadata</dfn>
+		</dt>
+		<dd>
+			If the resolution is successful, this <em class="rfc2119">MUST</em> be a <a href="#metadata-structure">metadata structure</a>. This structure contains
+			metadata about the <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-30">DID document</a> contained in the <code>didDocument</code>
+			property. This metadata typically does not change between invocations of the
+			<code>resolve</code> and <code>resolveRepresentation</code> functions unless the
+			<a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-31">DID document</a> changes, as it represents metadata about the <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-32">DID
+			document</a>. If the resolution is unsuccessful, this output <em class="rfc2119">MUST</em> be an empty <a href="#metadata-structure">metadata structure</a>. Properties defined by this
+			specification are in <a href="#did-document-metadata" class="sec-ref"><bdi class="secno">3.3 </bdi>DID Document Metadata</a>.
+		</dd>
+	</dl>
+
+	<section id="did-resolution-options"><div class="header-wrapper"><h3 id="x3-1-did-resolution-options"><bdi class="secno">3.1 </bdi>DID Resolution Options</h3><a class="self-link" href="#did-resolution-options" aria-label="Permalink for Section 3.1"></a></div>
+		
+
+		<p>
+			The possible properties within this structure and their possible values are
+			registered in the DID Specification Registries [<cite><a class="bibref" data-link-type="biblio" href="#bib-did-spec-registries" title="Decentralized Identifier Extensions">DID-SPEC-REGISTRIES</a></cite>]. This
+			specification defines the following common properties.
+		</p>
+
+		<dl>
+			<dt>
+				accept
+			</dt>
+			<dd>
+				The Media Type of the caller's preferred <a href="#dfn-representations" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-representations-3">representation</a> of the <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-33">DID
+				document</a>. The Media Type <em class="rfc2119">MUST</em> be expressed as an <a data-lt="ascii
+string" data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string">ASCII string</a>. The <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-18">DID resolver</a> implementation <em class="rfc2119">SHOULD</em> use this
+				value to determine the <a href="#dfn-representations" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-representations-4">representation</a> contained in the returned
+				<code>didDocumentStream</code> if such a <a href="#dfn-representations" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-representations-5">representation</a> is supported and
+				available. This property is <em class="rfc2119">OPTIONAL</em> for the <code>resolveRepresentation</code>
+				function and <em class="rfc2119">MUST NOT</em> be used with the <code>resolve</code> function.
+			</dd>
+		</dl>
+	</section>
+
+	<section id="did-resolution-metadata"><div class="header-wrapper"><h3 id="x3-2-did-resolution-metadata"><bdi class="secno">3.2 </bdi>DID Resolution Metadata</h3><a class="self-link" href="#did-resolution-metadata" aria-label="Permalink for Section 3.2"></a></div>
+		
+
+		<p>
+			The possible properties within this structure and their possible values are
+			registered in the DID Specification Registries [<cite><a class="bibref" data-link-type="biblio" href="#bib-did-spec-registries" title="Decentralized Identifier Extensions">DID-SPEC-REGISTRIES</a></cite>]. This
+			specification defines the following DID resolution metadata properties:
+		</p>
+
+		<dl>
+			<dt>
+				contentType
+			</dt>
+			<dd>
+				The Media Type of the returned <code>didDocumentStream</code>. This property is
+				<em class="rfc2119">REQUIRED</em> if resolution is successful and if the
+				<code>resolveRepresentation</code> function was called.
+				This property <em class="rfc2119">MUST NOT</em>
+				be present if the <code>resolve</code> function was called. The value of this
+				property <em class="rfc2119">MUST</em> be an <a data-lt="ascii string" data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string">ASCII string</a> that is the Media
+				Type of the conformant <a href="#dfn-representations" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-representations-6">representations</a>. The
+				caller of the <code>resolveRepresentation</code> function <em class="rfc2119">MUST</em> use this value
+				when determining how to parse and process the <code>didDocumentStream</code>
+				returned by this function into the <a href="https://w3c.github.io/did-core/#data-model">data model</a>.
+			</dd>
+			<dt>
+				error
+			</dt>
+			<dd>
+				The error code from the resolution process. This property is <em class="rfc2119">REQUIRED</em> when there
+				is an error in the resolution process. The value of this property <em class="rfc2119">MUST</em> be a
+				single keyword <a data-lt="ascii string" data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string">ASCII string</a>. The possible property
+				values of this field <em class="rfc2119">SHOULD</em> be registered in the DID Specification Registries
+				[<cite><a class="bibref" data-link-type="biblio" href="#bib-did-spec-registries" title="Decentralized Identifier Extensions">DID-SPEC-REGISTRIES</a></cite>]. This specification defines the following
+				common error values:
+				<dl>
+					<dt>
+						invalidDid
+					</dt>
+					<dd>
+						The <a href="#dfn-decentralized-identifiers" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-decentralized-identifiers-22">DID</a> supplied to the <a href="#dfn-did-resolution" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolution-12">DID resolution</a> function does not conform
+						to valid syntax. (See <a href="https://w3c.github.io/did-core/#did-syntax"></a>.)
+					</dd>
+					<dt>
+						notFound
+					</dt>
+					<dd>
+						The <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-19">DID resolver</a> was unable to find the <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-34">DID document</a>
+						resulting from this resolution request.
+					</dd>
+					<dt>
+						representationNotSupported
+					</dt>
+					<dd>
+						This error code is returned if the <a href="#dfn-representations" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-representations-7">representation</a> requested via the
+						<code>accept</code> input metadata property is not supported by the <a href="#dfn-did-method-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-method-s-12">DID
+						method</a> and/or <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-20">DID resolver</a> implementation.
+					</dd>
+				</dl>
+			</dd>
+		</dl>
+
+	</section>
+
+	<section id="did-document-metadata"><div class="header-wrapper"><h3 id="x3-3-did-document-metadata"><bdi class="secno">3.3 </bdi>DID Document Metadata</h3><a class="self-link" href="#did-document-metadata" aria-label="Permalink for Section 3.3"></a></div>
+		
+
+		<p>
+			The possible properties within this structure and their possible values <em class="rfc2119">SHOULD</em>
+			be registered in the DID Specification Registries [<cite><a class="bibref" data-link-type="biblio" href="#bib-did-spec-registries" title="Decentralized Identifier Extensions">DID-SPEC-REGISTRIES</a></cite>].
+			This specification defines the following common properties.
+		</p>
+
+		<dl>
+			<dt><dfn class="lint-ignore" id="dfn-created" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">created</dfn></dt>
+			<dd>
+				<a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-35">DID document</a> metadata <em class="rfc2119">SHOULD</em> include a <code>created</code> property to
+				indicate the timestamp of the <a href="https://w3c.github.io/did-core/#method-operations">Create operation</a>.
+				The value of the property <em class="rfc2119">MUST</em> be a <a href="https://infra.spec.whatwg.org/#string">string</a>
+				formatted as an <a href="https://www.w3.org/TR/xmlschema11-2/#dateTime">XML Datetime</a>
+				normalized to UTC 00:00:00 and without sub-second decimal precision. For
+				example: <code>2020-12-20T19:17:47Z</code>.
+			</dd>
+
+			<dt><dfn class="lint-ignore" id="dfn-updated" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">updated</dfn></dt>
+			<dd>
+				<a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-36">DID document</a> metadata <em class="rfc2119">SHOULD</em> include an <code>updated</code> property to
+				indicate the timestamp of the last <a href="https://w3c.github.io/did-core/#method-operations">Update
+				operation</a> for the document version which was resolved. The value of the
+				property <em class="rfc2119">MUST</em> follow the same formatting rules as the <code>created</code>
+				property. The <code>updated</code> property is omitted if an Update operation
+				has never been performed on the <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-37">DID document</a>. If an <code>updated</code>
+				property exists, it can be the same value as the <code>created</code> property
+				when the difference between the two timestamps is less than one second.
+			</dd>
+
+			<dt><dfn class="lint-ignore" id="dfn-deactivated" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">deactivated</dfn></dt>
+			<dd>
+				If a DID has been <a href="https://w3c.github.io/did-core/#method-operations">deactivated</a>,
+				<a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-38">DID document</a> metadata <em class="rfc2119">MUST</em> include this property with the boolean value
+				<code>true</code>. If a DID has not been deactivated, this property is <em class="rfc2119">OPTIONAL</em>,
+				but if included, <em class="rfc2119">MUST</em> have the boolean value <code>false</code>.
+			</dd>
+
+			<dt><dfn class="lint-ignore" id="dfn-nextupdate" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">nextUpdate</dfn></dt>
+			<dd>
+				<a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-39">DID document</a> metadata <em class="rfc2119">MAY</em> include a <code>nextUpdate</code> property if
+				the resolved document version is not the latest version of the document. It
+				indicates the timestamp of the next <a href="https://w3c.github.io/did-core/#method-operations">Update
+				operation</a>. The value of the property <em class="rfc2119">MUST</em> follow the same formatting rules
+				as the <code>created</code> property.
+			</dd>
+
+			<dt><dfn class="lint-ignore" id="dfn-versionid" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">versionId</dfn></dt>
+			<dd>
+				<a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-40">DID document</a> metadata <em class="rfc2119">SHOULD</em> include a <code>versionId</code> property to
+				indicate the version of the last <a href="https://w3c.github.io/did-core/#method-operations">Update
+				operation</a> for the document version which was resolved. The value of the
+				property <em class="rfc2119">MUST</em> be an <a data-lt="ascii string" data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string">ASCII string</a>.
+			</dd>
+
+			<dt><dfn class="lint-ignore" id="dfn-nextversionid" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">nextVersionId</dfn></dt>
+			<dd>
+				<a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-41">DID document</a> metadata <em class="rfc2119">MAY</em> include a <code>nextVersionId</code> property
+				if the resolved document version is not the latest version of the document. It
+				indicates the version of the next <a href="https://w3c.github.io/did-core/#method-operations">Update
+				operation</a>. The value of the property <em class="rfc2119">MUST</em> be an <a data-lt="ascii
+string" data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string">ASCII string</a>.
+			</dd>
+
+			<dt><dfn id="dfn-equivalentid" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">equivalentId</dfn></dt>
+			<dd>
+				<p>
+					A <a href="#dfn-did-method-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-method-s-13">DID method</a> can define different forms of a <a href="#dfn-decentralized-identifiers" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-decentralized-identifiers-23">DID</a> that are
+					logically equivalent. An example is when a <a href="#dfn-decentralized-identifiers" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-decentralized-identifiers-24">DID</a> takes one form prior to
+					registration in a <a href="#dfn-verifiable-data-registry" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-verifiable-data-registry-4">verifiable data registry</a> and another form after such
+					registration. In this case, the <a href="#dfn-did-method-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-method-s-14">DID method</a> specification might need to
+					express one or more <a href="#dfn-decentralized-identifiers" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-decentralized-identifiers-25">DIDs</a> that are logically equivalent to the resolved
+					<a href="#dfn-decentralized-identifiers" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-decentralized-identifiers-26">DID</a> as a property of the <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-42">DID document</a>. This is the purpose of the
+					<code><a href="#dfn-equivalentid" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-equivalentid-1">equivalentId</a></code> property.
+				</p>
+				<p>
+					<a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-43">DID document</a> metadata <em class="rfc2119">MAY</em> include an <code>equivalentId</code> property.
+					If present, the value <em class="rfc2119">MUST</em> be a <a href="https://infra.spec.whatwg.org/#ordered-set">set</a> where each item is a
+					<a href="https://infra.spec.whatwg.org/#string">string</a> that conforms to the rules in Section <a href="https://w3c.github.io/did-core/#did-syntax"></a>. The relationship is a statement that each
+					<code><a href="#dfn-equivalentid" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-equivalentid-2">equivalentId</a></code> value is logically equivalent to the
+					<code>id</code> property value and thus refers to the same <a href="#dfn-did-subjects" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-subjects-8">DID subject</a>.
+					Each <code><a href="#dfn-equivalentid" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-equivalentid-3">equivalentId</a></code> DID value <em class="rfc2119">MUST</em> be produced by, and a form
+					of, the same <a href="#dfn-did-method-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-method-s-15">DID method</a> as the <code>id</code> property value. (e.g.,
+					<code>did:example:abc</code> == <code>did:example:ABC</code>)
+				</p>
+				<p>
+					A conforming <a href="#dfn-did-method-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-method-s-16">DID method</a> specification <em class="rfc2119">MUST</em> guarantee that each
+					<code><a href="#dfn-equivalentid" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-equivalentid-4">equivalentId</a></code> value is logically equivalent to the
+					<code>id</code> property value.
+				</p>
+				<p>
+					A requesting party is expected to retain the values from the <code>id</code> and
+					<code><a href="#dfn-equivalentid" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-equivalentid-5">equivalentId</a></code> properties to ensure any subsequent
+					interactions with any of the values they contain are correctly handled as
+					logically equivalent (e.g., retain all variants in a database so an interaction
+					with any one maps to the same underlying account).
+				</p>
+				<div class="note" role="note" id="issue-container-generatedID-0"><div role="heading" class="note-title marker" id="h-note-0" aria-level="4"><span>Note</span><span class="issue-label">: Stronger equivalence</span></div><p class="">
+					<code><a href="#dfn-equivalentid" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-equivalentid-6">equivalentId</a></code> is a much stronger form of equivalence than
+					<code><a href="https://w3c.github.io/did-core/#also-known-as">alsoKnownAs</a></code> because the equivalence <em class="rfc2119">MUST</em> be guaranteed by
+					the governing <a href="#dfn-did-method-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-method-s-17">DID method</a>. <code><a href="#dfn-equivalentid" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-equivalentid-7">equivalentId</a></code> represents a
+					full graph merge because the same <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-44">DID document</a> describes both the
+					<code><a href="#dfn-equivalentid" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-equivalentid-8">equivalentId</a></code> <a href="#dfn-decentralized-identifiers" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-decentralized-identifiers-27">DID</a> and the <code>id</code> property
+					<a href="#dfn-decentralized-identifiers" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-decentralized-identifiers-28">DID</a>.
+				</p></div>
+				<p>
+					If a requesting party does not retain the values from the <code>id</code> and
+					<code><a href="#dfn-equivalentid" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-equivalentid-9">equivalentId</a></code> properties and ensure any subsequent
+					interactions with any of the values they contain are correctly handled as
+					logically equivalent, there might be negative or unexpected issues that
+					arise. Implementers are strongly advised to observe the
+					directives related to this metadata property.
+				</p>
+			</dd>
+			<dt><dfn id="dfn-canonicalid" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">canonicalId</dfn></dt>
+			<dd>
+				<p>
+					The <code><a href="#dfn-canonicalid" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-canonicalid-1">canonicalId</a></code> property is identical to the
+					<code><a href="#dfn-equivalentid" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-equivalentid-10">equivalentId</a></code> property except: a) it is associated with a
+					single value rather than a set, and b) the <a href="#dfn-decentralized-identifiers" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-decentralized-identifiers-29">DID</a> is defined to be
+					the canonical ID for the <a href="#dfn-did-subjects" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-subjects-9">DID subject</a> within the scope of the containing
+					<a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-45">DID document</a>.
+				</p>
+				<p>
+					<a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-46">DID document</a> metadata <em class="rfc2119">MAY</em> include a <code>canonicalId</code> property.
+					If present, the value <em class="rfc2119">MUST</em> be a <a href="https://infra.spec.whatwg.org/#string">string</a> that conforms to the rules in Section <a href="https://w3c.github.io/did-core/#did-syntax"></a>. The relationship is a statement that the
+					<code><a href="#dfn-canonicalid" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-canonicalid-2">canonicalId</a></code> value is logically equivalent to the
+					<code>id</code> property value and that the <code><a href="#dfn-canonicalid" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-canonicalid-3">canonicalId</a></code>
+					value is defined by the <a href="#dfn-did-method-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-method-s-18">DID method</a> to be the canonical ID for the <a href="#dfn-did-subjects" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-subjects-10">DID
+					subject</a> in the scope of the containing <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-47">DID document</a>. A
+					<code><a href="#dfn-canonicalid" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-canonicalid-4">canonicalId</a></code> value <em class="rfc2119">MUST</em> be produced by, and a form of, the
+					same <a href="#dfn-did-method-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-method-s-19">DID method</a> as the <code>id</code> property value. (e.g.,
+					<code>did:example:abc</code> == <code>did:example:ABC</code>).
+				</p>
+				<p>
+					A conforming <a href="#dfn-did-method-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-method-s-20">DID method</a> specification <em class="rfc2119">MUST</em> guarantee that the
+					<code><a href="#dfn-canonicalid" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-canonicalid-5">canonicalId</a></code> value is logically equivalent to the
+					<code>id</code> property value.
+				</p>
+				<p>
+					A requesting party is expected to use the <code><a href="#dfn-canonicalid" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-canonicalid-6">canonicalId</a></code> value
+					as its primary ID value for the <a href="#dfn-did-subjects" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-subjects-11">DID subject</a> and treat all other
+					equivalent values as secondary aliases (e.g., update corresponding primary
+					references in their systems to reflect the new canonical ID directive).
+				</p>
+				<div class="note" role="note" id="issue-container-generatedID-1"><div role="heading" class="note-title marker" id="h-note-1" aria-level="4"><span>Note</span><span class="issue-label">: Canonical equivalence</span></div><p class="">
+					<code><a href="#dfn-canonicalid" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-canonicalid-7">canonicalId</a></code> is the same statement of equivalence as
+					<code><a href="#dfn-equivalentid" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-equivalentid-11">equivalentId</a></code> except it is constrained to a single value that
+					is defined to be canonical for the <a href="#dfn-did-subjects" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-subjects-12">DID subject</a> in the scope of the <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-48">DID
+					document</a>. Like <code><a href="#dfn-equivalentid" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-equivalentid-12">equivalentId</a></code>,
+					<code><a href="#dfn-canonicalid" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-canonicalid-8">canonicalId</a></code> represents a full graph merge because the same
+					<a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-49">DID document</a> describes both the <code><a href="#dfn-canonicalid" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-canonicalid-9">canonicalId</a></code> DID and
+					the <code>id</code> property <a href="#dfn-decentralized-identifiers" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-decentralized-identifiers-30">DID</a>.
+				</p></div>
+				<p>
+					If a resolving party does not use the <code><a href="#dfn-canonicalid" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-canonicalid-10">canonicalId</a></code> value as
+					its primary ID value for the DID subject and treat all other equivalent values
+					as secondary aliases, there might be negative or unexpected issues that arise
+					related to user experience. Implementers are strongly advised to observe the
+					directives related to this metadata property.
+				</p>
+			</dd>
+		</dl>
+
+	</section>
+
+	<section id="resolving-algorithm"><div class="header-wrapper"><h3 id="x3-4-algorithm"><bdi class="secno">3.4 </bdi>Algorithm</h3><a class="self-link" href="#resolving-algorithm" aria-label="Permalink for Section 3.4"></a></div>
+		
+		<p>The following <a href="#dfn-did-resolution" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolution-13">DID resolution</a> algorithm <em class="rfc2119">MUST</em> be implemented by a conformant <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-21">DID resolver</a>.</p>
+		<ol class="algorithm">
+			<li>Validate that the <var>input <a href="#dfn-decentralized-identifiers" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-decentralized-identifiers-31">DID</a></var> conforms to the <code>did</code> rule of the
+			<a href="https://www.w3.org/TR/did-core/#did-syntax">DID Syntax</a>.
+			If not, the <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-22">DID resolver</a> <em class="rfc2119">MUST</em> return the following result:
+			<ol class="algorithm">
+				<li><b>didResolutionMetadata</b>: <code>«[ "error" → "invalidDid" ]»</code></li>
+				<li><b>didDocument</b>: <code>null</code></li>
+				<li><b>didDocumentMetadata</b>: <code>«[ ]»</code></li>
+			</ol>
+			</li>
+			<li>Determine whether the DID method of the <var>input <a href="#dfn-decentralized-identifiers" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-decentralized-identifiers-32">DID</a></var> is supported by the <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-23">DID resolver</a>
+			that implements this algorithm. If not, the <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-24">DID resolver</a> <em class="rfc2119">MUST</em> return the following result:
+			<ol class="algorithm">
+				<li><b>didResolutionMetadata</b>: <code>«[ "error" → "methodNotSupported" ]»</code></li>
+				<li><b>didDocument</b>: <code>null</code></li>
+				<li><b>didDocumentMetadata</b>: <code>«[ ]»</code></li>
+			</ol>
+			</li>
+			<li>Obtain the <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-50">DID document</a> for the <var>input <a href="#dfn-decentralized-identifiers" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-decentralized-identifiers-33">DID</a></var> by executing the
+			<a href="https://www.w3.org/TR/did-core/#method-operations">Read</a> operation against the
+			<var>input <a href="#dfn-decentralized-identifiers" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-decentralized-identifiers-34">DID</a>'s</var> <a href="#dfn-verifiable-data-registry" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-verifiable-data-registry-5">verifiable data registry</a>, as defined by the <var>input <a href="#dfn-did-method-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-method-s-21">DID method</a></var>:
+			<ol class="algorithm">
+				<li>Besides the <var>input <a href="#dfn-decentralized-identifiers" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-decentralized-identifiers-35">DID</a></var>, all additional <var>resolution options</var> of
+				this algorithm <em class="rfc2119">MUST</em> be passed to the
+				<a href="https://www.w3.org/TR/did-core/#method-operations">Read</a> operation of the
+				<var>input <a href="#dfn-did-method-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-method-s-22">DID method</a></var>.</li>
+				<li>If the <var>input <a href="#dfn-decentralized-identifiers" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-decentralized-identifiers-36">DID</a></var> does not exist, return the following result:
+				<ol class="algorithm">
+					<li><b>didResolutionMetadata</b>: <code>«[ "error" → "notFound" ]»</code></li>
+					<li><b>didDocument</b>: <code>null</code></li>
+					<li><b>didDocumentMetadata</b>: <code>«[ ]»</code></li>
+				</ol>
+				</li>
+				<li>If the <var>input <a href="#dfn-decentralized-identifiers" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-decentralized-identifiers-37">DID</a></var> has been deactivated, return the following result:
+				<ol class="algorithm">
+					<li><b>didResolutionMetadata</b>: <code>«[ ]»</code></li>
+					<li><b>didDocument</b>: <code>null</code></li>
+					<li><b>didDocumentMetadata</b>: <code>«[ "deactivated" → true ]»</code></li>
+				</ol>
+				</li>
+				<li>The result of the <a href="https://www.w3.org/TR/did-core/#method-operations">Read</a> operation
+				is called the <var>output <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-51">DID document</a></var>.</li>
+			</ol>
+			</li>
+			<li>Validate that the <var>output <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-52">DID document</a></var> conforms to a
+			<a href="https://www.w3.org/TR/did-core/#representations">conformant representation</a> of the <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-53">DID document</a>
+			<a href="https://www.w3.org/TR/did-core/#data-model">data model</a>. If not,
+			the <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-25">DID resolver</a> <em class="rfc2119">MUST</em> raise an error.</li>
+		</ol>
+
+		<div class="issue" id="issue-container-number-5"><div role="heading" class="issue-title marker" id="h-issue" aria-level="4"><a href="https://github.com/w3c/did-resolution/issues/5"><span class="issue-number">Issue 5</span></a><span class="issue-label">: Discuss how to treat deactivated DIDs <a class="respec-gh-label" style="background-color: rgb(162, 238, 239); color: rgb(0, 0, 0);" href="https://github.com/w3c/did-resolution/issues/?q=is%3Aissue+is%3Aopen+label%3A%22enhancement%22" aria-label="GitHub label: enhancement">enhancement</a><a class="respec-gh-label" style="background-color: rgb(23, 174, 243); color: rgb(0, 0, 0);" href="https://github.com/w3c/did-resolution/issues/?q=is%3Aissue+is%3Aopen+label%3A%22discuss%22" aria-label="GitHub label: discuss">discuss</a></span></div><p class="">There is discussion how a DID that has been
+		<a href="https://www.w3.org/TR/did-core/#method-operations">deactivated</a> should be treated during the <a href="#dfn-did-resolution" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolution-14">DID resolution</a>
+		process.</p></div>
+
+		<div class="issue" id="issue-container-number-13"><div role="heading" class="issue-title marker" id="h-issue-0" aria-level="4"><a href="https://github.com/w3c/did-resolution/issues/13"><span class="issue-number">Issue 13</span></a><span class="issue-label">: Validate signatures/proofs of DID Document <a class="respec-gh-label" style="background-color: rgb(250, 38, 234); color: rgb(0, 0, 0);" href="https://github.com/w3c/did-resolution/issues/?q=is%3Aissue+is%3Aopen+label%3A%22security%22" aria-label="GitHub label: security">security</a></span></div><p class="">Specify how signatures/proofs on a DID document should be verified during the
+		DID resolution process.</p></div>
+
+		<div class="issue" id="issue-container-generatedID-2"><div role="heading" class="issue-title marker" id="h-issue-1" aria-level="4"><span>Issue</span></div><p class="">Should we define functionality that enables discovery of the list of <a href="#dfn-did-method-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-method-s-23">DID methods</a> or other
+		capabilities that are supported by a <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-26">DID resolver</a>? Or is this implementation-specific and out-of-scope
+		for this spec? For example, see <a href="https://github.com/w3c/did-resolution/issues/26">here</a> and
+		<a href="https://github.com/w3c/did-resolution/issues/25">here</a>.</p></div>
+
+	</section>
+
+</section>
+
+<section id="dereferencing"><div class="header-wrapper"><h2 id="x4-did-url-dereferencing"><bdi class="secno">4. </bdi>DID URL Dereferencing</h2><a class="self-link" href="#dereferencing" aria-label="Permalink for Section 4."></a></div>
+	
+
+	<p>
+		The <a href="#dfn-did-url-dereferencing" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-url-dereferencing-6">DID URL dereferencing</a> function dereferences a <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-12">DID URL</a> into a
+		<a href="#dfn-resources" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-resources-2">resource</a> with contents depending on the <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-13">DID URL</a>'s components,
+		including the <a href="#dfn-did-method-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-method-s-24">DID method</a>, method-specific identifier, path, query, and
+		fragment. This process depends on <a href="#dfn-did-resolution" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolution-15">DID resolution</a> of the <a href="#dfn-decentralized-identifiers" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-decentralized-identifiers-38">DID</a>
+		contained in the <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-14">DID URL</a>. <a href="#dfn-did-url-dereferencing" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-url-dereferencing-7">DID URL dereferencing</a> might involve
+		multiple steps (e.g., when the DID URL being dereferenced includes a fragment),
+		and the function is defined to return the final resource after all steps are
+		completed. The following figure depicts the relationship described
+		above.
+	</p>
+
+	<figure id="did-url-dereference-overview">
+		<img style="margin: auto; display: block; width: 75%;" src="diagrams/did_url_dereference_overview.svg" alt="
+DIDs resolve to DID documents; DID URLs contains a DID; DID URLs dereferenced to DID document fragments or
+external resources.
+        ">
+		<figcaption><a class="self-link" href="#did-url-dereference-overview">Figure <bdi class="figno">2</bdi></a> <span class="fig-title">
+			Overview of DID URL dereference
+			See also: <a class="longdesc-link" href="#did-url-dereference-overview-longdesc">narrative description</a>.
+		</span></figcaption>
+	</figure>
+
+	<div class="longdesc" id="did-url-dereference-overview-longdesc">
+		<p>
+			The top left part of the diagram contains a rectangle with black outline, labeled "DID".
+		</p>
+		<p>
+			The bottom left part of the diagram contains a rectangle with black outline, labeled "DID URL".
+			This rectangle contains four smaller black-outlined rectangles, aligned in a horizontal row adjacent to
+			each other. These smaller rectangles are labeled, in order, "DID", "path", "query", and "fragment.
+		</p>
+		<p>
+			The top right part of the diagram contains a rectangle with black outline, labeled "DID document".
+			This rectangle contains three smaller black-outlined rectangles. These smaller rectangles are
+			labeled "id", "(property X)", and "(property Y)", and are surrounded by multiple series of three
+			dots (ellipses). A curved black arrow, labeled "DID document - relative fragment dereference", extends
+			from the rectangle labeled "(property X)", and points to the rectangle labeled "(property Y)".
+		</p>
+		<p>
+			The bottom right part of the diagram contains an oval shape with black outline, labeled "Resource".
+		</p>
+		<p>
+			A black arrow, labeled "resolves to a DID document", extends from the rectangle in the top left part of
+			the diagram, labeled "DID", and points to the rectangle in the top right part of diagram, labeled
+			"DID document".
+		</p>
+		<p>
+			A black arrow, labeled "refers to", extends from the rectangle in the top right part of the diagram,
+			labeled "DID document", and points to the oval shape in the bottom right part of diagram, labeled
+			"Resource".
+		</p>
+		<p>
+			A black arrow, labeled "contains", extends from the small rectangle labeled "DID" inside the
+			rectangle in the bottom left part of the diagram, labeled "DID URL", and points to the rectangle
+			in the top left part of diagram, labeled "DID".
+		</p>
+		<p>
+			A black arrow, labeled "dereferences to a DID document", extends from the rectangle in the bottom left
+			part of the diagram, labeled "DID URL", and points to the rectangle in the top right part of diagram,
+			labeled "DID document".
+		</p>
+		<p>
+			A black arrow, labeled "dereferences to a resource", extends from the rectangle in the bottom left
+			part of the diagram, labeled "DID URL", and points to the oval shape in the bottom right part of diagram,
+			labeled "Resource".
+		</p>
+	</div>
+
+	<p>
+		All conforming <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-27">DID resolvers</a> implement
+		the following function which has the following abstract form:
+	</p>
+
+	<pre title="Abstract functions for DID URL Dereferencing" aria-busy="false"><code class="hljs">dereference(didUrl, dereferenceOptions) →
+   « dereferencingMetadata, contentStream, contentMetadata »</code></pre>
+
+	<p>
+		The input variables of the <code>dereference</code> function are as follows:
+	</p>
+
+	<dl>
+		<dt>
+			didUrl
+		</dt>
+		<dd>
+			A conformant <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-15">DID URL</a> as a single <a href="https://infra.spec.whatwg.org/#string">string</a>.
+			This is the <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-16">DID URL</a> to dereference. To dereference a <a href="#dfn-did-fragments" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-fragments-2">DID fragment</a>,
+			the complete <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-17">DID URL</a> including the <a href="#dfn-did-fragments" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-fragments-3">DID fragment</a> <em class="rfc2119">MUST</em> be used. This
+			input is <em class="rfc2119">REQUIRED</em>.
+
+			<div class="note" role="note" id="issue-container-generatedID-3"><div role="heading" class="note-title marker" id="h-note-2" aria-level="3"><span>Note</span><span class="issue-label">: DID URL dereferencer patterns</span></div><p class="">
+				While it is valid for any <code>didUrl</code> to be passed to a DID URL
+				dereferencer, implementers are expected to refer to <a href="#dereferencing" class="sec-ref"><bdi class="secno">4. </bdi>DID URL Dereferencing</a> to
+				further understand common patterns for how a <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-18">DID URL</a> is expected
+				to be dereferenced.
+			</p></div>
+		</dd>
+		<dt>
+			dereferencingOptions
+		</dt>
+		<dd>
+			A <a href="#metadata-structure">metadata structure</a> consisting of input
+			options to the <code>dereference</code> function in addition to the
+			<code>didUrl</code> itself. Properties defined by this specification are in <a href="#did-url-dereferencing-options" class="sec-ref"><bdi class="secno">4.1 </bdi>DID URL Dereferencing Options</a>. This input is <em class="rfc2119">REQUIRED</em>, but the
+			structure <em class="rfc2119">MAY</em> be empty.
+		</dd>
+	</dl>
+
+	<p>
+		This function returns multiple values, and no limitations
+		are placed on how these values are returned together.
+		The return values of the <code>dereference</code> include
+		<code>dereferencingMetadata</code>, <code>contentStream</code>,
+		and <code>contentMetadata</code>:
+	</p>
+
+	<dl>
+		<dt>
+			dereferencingMetadata
+		</dt>
+		<dd>
+			A <a href="#metadata-structure">metadata structure</a> consisting of values
+			relating to the results of the <a href="#dfn-did-url-dereferencing" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-url-dereferencing-8">DID URL dereferencing</a> process. This
+			structure is <em class="rfc2119">REQUIRED</em>, and in the case of an error in the dereferencing process,
+			this <em class="rfc2119">MUST NOT</em> be empty. Properties defined by this specification are in <a href="#did-url-dereferencing-metadata" class="sec-ref"><bdi class="secno">4.2 </bdi>DID URL Dereferencing Metadata</a>. If the dereferencing is not
+			successful, this structure <em class="rfc2119">MUST</em> contain an <code>error</code> property
+			describing the error.
+		</dd>
+		<dt>
+			contentStream
+		</dt>
+		<dd>
+			If the <code>dereferencing</code> function was called and successful, this <em class="rfc2119">MUST</em>
+			contain a <a href="#dfn-resources" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-resources-3">resource</a> corresponding to the <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-19">DID URL</a>. The
+			<code>contentStream</code> <em class="rfc2119">MAY</em> be a <a href="#dfn-resources" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-resources-4">resource</a> such as a <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-54">DID
+			document</a> that is serializable in one of the conformant
+			<a href="#dfn-representations" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-representations-8">representations</a>, a <a href="https://w3c.github.io/did-core/#verification-methods">verification
+			method</a>, a <a href="https://w3c.github.io/did-core/#services">service</a>, or any other resource format that
+			can be identified via a Media Type and obtained through the resolution process.
+			If the dereferencing is unsuccessful, this value <em class="rfc2119">MUST</em> be empty.
+		</dd>
+		<dt>
+			contentMetadata
+		</dt>
+		<dd>
+			If the dereferencing is successful, this <em class="rfc2119">MUST</em> be a <a href="#metadata-structure">
+			metadata structure</a>, but the structure <em class="rfc2119">MAY</em> be empty. This structure contains
+			metadata about the <code>contentStream</code>. If the <code>contentStream</code>
+			is a <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-55">DID document</a>, this <em class="rfc2119">MUST</em> be a <a href="#dfn-diddocumentmetadata" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-diddocumentmetadata-3">didDocumentMetadata</a> structure as
+			described in <a href="#dfn-did-resolution" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolution-16">DID Resolution</a>. If the dereferencing is unsuccessful, this
+			output <em class="rfc2119">MUST</em> be an empty <a href="#metadata-structure">metadata structure</a>.
+		</dd>
+	</dl>
+
+	<p>
+		Conforming <a href="#dfn-did-url-dereferencing" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-url-dereferencing-9">DID URL dereferencing</a> implementations do not alter the
+		signature of these functions in any way. <a href="#dfn-did-url-dereferencing" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-url-dereferencing-10">DID URL dereferencing</a>
+		implementations might map the <code>dereference</code> function to a
+		method-specific internal function to perform the actual <a href="#dfn-did-url-dereferencing" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-url-dereferencing-11">DID URL
+		dereferencing</a> process. <a href="#dfn-did-url-dereferencing" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-url-dereferencing-12">DID URL dereferencing</a> implementations might
+		implement and expose additional functions with different signatures in addition
+		to the <code>dereference</code> function specified here.
+	</p>
+
+	<section id="did-url-dereferencing-options"><div class="header-wrapper"><h3 id="x4-1-did-url-dereferencing-options"><bdi class="secno">4.1 </bdi>DID URL Dereferencing Options</h3><a class="self-link" href="#did-url-dereferencing-options" aria-label="Permalink for Section 4.1"></a></div>
+		
+
+		<p>
+			The possible properties within this structure and their possible values <em class="rfc2119">SHOULD</em>
+			be registered in the DID Specification Registries [<cite><a class="bibref" data-link-type="biblio" href="#bib-did-spec-registries" title="Decentralized Identifier Extensions">DID-SPEC-REGISTRIES</a></cite>].
+			This specification defines the following common properties for
+			dereferencing options:
+		</p>
+
+		<dl>
+			<dt>
+				accept
+			</dt>
+			<dd>
+				The Media Type that the caller prefers for <code>contentStream</code>. The Media
+				Type <em class="rfc2119">MUST</em> be expressed as an <a data-lt="ascii string" data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string">ASCII string</a>. The
+				<a href="#dfn-did-url-dereferencing" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-url-dereferencing-13">DID URL dereferencing</a> implementation <em class="rfc2119">SHOULD</em> use this value to determine
+				the <code>contentType</code> of the <a href="#dfn-representations" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-representations-9">representation</a> contained in the
+				returned value if such a <a href="#dfn-representations" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-representations-10">representation</a> is supported and available.
+			</dd>
+		</dl>
+	</section>
+
+	<section id="did-url-dereferencing-metadata"><div class="header-wrapper"><h3 id="x4-2-did-url-dereferencing-metadata"><bdi class="secno">4.2 </bdi>DID URL Dereferencing Metadata</h3><a class="self-link" href="#did-url-dereferencing-metadata" aria-label="Permalink for Section 4.2"></a></div>
+		
+
+		<p>
+			The possible properties within this structure and their possible values are
+			registered in the DID Specification Registries [<cite><a class="bibref" data-link-type="biblio" href="#bib-did-spec-registries" title="Decentralized Identifier Extensions">DID-SPEC-REGISTRIES</a></cite>]. This
+			specification defines the following common properties.
+		</p>
+
+		<dl>
+			<dt>
+				contentType
+			</dt>
+			<dd>
+				The Media Type of the returned <code>contentStream</code> <em class="rfc2119">SHOULD</em> be expressed
+				using this property if dereferencing is successful. The Media
+				Type value <em class="rfc2119">MUST</em> be expressed as an <a data-lt="ascii string" data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string">ASCII string</a>.
+			</dd>
+			<dt>
+				error
+			</dt>
+			<dd>
+				The error code from the dereferencing process. This property is <em class="rfc2119">REQUIRED</em> when
+				there is an error in the dereferencing process. The value of this property
+				<em class="rfc2119">MUST</em> be a single keyword expressed as an <a data-lt="ascii string" data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-string">ASCII
+				string</a>. The possible property values of this field <em class="rfc2119">SHOULD</em> be registered in
+				the DID Specification Registries [<cite><a class="bibref" data-link-type="biblio" href="#bib-did-spec-registries" title="Decentralized Identifier Extensions">DID-SPEC-REGISTRIES</a></cite>]. This specification
+				defines the following common error values:
+				<dl>
+					<dt>
+						invalidDidUrl
+					</dt>
+					<dd>
+						The <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-20">DID URL</a> supplied to the <a href="#dfn-did-url-dereferencing" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-url-dereferencing-14">DID URL dereferencing</a> function does
+						not conform to valid syntax. (See <a href="https://w3c.github.io/did-core/#did-url-syntax"></a>.)
+					</dd>
+					<dt>
+						notFound
+					</dt>
+					<dd>
+						The <a href="#dfn-did-url-dereferencers" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-url-dereferencers-1">DID URL dereferencer</a> was unable to find the
+						<code>contentStream</code> resulting from this dereferencing request.
+					</dd>
+				</dl>
+			</dd>
+		</dl>
+	</section>
+
+
+	<section id="dereferencing-algorithm"><div class="header-wrapper"><h3 id="x4-3-algorithm"><bdi class="secno">4.3 </bdi>Algorithm</h3><a class="self-link" href="#dereferencing-algorithm" aria-label="Permalink for Section 4.3"></a></div>
+		
+		<p>The following <a href="#dfn-did-url-dereferencing" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-url-dereferencing-15">DID URL dereferencing</a> algorithm <em class="rfc2119">MUST</em> be implemented by a conformant <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-28">DID resolver</a>.
+		In accordance with [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc3986" title="Uniform Resource Identifier (URI): Generic Syntax">RFC3986</a></cite>], it consists of the following three steps: resolving the DID; dereferencing the
+		resource; and dereferencing the fragment (only if the <var>input <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-21">DID URL</a></var> contains a <a href="#dfn-did-fragments" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-fragments-4">DID fragment</a>):</p>
+
+		<section id="dereferencing-algorithm-resource"><div class="header-wrapper"><h4 id="x4-3-1-dereferencing-the-resource"><bdi class="secno">4.3.1 </bdi>Dereferencing the Resource</h4><a class="self-link" href="#dereferencing-algorithm-resource" aria-label="Permalink for Section 4.3.1"></a></div>
+			
+			<ol class="algorithm">
+				<li>Validate that the <var>input <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-22">DID URL</a></var> conforms to the <code>did-url</code> rule of the
+					<a href="https://www.w3.org/TR/did-core/#did-url-syntax">DID URL Syntax</a>.
+					If not, the <a href="#dfn-did-url-dereferencers" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-url-dereferencers-2">DID URL dereferencer</a> <em class="rfc2119">MUST</em> return the following result:
+
+					<ol class="algorithm">
+						<li><b>dereferencingMetadata</b>: <code>«[ "error" → "invalidDidUrl" ]»</code></li>
+						<li><b>contentStream</b>: <code>null</code></li>
+						<li><b>contentMetadata</b>: <code>«[ ]»</code></li>
+					</ol>
+
+				</li><li>Obtain the <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-56">DID document</a> for the <var>input <a href="#dfn-decentralized-identifiers" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-decentralized-identifiers-39">DID</a></var> by executing the
+					<a href="#dfn-did-resolution" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolution-17">DID resolution</a> algorithm as defined in <a href="#resolving" class="sec-ref"><bdi class="secno">3. </bdi>DID Resolution</a>. All
+					<a href="https://www.w3.org/TR/did-core/#did-parameters">
+						DID parameters</a> of the <var>input <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-23">DID URL</a></var> <em class="rfc2119">MUST</em> be passed as <var>resolution options</var> to the
+						<a href="#dfn-did-resolution" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolution-18">DID Resolution</a> algorithm. If the <var>input <a href="#dfn-decentralized-identifiers" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-decentralized-identifiers-40">DID</a></var> does not exist, return a null result.
+						Otherwise, the result is called the <var>resolved <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-57">DID document</a></var>.</li>
+				
+
+				<li>If present, separate the <a href="#dfn-did-fragments" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-fragments-5">DID fragment</a> from the <var>input <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-24">DID URL</a></var> and continue
+					with the adjusted <var>input <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-25">DID URL</a></var>.</li>
+
+				<li>If the <var>input <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-26">DID URL</a></var> contains no <a href="#dfn-did-paths" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-paths-2">DID path</a> and no <a href="#dfn-did-queries" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-queries-2">DID query</a>:
+					<div class="example" id="example-1">
+        <div class="marker">
+    <a class="self-link" href="#example-1">Example<bdi> 1</bdi></a>
+  </div> <pre class="nohighlight">did:example:1234</pre>
+      </div>
+					<ol class="algorithm">
+						<li>Return the <var>resolved <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-58">DID document</a></var>.</li>
+					</ol>
+				</li>
+
+				<li>Otherwise, if the <var>input <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-27">DID URL</a></var> contains the
+				<a href="https://www.w3.org/TR/did-core/#did-parameters">
+				DID parameter</a> <code>service</code> and optionally the <code>relativeRef</code> DID parameter:
+				<div class="example" id="example-2">
+        <div class="marker">
+    <a class="self-link" href="#example-2">Example<bdi> 2</bdi></a>
+  </div> <pre class="nohighlight">did:example:1234?service=files&amp;relativeRef=%2Fmyresume%2Fdoc%3Fversion%3Dlatest</pre>
+      </div>
+				<ol class="algorithm">
+					<li>From the <var>resolved <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-59">DID document</a></var>, select the
+					<a href="#service-endpoint-construction">service endpoint</a> whose <code>id</code>
+					property contains a fragment which matches the value of the <code>service</code> DID parameter of the
+					<var>input <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-28">DID URL</a></var>. This is called the <var>input <a href="#dfn-service-endpoints" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-service-endpoints-3">service endpoint</a></var>.</li>
+					<li>Execute the <a href="#service-endpoint-construction">Service Endpoint Construction</a> algorithm:
+					<ol class="algorithm">
+						<li>Read the value of the <code>serviceEndpoint</code> property of the
+						<var>input <a href="#dfn-service-endpoints" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-service-endpoints-4">service endpoint</a></var>. This is called the <var>input <a href="#dfn-service-endpoints" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-service-endpoints-5">service endpoint</a> URL</var>.</li>
+						<li>Pass the <var>input <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-29">DID URL </a></var> and <var>input <a href="#dfn-service-endpoints" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-service-endpoints-6">service endpoint</a> URL</var> to
+						the <a href="#service-endpoint-construction">Service Endpoint Construction</a> algorithm.</li>
+						<li>The result is called the <var>output <a href="#dfn-service-endpoints" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-service-endpoints-7">service endpoint</a> URL</var>.</li>
+					</ol>
+					</li>
+					<li>Return the <var>output <a href="#dfn-service-endpoints" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-service-endpoints-8">service endpoint</a> URL</var>.</li>
+				</ol>
+				</li>
+				<li>Otherwise, if the <var>input <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-30">DID URL</a></var> contains a <a href="#dfn-did-paths" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-paths-3">DID path</a> and/or <a href="#dfn-did-queries" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-queries-3">DID query</a>:
+				<div class="example" id="example-3">
+        <div class="marker">
+    <a class="self-link" href="#example-3">Example<bdi> 3</bdi></a>
+  </div> <pre class="nohighlight">did:example:1234/custom/path?customquery</pre>
+      </div>
+				<ol class="algorithm">
+					<li>The applicable <a href="#dfn-did-method-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-method-s-25">DID method</a> <em class="rfc2119">MAY</em> specify how to dereference
+					the <var>input <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-31">DID URL</a></var>.</li>
+					<li>The client <em class="rfc2119">MAY</em> be able to dereference the <var>input <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-32">DID URL</a></var>
+					in an application-specific way.</li>
+				</ol>
+				</li>
+				<li>If neither this algorithm, nor the applicable <a href="#dfn-did-method-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-method-s-26">DID method</a>, nor the client
+				is able to dereference the <var>input <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-33">DID URL</a></var>, return the following result:
+				<ol class="algorithm">
+					<li><b>dereferencingMetadata</b>: <code>«[ "error" → "notFound" ]»</code></li>
+					<li><b>contentStream</b>: <code>null</code></li>
+					<li><b>contentMetadata</b>: <code>«[ ]»</code></li>
+				</ol>
+				</li>
+			</ol>
+
+			<div class="issue" id="issue-container-number-85"><div role="heading" class="issue-title marker" id="h-issue-2" aria-level="5"><a href="https://github.com/w3c/did-resolution/issues/85"><span class="issue-number">Issue 85</span></a><span class="issue-label">: Request service by type <a class="respec-gh-label" style="background-color: rgb(162, 238, 239); color: rgb(0, 0, 0);" href="https://github.com/w3c/did-resolution/issues/?q=is%3Aissue+is%3Aopen+label%3A%22enhancement%22" aria-label="GitHub label: enhancement">enhancement</a></span></div><p class="">There have been discussions whether in addition to the DID parameter <code>service</code>,
+				there could also be a DID parameter <code>serviceType</code> to select services based
+				on their type rather than ID.
+				See <a href="https://lists.w3.org/Archives/Public/public-credentials/2019Jun/0028.html">
+					comments by Dave Longley</a> about <code>serviceType</code>.</p></div>
+
+		</section>
+
+		<section id="dereferencing-algorithm-fragment"><div class="header-wrapper"><h4 id="x4-3-2-dereferencing-the-fragment"><bdi class="secno">4.3.2 </bdi>Dereferencing the Fragment</h4><a class="self-link" href="#dereferencing-algorithm-fragment" aria-label="Permalink for Section 4.3.2"></a></div>
+			
+			<p>If the <var>input <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-34">DID URL</a></var> contains a <a href="#dfn-did-fragments" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-fragments-6">DID fragment</a>,
+			then dereferencing of the fragment is dependent
+			on the media type ([<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc2046" title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types">RFC2046</a></cite>]) of the resource, i.e., on the result of
+			<a href="#dereferencing-algorithm-resource" class="sec-ref"><bdi class="secno">4.3.1 </bdi>Dereferencing the Resource</a>.</p>
+			<ol class="algorithm">
+				<li>If the result of <a href="#dereferencing-algorithm-resource" class="sec-ref"><bdi class="secno">4.3.1 </bdi>Dereferencing the Resource</a> is an <var>output <a href="#dfn-service-endpoints" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-service-endpoints-9">service endpoint</a> URL</var>,
+				and the <var>input <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-35">DID URL</a></var> contains a <a href="#dfn-did-fragments" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-fragments-7">DID fragment</a>:
+				<div class="example" id="example-4">
+        <div class="marker">
+    <a class="self-link" href="#example-4">Example<bdi> 4</bdi></a>
+  </div> <pre class="nohighlight">did:example:1234?service=files&amp;relativeRef=%2Fmyresume%2Fdoc%3Fversion%3Dlatest#intro</pre>
+      </div>
+				<ol class="algorithm">
+					<li>If the <var>output <a href="#dfn-service-endpoints" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-service-endpoints-10">service endpoint</a> URL</var>
+					contains a <code>fragment</code> component, raise an error.</li>
+					<li>Append the <a href="#dfn-did-fragments" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-fragments-8">DID fragment</a> to the <var>output <a href="#dfn-service-endpoints" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-service-endpoints-11">service endpoint</a> URL</var>. In other words,
+					the <var>output <a href="#dfn-service-endpoints" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-service-endpoints-12">service endpoint</a> URL</var> "inherits" the <a href="#dfn-did-fragments" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-fragments-9">DID fragment</a> of the
+					<var>input <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-36">DID URL</a></var>.</li>
+					<li>Return the <var>output <a href="#dfn-service-endpoints" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-service-endpoints-13">service endpoint</a> URL</var>.</li>
+				</ol>
+				</li>
+				<li>Otherwise, dereference the DID fragment as defined by the media type ([<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc2046" title="Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types">RFC2046</a></cite>]) of the resource.
+				For example, if the resource is a representation of a DID document with media type <code>application/did</code>, then
+				the fragment is treated according to the rules associated with the
+				<a href="https://www.w3.org/TR/json-ld11/#iana-considerations">JSON-LD 1.1: application/ld+json media type</a>
+				[JSON-LD11].
+				</li>
+			</ol>
+
+			<div class="note" role="note" id="issue-container-generatedID-4"><div role="heading" class="note-title marker" id="h-note-3" aria-level="5"><span>Note</span></div><p class="">
+				This use of the <a href="#dfn-did-fragments" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-fragments-10">DID fragment</a> is consistent with the definition of the fragment identifier in
+				[<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc3986" title="Uniform Resource Identifier (URI): Generic Syntax">RFC3986</a></cite>]. It identifies a <em>secondary resource</em> which is a subset of the <em>primary resource</em>
+				(the <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-60">DID document</a>).
+			</p></div>
+
+			<div class="note" role="note" id="issue-container-generatedID-5"><div role="heading" class="note-title marker" id="h-note-4" aria-level="5"><span>Note</span></div><p class="">
+				This behavior of the <a href="#dfn-did-fragments" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-fragments-11">DID fragment</a> is analogous to the handling of a fragment in an HTTP URL in the
+				case when dereferencing it returns an HTTP <code>3xx</code> (Redirection) response with a
+				<code>Location</code> header (see section 7.1.2 of [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7231" title="Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content">RFC7231</a></cite>].
+			</p></div>
+
+		</section>
+
+	</section>
+
+	<section id="examples"><div class="header-wrapper"><h3 id="x4-4-examples"><bdi class="secno">4.4 </bdi>Examples</h3><a class="self-link" href="#examples" aria-label="Permalink for Section 4.4"></a></div>
+		
+		<p>Given the following <var>input <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-37">DID URL</a></var>:</p>
+		<div class="example" id="example-5">
+        <div class="marker">
+    <a class="self-link" href="#example-5">Example<bdi> 5</bdi></a>
+  </div> <pre class="nohighlight">did:example:123456789abcdefghi#keys-1</pre>
+      </div>
+		<p>... and the following <var>resolved <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-61">DID document</a></var>:</p><p>
+		</p><div class="example" id="example-6">
+        <div class="marker">
+    <a class="self-link" href="#example-6">Example<bdi> 6</bdi></a>
+  </div> <pre class="nohighlight">{
+	"@context": "https://www.w3.org/ns/did/v1",
+	"id": "did:example:123456789abcdefghi",
+	"verificationMethod": [{
+		"id": "did:example:123456789abcdefghi#keys-1",
+		"type": "Ed25519VerificationKey2018",
+		"controller": "did:example:123456789abcdefghi",
+		"publicKeyBase58": "H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"
+	}],
+	"service": [{
+		"id": "did:example:123456789abcdefghi#agent",
+		"type": "AgentService",
+		"serviceEndpoint": "https://agent.example.com/8377464"
+	}, {
+		"id": "did:example:123456789abcdefghi#messages",
+		"type": "MessagingService",
+		"serviceEndpoint": "https://example.com/messages/8377464"
+	}]
+}</pre>
+      </div>
+		<p>... then the result of the <a href="#dereferencing" class="sec-ref"><bdi class="secno">4. </bdi>DID URL Dereferencing</a> algorithm is the following <var>output resource</var>:</p>
+		<div class="example" id="example-7">
+        <div class="marker">
+    <a class="self-link" href="#example-7">Example<bdi> 7</bdi></a>
+  </div> <pre class="nohighlight">{
+	"@context": "https://www.w3.org/ns/did/v1",
+	"id": "did:example:123456789abcdefghi#keys-1",
+	"type": "Ed25519VerificationKey2018",
+	"controller": "did:example:123456789abcdefghi",
+	"publicKeyBase58": "H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"
+}</pre>
+      </div>
+		<p>Given the following <var>input <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-38">DID URL</a></var> and the same <var>resolved <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-62">DID document</a></var> as above:</p>
+		<div class="example" id="example-8">
+        <div class="marker">
+    <a class="self-link" href="#example-8">Example<bdi> 8</bdi></a>
+  </div> <pre class="nohighlight">did:example:123456789abcdefghi?service=messages&amp;relativeRef=%2Fsome%2Fpath%3Fquery#frag</pre>
+      </div>
+		<p>... then the result of the <a href="#dereferencing" class="sec-ref"><bdi class="secno">4. </bdi>DID URL Dereferencing</a> algorithm is the following <var>output <a href="#dfn-service-endpoints" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-service-endpoints-14">service endpoint</a> URL</var>:</p>
+		<div class="example" id="example-9">
+        <div class="marker">
+    <a class="self-link" href="#example-9">Example<bdi> 9</bdi></a>
+  </div> <pre class="nohighlight">https://example.com/messages/8377464/some/path?query#frag</pre>
+      </div>
+		<figure id="figure-dereferencing">
+			<img style="margin: auto; display: block; width: 100%;" src="diagrams/did-url-dereferencing.png" alt="Diagram showing how a DID URL can be dereferenced to a service endpoint URL">
+			<figcaption style="text-align: center;"><a class="self-link" href="#figure-dereferencing">Figure <bdi class="figno">3</bdi></a> <span class="fig-title">
+				Dereferencing a DID URL to a service endpoint URL.
+			</span></figcaption>
+		</figure>
+		<div class="issue" id="issue-container-generatedID-6"><div role="heading" class="issue-title marker" id="h-issue-3" aria-level="4"><span>Issue</span></div><p class="">Change the diagram and/or examples to make them consistent.</p></div>
+
+	</section>
+
+</section>
+
+<section id="metadata-structure"><div class="header-wrapper"><h2 id="x5-metadata-structure"><bdi class="secno">5. </bdi>Metadata Structure</h2><a class="self-link" href="#metadata-structure" aria-label="Permalink for Section 5."></a></div>
+	
+
+	<p>
+		Input and output metadata is often involved during the <a href="#dfn-did-resolution" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolution-19">DID Resolution</a>,
+		<a href="#dfn-did-url-dereferencing" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-url-dereferencing-16">DID URL dereferencing</a>, and other DID-related processes. The structure
+		used to communicate this metadata <em class="rfc2119">MUST</em> be a <a href="https://infra.spec.whatwg.org/#maps">map</a>
+		of properties. Each property name <em class="rfc2119">MUST</em> be a <a href="https://infra.spec.whatwg.org/#string">string</a>. Each property value <em class="rfc2119">MUST</em> be a <a href="https://infra.spec.whatwg.org/#string">string</a>, <a href="https://infra.spec.whatwg.org/#maps">map</a>, <a href="https://infra.spec.whatwg.org/#list">list</a>, <a href="https://infra.spec.whatwg.org/#ordered-set">set</a>,
+		<a href="https://infra.spec.whatwg.org/#boolean">boolean</a>, or
+		<a href="https://infra.spec.whatwg.org/#nulls">null</a>. The values within any complex data
+		structures such as maps and lists <em class="rfc2119">MUST</em> be one of these data types as well.
+		All metadata property definitions registered in the DID Specification
+		Registries [<cite><a class="bibref" data-link-type="biblio" href="#bib-did-spec-registries" title="Decentralized Identifier Extensions">DID-SPEC-REGISTRIES</a></cite>] <em class="rfc2119">MUST</em> define the value type, including any
+		additional formats or restrictions to that value (for example, a string
+		formatted as a date or as a decimal integer). It is <em class="rfc2119">RECOMMENDED</em> that property
+		definitions use strings for values. The entire metadata structure <em class="rfc2119">MUST</em> be
+		serializable according to the <a href="https://infra.spec.whatwg.org/#serialize-an-infra-value-to-json-bytes">JSON
+		serialization rules</a> in the [<cite><a class="bibref" data-link-type="biblio" href="#bib-infra" title="Infra Standard">INFRA</a></cite>] specification. Implementations <em class="rfc2119">MAY</em>
+		serialize the metadata structure to other data formats.
+	</p>
+
+	<p>
+		All implementations of functions that use metadata structures as either input or
+		output are able to fully represent all data types described here in a
+		deterministic fashion. As inputs and outputs using metadata structures are
+		defined in terms of data types and not their serialization, the method for
+		<a href="#dfn-representations" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-representations-11">representation</a> is internal to the implementation of the function and is
+		out of scope of this specification.
+	</p>
+
+	<p>
+		The following example demonstrates a JSON-encoded metadata structure that
+		might be used as <a href="#did-resolution-options">DID
+		resolution input metadata</a>.
+	</p>
+
+	<div class="example" id="example-json-encoded-did-resolution-input-metadata-example">
+        <div class="marker">
+    <a class="self-link" href="#example-json-encoded-did-resolution-input-metadata-example">Example<bdi> 10</bdi></a><span class="example-title">: JSON-encoded DID resolution input metadata example</span>
+  </div> <pre aria-busy="false"><code class="hljs json"><span class="hljs-punctuation">{</span>
+<span class="hljs-attr">"accept"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"application/did+ld+json"</span>
+<span class="hljs-punctuation">}</span></code></pre>
+      </div>
+
+	<p>
+		This example corresponds to a metadata structure of the following format:
+	</p>
+
+	<div class="example" id="example-did-resolution-input-metadata-example">
+        <div class="marker">
+    <a class="self-link" href="#example-did-resolution-input-metadata-example">Example<bdi> 11</bdi></a><span class="example-title">: DID resolution input metadata example</span>
+  </div> <pre aria-busy="false"><code class="hljs abnf">«[
+<span class="hljs-string">"accept"</span> → <span class="hljs-string">"application/did+ld+json"</span>
+]»</code></pre>
+      </div>
+
+	<p>
+		The next example demonstrates a JSON-encoded metadata structure that might be
+		used as <a href="#did-resolution-options">DID resolution
+		metadata</a> if a <a href="#dfn-decentralized-identifiers" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-decentralized-identifiers-41">DID</a> was not found.
+	</p>
+
+	<div class="example" id="example-json-encoded-did-resolution-metadata-example">
+        <div class="marker">
+    <a class="self-link" href="#example-json-encoded-did-resolution-metadata-example">Example<bdi> 12</bdi></a><span class="example-title">: JSON-encoded DID resolution metadata example</span>
+  </div> <pre aria-busy="false"><code class="hljs json"><span class="hljs-punctuation">{</span>
+<span class="hljs-attr">"error"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"notFound"</span>
+<span class="hljs-punctuation">}</span></code></pre>
+      </div>
+
+	<p>
+		This example corresponds to a metadata structure of the following format:
+	</p>
+
+	<div class="example" id="example-did-resolution-metadata-example">
+        <div class="marker">
+    <a class="self-link" href="#example-did-resolution-metadata-example">Example<bdi> 13</bdi></a><span class="example-title">: DID resolution metadata example</span>
+  </div> <pre aria-busy="false"><code class="hljs abnf">«[
+<span class="hljs-string">"error"</span> → <span class="hljs-string">"notFound"</span>
+]»</code></pre>
+      </div>
+
+	<p>
+		The next example demonstrates a JSON-encoded metadata structure that might be
+		used as <a href="#did-document-metadata">DID document metadata</a>
+		to describe timestamps associated with the <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-63">DID document</a>.
+	</p>
+
+	<div class="example" id="example-json-encoded-did-document-metadata-example">
+        <div class="marker">
+    <a class="self-link" href="#example-json-encoded-did-document-metadata-example">Example<bdi> 14</bdi></a><span class="example-title">: JSON-encoded DID document metadata example</span>
+  </div> <pre aria-busy="false"><code class="hljs json"><span class="hljs-punctuation">{</span>
+<span class="hljs-attr">"created"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"2019-03-23T06:35:22Z"</span><span class="hljs-punctuation">,</span>
+<span class="hljs-attr">"updated"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"2023-08-10T13:40:06Z"</span>
+<span class="hljs-punctuation">}</span></code></pre>
+      </div>
+
+	<p>
+		This example corresponds to a metadata structure of the following format:
+	</p>
+
+	<div class="example" id="example-did-document-metadata-example">
+        <div class="marker">
+    <a class="self-link" href="#example-did-document-metadata-example">Example<bdi> 15</bdi></a><span class="example-title">: DID document metadata example</span>
+  </div> <pre aria-busy="false"><code class="hljs javascript">«[
+<span class="hljs-string">"created"</span> → <span class="hljs-string">"2019-03-23T06:35:22Z"</span>,
+<span class="hljs-string">"updated"</span> → <span class="hljs-string">"2023-08-10T13:40:06Z"</span>
+]»</code></pre>
+      </div>
+
+</section>
+
+<section id="architectures"><div class="header-wrapper"><h2 id="x6-did-resolution-architectures"><bdi class="secno">6. </bdi>DID Resolution Architectures</h2><a class="self-link" href="#architectures" aria-label="Permalink for Section 6."></a></div>
+	
+	<div class="issue" id="issue-container-generatedID-7"><div role="heading" class="issue-title marker" id="h-issue-4" aria-level="3"><span>Issue</span></div><p class="">TODO: Describe how <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-29">DID resolvers</a> are implemented and used, describe the relevance
+	of <a href="#dfn-did-method-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-method-s-27">DID methods</a>.
+	Explain the difference between "method architectures" and "resolver architectures".</p></div>
+
+	<section id="method-architectures"><div class="header-wrapper"><h3 id="x6-1-method-architectures"><bdi class="secno">6.1 </bdi>Method Architectures</h3><a class="self-link" href="#method-architectures" aria-label="Permalink for Section 6.1"></a></div>
+		
+		<p>The <a href="#dfn-did-resolution" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolution-20">DID resolution</a> algorithm involves executing the <a href="https://www.w3.org/TR/did-core/#method-operations">Read</a>
+		operation on a <a href="#dfn-decentralized-identifiers" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-decentralized-identifiers-42">DID</a> according to its <a href="#dfn-did-method-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-method-s-28">DID method</a> (see <a href="#resolving" class="sec-ref"><bdi class="secno">3. </bdi>DID Resolution</a>).</p>
+
+		<div class="note" role="note" id="issue-container-generatedID-8"><div role="heading" class="note-title marker" id="h-note-5" aria-level="4"><span>Note</span></div><div class="">
+		<p>The mechanics of the "Read" operation can vary considerably between
+		<a href="#dfn-did-method-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-method-s-29">DID methods</a>. In particular, no assumption should be made that:</p>
+		<ul>
+		<li>... an immutable blockchain is used as (part of) the <a href="#dfn-verifiable-data-registry" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-verifiable-data-registry-6">verifiable data registry</a>.</li>
+		<li>... interaction with a remote network is required during execution of the "Read" operation.</li>
+		<li>... an actual <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-64">DID document</a> is stored in plain-text on a <a href="#dfn-verifiable-data-registry" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-verifiable-data-registry-7">verifiable data registry</a>,
+		or that the <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-65">DID document</a> can simply be retrieved via a standard protocol such as HTTP(S).
+		While some <a href="#dfn-did-method-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-method-s-30">DID methods</a> may define their "Read" operation this way, others may
+		define more complex multi-step processes that involve on-the-fly construction of a "virtual" <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-66">DID document</a>.</li>
+		</ul>
+		</div></div>
+
+		<div class="issue" id="issue-container-generatedID-9"><div role="heading" class="issue-title marker" id="h-issue-5" aria-level="4"><span>Issue</span></div><p class="">As an example, mention what it means to "resolve" peer/off-ledger/microledger/edgechain DIDs (for instance, see
+		[<cite><a class="bibref" data-link-type="biblio" href="#bib-did-peer" title="Peer DID Method Specification">DID-PEER</a></cite>] and
+		<a href="https://docs.google.com/presentation/d/1UnC_nfOUK40WS5TD_EhyDuFe5cStX-u0Z7wjoae_PqQ/">here</a>).</p></div>
+
+		<div class="issue" id="issue-container-generatedID-10"><div role="heading" class="issue-title marker" id="h-issue-6" aria-level="4"><span>Issue</span></div><p class="">As an example, mention what it means to "resolve" DIDs that are simply wrapped public keys (for instance, see
+		[<cite><a class="bibref" data-link-type="biblio" href="#bib-did-key" title="The did:key Method">DID-KEY</a></cite>] and
+		<a href="https://github.com/w3c/did-spec/pull/55">here</a>).</p></div>
+
+		<p>Depending on the exact nature of the <a href="#dfn-did-method-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-method-s-31">DID method's</a> "Read" operation, the interaction between a
+		<a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-30">DID resolver</a> and the <a href="#dfn-verifiable-data-registry" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-verifiable-data-registry-8">verifiable data registry</a> may be implemented as a <a href="#dfn-verifiable-read" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-verifiable-read-1">verifiable read</a>
+		or <a href="#dfn-unverifiable-read" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-unverifiable-read-1">unverifiable read</a>:</p>
+
+		<figure id="figure-method-verifiable">
+			<img style="margin: auto; display: block; width: 100%;" src="diagrams/method-verifiable.png" alt="Diagram showing a 'verifiable read' implementation of a DID method.">
+			<figcaption style="text-align: center;"><a class="self-link" href="#figure-method-verifiable">Figure <bdi class="figno">4</bdi></a> <span class="fig-title">
+				A <a href="#dfn-verifiable-read" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-verifiable-read-2">verifiable read</a> implementation of a <a href="#dfn-did-method-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-method-s-32">DID method</a>.
+			</span></figcaption>
+		</figure>
+		<figure id="figure-method-unverifiable">
+			<img style="margin: auto; display: block; width: 100%;" src="diagrams/method-unverifiable.png" alt="Diagram showing an 'unverifiable read' implementation of a DID method.">
+			<figcaption style="text-align: center;"><a class="self-link" href="#figure-method-unverifiable">Figure <bdi class="figno">5</bdi></a> <span class="fig-title">
+				An <a href="#dfn-unverifiable-read" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-unverifiable-read-2">unverifiable read</a> implementation of a <a href="#dfn-did-method-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-method-s-33">DID method</a>.
+			</span></figcaption>
+		</figure>
+
+		<p>
+			A <a href="#dfn-verifiable-read" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-verifiable-read-3">verifiable read</a> maximizes confidence in the integrity and correctness of the result of the "Read" operation ‐ to the extent
+			possible under the applicable <a href="#dfn-did-method-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-method-s-34">DID method</a>. It can be implemented in a variety of ways, for example:
+		</p>
+
+		<ul>
+		<li>A "Read" operation may be considered "Verifiable" if access to the <a href="#dfn-verifiable-data-registry" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-verifiable-data-registry-9">verifiable data registry</a> is
+			possible via a local, trusted network host. In the case of blockchain-based <a href="#dfn-did-method-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-method-s-35">DID methods</a>, a blockchain full node
+			may be run on a local network host in order to implement a <a href="#dfn-verifiable-read" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-verifiable-read-4">verifiable read</a>.</li>
+		<li>The <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-31">DID resolver</a> may be remotely connected to the <a href="#dfn-verifiable-data-registry" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-verifiable-data-registry-10">verifiable data registry</a> but have some method
+			to verify the contents of the response of the "Read" operation. In the case of blockchain-based <a href="#dfn-did-method-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-method-s-36">DID methods</a>, even if
+			direct access to a blockchain full node is not available, a <a href="#dfn-verifiable-read" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-verifiable-read-5">verifiable read</a> may still be possible by running a light client that
+			processes metadata to verify that the result of the "Read" operation hasn't been tampered with.</li>
+		<li>A <a href="#dfn-verifiable-read" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-verifiable-read-6">verifiable read</a> may be implemented if access to the <a href="#dfn-verifiable-data-registry" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-verifiable-data-registry-11">verifiable data registry</a> happens via a remote
+			network host that is considered trusted because it is run on a personal device in the home and accessed via
+			a secure channel.</li>
+		</ul>
+
+		<p>
+			An <a href="#dfn-unverifiable-read" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-unverifiable-read-3">unverifiable read</a> does not have such guarantees and is therefore less desirable, for example:
+		</p>
+
+		<ul>
+		<li>A "Read" operation may be considered "Unverifiable" if access to the <a href="#dfn-verifiable-data-registry" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-verifiable-data-registry-12">verifiable data registry</a> happens
+			via a remote, untrusted intermediary. In the case of blockchain-based <a href="#dfn-did-method-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-method-s-37">DID methods</a>, a remote blockchain explorer API
+			operated by an third party may be used to look up data from the blockchain.</li>
+		</ul>
+
+		<p>
+			Whether or not a <a href="#dfn-verifiable-read" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-verifiable-read-7">verifiable read</a> is possible depends not only on a <a href="#dfn-did-method-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-method-s-38">DID method</a> itself, but also on the way how
+			a <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-32">DID resolver</a> implements it. <a href="#dfn-did-method-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-method-s-39">DID methods</a> <em class="rfc2119">MAY</em> define multiple different ways of implementing their "Read"
+			operation(s) and <em class="rfc2119">SHOULD</em> offer guidance on how to implement a <a href="#dfn-verifiable-read" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-verifiable-read-8">verifiable read</a> in at least one way.
+		</p>
+
+		<div class="note" role="note" id="issue-container-generatedID-11"><div role="heading" class="note-title marker" id="h-note-6" aria-level="4"><span>Note</span></div><p class="">
+			The guarantees associated with a <a href="#dfn-verifiable-read" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-verifiable-read-9">verifiable read</a> are still always limited by the architectures, protocols, cryptography,
+			and other aspects of the underlying <a href="#dfn-verifiable-data-registry" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-verifiable-data-registry-13">verifiable data registry</a>. The strongest forms of <a href="#dfn-verifiable-read" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-verifiable-read-10">verifiable read</a>
+			implementations are considered those that do not require any interaction with a remote network at all (for example, see
+			[<cite><a class="bibref" data-link-type="biblio" href="#bib-did-key" title="The did:key Method">DID-KEY</a></cite>]), or that minimize dependencies on specific network infrastructure and reduce the "root of trust"
+			to proven entropy and cryptography alone (for example, see [<cite><a class="bibref" data-link-type="biblio" href="#bib-keri" title="Key Event Receipt Infrastructure (KERI)">KERI</a></cite>]).
+		</p></div>
+
+		<div class="issue" id="issue-container-generatedID-12"><div role="heading" class="issue-title marker" id="h-issue-7" aria-level="4"><span>Issue</span></div><p class="">TODO: Describe how a client can potentially verify the result of a "Read" operation independently even if it does
+		not trust the DID resolver (e.g., using state proofs).</p></div>
+
+		<p>A <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-33">DID resolver</a> <em class="rfc2119">MUST</em> support the <a href="#dfn-did-resolution" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolution-21">DID resolution</a> algorithm for at least one <a href="#dfn-did-method-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-method-s-40">DID method</a> and
+		<em class="rfc2119">MAY</em> support it for multiple <a href="#dfn-did-method-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-method-s-41">DID methods</a>:</p>
+		<figure id="figure-method-multiple">
+			<img style="margin: auto; display: block; width: 100%;" src="diagrams/method-multiple.png" alt="Diagram showing a DID resolver that supports multiple DID methods.">
+			<figcaption style="text-align: center;"><a class="self-link" href="#figure-method-multiple">Figure <bdi class="figno">6</bdi></a> <span class="fig-title">
+				A <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-34">DID resolver</a> that supports multiple <a href="#dfn-did-method-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-method-s-42">DID methods</a>.
+			</span></figcaption>
+		</figure>
+
+		<p>In this case, the above considerations about <a href="#dfn-verifiable-read" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-verifiable-read-11">verifiable read</a> and <a href="#dfn-unverifiable-read" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-unverifiable-read-4">unverifiable read</a>
+		implementations apply to each supported <a href="#dfn-did-method-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-method-s-43">DID method</a> individually.</p>
+
+	</section>
+
+	<section id="resolver-architectures"><div class="header-wrapper"><h3 id="x6-2-resolver-architectures"><bdi class="secno">6.2 </bdi>Resolver Architectures</h3><a class="self-link" href="#resolver-architectures" aria-label="Permalink for Section 6.2"></a></div>
+		
+		<p>The algorithms for <a href="#dfn-did-resolution" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolution-22">DID resolution</a> and <a href="#dfn-did-url-dereferencing" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-url-dereferencing-17">DID URL dereferencing</a> are defined as abstract functions
+		(see <a href="#resolving" class="sec-ref"><bdi class="secno">3. </bdi>DID Resolution</a> and <a href="#dereferencing" class="sec-ref"><bdi class="secno">4. </bdi>DID URL Dereferencing</a>).</p>
+		Those algorithms are implemented by <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-35">DID resolvers</a>. A <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-36">DID resolver</a> is invoked by a <a href="#dfn-client" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-client-5">client</a>
+		via a <a href="#dfn-binding" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-binding-4">binding</a>. bindings define how the abstract functions are realized using concrete
+		programming or communication interfaces. It is possible to distinguish between <a href="#dfn-local-binding" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-local-binding-2">local bindings</a>
+		(such as a local command line tool or library API) and <a href="#dfn-remote-binding" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-remote-binding-2">remote bindings</a> (such as the
+		<a href="#bindings-https">HTTP(S) binding</a>).<p></p>
+
+		<figure id="figure-binding-local">
+			<img style="margin: auto; display: block; width: 100%;" src="diagrams/binding-local.png" alt="Diagram showing a DID resolver with a 'local binding'.">
+			<figcaption style="text-align: center;"><a class="self-link" href="#figure-binding-local">Figure <bdi class="figno">7</bdi></a> <span class="fig-title">
+				A <a href="#dfn-local-binding" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-local-binding-3">local binding</a> for a <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-37">DID resolver</a>.
+			</span></figcaption>
+		</figure>
+		<figure id="figure-binding-remote">
+			<img style="margin: auto; display: block; width: 100%;" src="diagrams/binding-remote.png" alt="Diagram showing a DID resolver with a 'remote binding'.">
+			<figcaption style="text-align: center;"><a class="self-link" href="#figure-binding-remote">Figure <bdi class="figno">8</bdi></a> <span class="fig-title">
+				A <a href="#dfn-remote-binding" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-remote-binding-3">remote binding</a> for a <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-38">DID resolver</a>.
+			</span></figcaption>
+		</figure>
+
+		<div class="issue" id="issue-container-number-28"><div role="heading" class="issue-title marker" id="h-issue-8" aria-level="4"><a href="https://github.com/w3c/did-resolution/issues/28"><span class="issue-number">Issue 28</span></a><span class="issue-label">: 'remote' vs 'local' DID Resolvers</span></div><div class="">
+			<p>TODO: Describe <a href="#dfn-local-binding" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-local-binding-4">local bindings</a> vs. <a href="#dfn-remote-binding" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-remote-binding-4">remote bindings</a>, and implications for privacy, security and trust.</p>
+			<p>Also describe mitigations against potential downsides of <a href="#dfn-remote-binding" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-remote-binding-5">remote bindings</a>, e.g.:</p>
+			<ul>
+				<li>A <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-39">DID resolver's</a> <a href="#dfn-remote-binding" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-remote-binding-6">remote binding</a> can use a trusted channel such as VPN or TLS with mutual authentication.</li>
+				<li>A <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-40">DID resolver</a> can add a data integrity proof (see [<cite><a class="bibref" data-link-type="biblio" href="#bib-data-integrity" title="Verifiable Credential Data Integrity 1.0">DATA-INTEGRITY</a></cite>])
+				to a <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-67">DID document</a> and/or the <a href="#dfn-did-resolution-result" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolution-result-1">DID resolution result</a>. Discuss what this does and doesn't achieve. Also see
+				<a href="https://www.w3.org/TR/did-core/#proving-control-and-binding">Proving Control and Binding</a>.</li>
+				<li>A client could query multiple <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-41">DID resolvers</a> over a <a href="#dfn-remote-binding" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-remote-binding-7">remote binding</a> and compare results.</li>
+			</ul>
+		</div></div>
+		<div class="issue" id="issue-container-generatedID-13"><div role="heading" class="issue-title marker" id="h-issue-9" aria-level="4"><span>Issue</span></div><p class="">TODO: Discuss DID resolution in constrained user agents such as mobile apps and browsers.</p></div>
+		
+		<p>The following diagram shows how the <code>resolve()</code> and <code>resolveRepresentation()</code> functions
+		use production and consumption rules of DID document representation can apply in an architecture that involves
+		both a local resolver and a remote resolver.</p> 
+		<figure id="resolvers-and-representations">
+			<img style="margin: auto; display: block; width: 100%;" src="diagrams/resolvers-and-representations.png" alt="Diagram showing a local and remote DID resolver executing the resolve() and resolveRepresentation() functions.">
+			<figcaption style="text-align: center;"><a class="self-link" href="#resolvers-and-representations">Figure <bdi class="figno">9</bdi></a> <span class="fig-title">
+				Production and consumption in an architecture that involves both
+				a local and a remote <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-42">DID resolver</a>.
+			</span></figcaption>
+		</figure>
+
+	<section id="resolver-architectures-proxied"><div class="header-wrapper"><h4 id="x6-2-1-proxied-resolution"><bdi class="secno">6.2.1 </bdi>Proxied Resolution</h4><a class="self-link" href="#resolver-architectures-proxied" aria-label="Permalink for Section 6.2.1"></a></div>
+		
+
+		<p>A <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-43">DID resolver</a> <em class="rfc2119">MAY</em> invoke another <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-44">DID resolver</a>, which serves as a proxy that executes
+		the <a href="#dfn-did-resolution" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolution-23">DID resolution</a> algorithm as defined in <a href="#resolving" class="sec-ref"><bdi class="secno">3. </bdi>DID Resolution</a>.</p>
+
+		<p>The first <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-45">DID resolver</a> then acts
+		as a <a href="#dfn-client" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-client-6">client</a> and chooses a suitable <a href="#dfn-binding" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-binding-5">binding</a> for invoking the second <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-46">DID resolver</a>. For example, a <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-47">DID resolver</a> may be
+		invoked via a <a href="#dfn-local-binding" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-local-binding-5">local binding</a> (such as a command line tool), which in turn invokes another <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-48">DID resolver</a>
+		via a <a href="#dfn-remote-binding" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-remote-binding-8">remote binding</a> (such as the <a href="#bindings-https">HTTP(S) binding</a>).</p>
+
+		<figure id="figure-proxied-dereferencing">
+			<img style="margin: auto; display: block; width: 100%;" src="diagrams/proxied-dereferencing.png" alt="Diagram showing two DID resolvers, one invoked via 'local binding', the other invoked via 'remote binding'.">
+			<figcaption style="text-align: center;"><a class="self-link" href="#figure-proxied-dereferencing">Figure <bdi class="figno">10</bdi></a> <span class="fig-title">
+				A client invokes a <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-49">DID resolver</a> via <a href="#dfn-local-binding" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-local-binding-6">local binding</a> which invokes another <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-50">DID resolver</a> via
+				<a href="#dfn-remote-binding" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-remote-binding-9">remote binding</a>, which in turn supports resolving multiple <a href="#dfn-did-method-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-method-s-44">DID methods</a>.
+			</span></figcaption>
+		</figure>
+
+		<div class="note" role="note" id="issue-container-generatedID-14"><div role="heading" class="note-title marker" id="h-note-7" aria-level="5"><span>Note</span></div><p class="">This is similar to a "stub resolver" invoking a "recursive resolver" in DNS architecture, although
+		the concepts are not entirely comparable (DNS Resolution uses a single concrete protocol, whereas DID resolution
+		is an abstract function realized by different <a href="#dfn-did-method-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-method-s-45">DID methods</a> and different <a href="#dfn-binding" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-binding-6">bindings</a>).</p></div>
+
+	</section>
+
+	<section id="resolver-architectures-client-side"><div class="header-wrapper"><h4 id="x6-2-2-client-side-dereferencing"><bdi class="secno">6.2.2 </bdi>Client-Side Dereferencing</h4><a class="self-link" href="#resolver-architectures-client-side" aria-label="Permalink for Section 6.2.2"></a></div>
+		
+
+		<p>Different parts of the <a href="#dereferencing">DID URL dereferencing</a>
+		algorithm may be performed by different components of a <a href="#resolver-architectures">Resolver Architecture</a>.</p>
+
+		<p>Specifically, when a <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-39">DID URL</a> with a <a href="#dfn-did-fragments" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-fragments-12">DID fragment</a> is dereferenced, then
+		<a href="#dereferencing-algorithm-resource">Dereferencing the Resource</a> is done by
+		the <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-51">DID resolver</a>, and
+		<a href="#dereferencing-algorithm-fragment">Dereferencing the Fragment</a> is done by the <a href="#dfn-client" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-client-7">client</a>.</p>
+
+		<p>Example: Given the <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-40">DID URL</a> <code>did:xyz:1234#keys-1</code>, a <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-52">DID resolver</a> could be invoked
+		via <a href="#dfn-local-binding" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-local-binding-7">local binding</a>
+		for <a href="#dereferencing-algorithm-resource">Dereferencing the Resource</a> (i.e., the <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-68">DID document</a>),
+		and the <a href="#dfn-client" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-client-8">client</a> could complete the <a href="#dfn-did-url-dereferencing" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-url-dereferencing-18">DID URL dereferencing</a> algorithm by
+		<a href="#dereferencing-algorithm-fragment">Dereferencing the Fragment</a> (i.e., a part of the <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-69">DID document</a>).</p>
+
+		<figure id="figure-client-side-dereferencing-1">
+			<img style="display: block; width: 100%;" src="diagrams/client-side-dereferencing-1.png" alt="Diagram showing client-side dereferencing of a DID URL by a DID resolver and a client">
+			<figcaption style="text-align: center;"><a class="self-link" href="#figure-client-side-dereferencing-1">Figure <bdi class="figno">11</bdi></a> <span class="fig-title">
+				Client-side dereferencing of a <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-41">DID URL</a> by a <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-53">DID resolver</a> and a <a href="#dfn-client" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-client-9">client</a>.
+			</span></figcaption>
+		</figure>
+
+		<p>Example: Given the <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-42">DID URL</a> <code>did:xyz:1234#keys-1</code>, a <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-54">DID resolver</a> could be invoked via
+		<a href="#dfn-local-binding" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-local-binding-8">local binding</a> which invokes another <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-55">DID resolver</a> via <a href="#dfn-remote-binding" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-remote-binding-10">remote binding</a>
+		for <a href="#dereferencing-algorithm-resource">Dereferencing the Resource</a> (i.e., the <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-70">DID document</a>),
+		and the <a href="#dfn-client" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-client-10">client</a> could complete the <a href="#dfn-did-url-dereferencing" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-url-dereferencing-19">DID URL dereferencing</a> algorithm by
+		<a href="#dereferencing-algorithm-fragment">Dereferencing the Fragment</a> (i.e., a part of the <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-71">DID document</a>).</p>
+
+		<figure id="figure-client-side-dereferencing-3">
+			<img style="margin: auto; display: block; width: 100%;" src="diagrams/client-side-dereferencing-2.png" alt="Diagram showing client-side dereferencing of a DID URL by two DID resolvers and a client">
+			<figcaption style="text-align: center;"><a class="self-link" href="#figure-client-side-dereferencing-3">Figure <bdi class="figno">12</bdi></a> <span class="fig-title">
+				Client-side dereferencing (in combination with <a href="#resolver-architectures-proxied">Proxied Resolution</a>)
+				of a <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-43">DID URL</a> by two <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-56">DID resolvers</a> and a <a href="#dfn-client" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-client-11">client</a>.
+			</span></figcaption>
+		</figure>
+
+		<p>Example: Given the <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-44">DID URL</a> <code>did:xyz:1234?service=agent&amp;relativeRef=%2Fsome%2Fpath%3Fquery#frag</code>, a <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-57">DID resolver</a> could be invoked
+		for <a href="#dereferencing-algorithm-resource">Dereferencing the Resource</a> (i.e., a <a href="#dfn-service-endpoints" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-service-endpoints-15">service endpoint</a> URL),
+		and the <a href="#dfn-client" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-client-12">client</a> could complete the <a href="#dfn-did-url-dereferencing" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-url-dereferencing-20">DID URL dereferencing</a> algorithm by
+		<a href="#dereferencing-algorithm-fragment">Dereferencing the Fragment</a> (i.e., a <a href="#dfn-service-endpoints" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-service-endpoints-16">service endpoint</a> URL with a fragment).</p>
+
+		<figure id="figure-client-side-dereferencing-2">
+			<img style="margin: auto; display: block; width: 100%;" src="diagrams/client-side-dereferencing-3.png" alt="Diagram showing client-side dereferencing of a DID URL by a DID resolver and a client">
+			<figcaption style="text-align: center;"><a class="self-link" href="#figure-client-side-dereferencing-2">Figure <bdi class="figno">13</bdi></a> <span class="fig-title">
+				Client-side dereferencing of a <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-45">DID URL</a> by a <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-58">DID resolver</a> and a <a href="#dfn-client" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-client-13">client</a>.
+			</span></figcaption>
+		</figure>
+
+	</section>
+
+	</section>
+
+</section>
+
+<section id="did-resolution-result"><div class="header-wrapper"><h2 id="x7-did-resolution-result"><bdi class="secno">7. </bdi>DID Resolution Result</h2><a class="self-link" href="#did-resolution-result" aria-label="Permalink for Section 7."></a></div>
+	
+	<p>This section defines a data structure that represents the result of the algorithm described
+	in <a href="#resolving" class="sec-ref"><bdi class="secno">3. </bdi>DID Resolution</a>. A <a href="#dfn-did-resolution-result" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolution-result-2">DID resolution result</a> contains
+	a <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-72">DID document</a> as well as
+	<a href="#output-resolutionmetadata">DID resolution metadata</a> and <a href="#output-documentmetadata">DID
+	document metadata</a>.</p>
+
+	<p>The media type of this data structure is defined to be <code>application/ld+json;profile="https://w3id.org/did-resolution"</code>.</p>
+
+	<section id="example"><div class="header-wrapper"><h3 id="x7-1-example"><bdi class="secno">7.1 </bdi>Example</h3><a class="self-link" href="#example" aria-label="Permalink for Section 7.1"></a></div>
+		
+
+		<div class="example" id="example-example-did-resolution-result">
+        <div class="marker">
+    <a class="self-link" href="#example-example-did-resolution-result">Example<bdi> 16</bdi></a><span class="example-title">: Example DID resolution result</span>
+  </div> <pre class="nohighlight">{
+	"@context": "https://w3id.org/did-resolution/v1",
+	"didDocument": {
+		"@context": "https://www.w3.org/ns/did/v1",
+		"id": "did:example:123456789abcdefghi",
+		"authentication": [{
+			"id": "did:example:123456789abcdefghi#keys-1",
+			"type": "Ed25519VerificationKey2018",
+			"controller": "did:example:123456789abcdefghi",
+			"publicKeyBase58": "H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"
+		}],
+		"service": [{
+			"id":"did:example:123456789abcdefghi#vcs",
+			"type": "VerifiableCredentialService",
+			"serviceEndpoint": "https://example.com/vc/"
+		}]
+	},
+	"didResolutionMetadata": {
+		"contentType": "application/did+ld+json",
+		"retrieved": "2024-06-01T19:73:24Z",
+	},
+	"didDocumentMetadata": {
+		"created": "2019-03-23T06:35:22Z",
+		"updated": "2023-08-10T13:40:06Z",
+		"method": {
+			"nymResponse": {
+				"result": {
+					"data": "{\"dest\":\"WRfXPg8dantKVubE3HX8pw\",\"identifier\":\"V4SGRU86Z58d6TV7PBUe6f\",\"role\":\"0\",\"seqNo\":11,\"txnTime\":1524055264,\"verkey\":\"H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV\"}",
+					"type": "105",
+					"txnTime": 1.524055264E9,
+					"seqNo": 11.0,
+					"reqId": 1.52725687080231475E18,
+					"identifier": "HixkhyA4dXGz9yxmLQC4PU",
+					"dest": "WRfXPg8dantKVubE3HX8pw"
+				},
+				"op": "REPLY"
+			},
+			"attrResponse": {
+				"result": {
+					"identifier": "HixkhyA4dXGz9yxmLQC4PU",
+					"seqNo": 12.0,
+					"raw": "endpoint",
+					"dest": "WRfXPg8dantKVubE3HX8pw",
+					"data": "{\"endpoint\":{\"xdi\":\"http://127.0.0.1:8080/xdi\"}}",
+					"txnTime": 1.524055265E9,
+					"type": "104",
+					"reqId": 1.52725687092557056E18
+				},
+				"op": "REPLY"
+			}
+		}
+	}
+}</pre>
+      </div>
+
+	<div class="issue closed" id="issue-container-number-23"><div role="heading" class="issue-title marker" id="h-issue-10" aria-level="4"><a href="https://github.com/w3c/did-resolution/issues/23"><span class="issue-number">Issue 23</span></a><span class="issue-label">: The did is not a url for the did, but for a resolution structure which as yet has no name <a class="respec-gh-label" style="background-color: rgb(101, 159, 43); color: rgb(0, 0, 0);" href="https://github.com/w3c/did-resolution/issues/?q=is%3Aissue+is%3Aopen+label%3A%22pending-close%22" aria-label="GitHub label: pending-close">pending-close</a></span></div><p class="">See corresponding open issue.</p></div>
+	<div class="issue" id="issue-container-generatedID-15"><div role="heading" class="issue-title marker" id="h-issue-11" aria-level="4"><span>Issue</span></div><p class="">Need to define how this data structure works exactly, and whether it always contains
+	a <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-73">DID document</a> or can also contain other results.</p></div>
+
+	</section>
+
+	<section id="output-diddocument"><div class="header-wrapper"><h3 id="x7-2-did-document"><bdi class="secno">7.2 </bdi>DID Document</h3><a class="self-link" href="#output-diddocument" aria-label="Permalink for Section 7.2"></a></div>
+		
+		<p>A <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-74">DID document</a> associated with a <a href="#dfn-decentralized-identifiers" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-decentralized-identifiers-43">DID</a>. The result of <a href="#resolving" class="sec-ref"><bdi class="secno">3. </bdi>DID Resolution</a>.</p>
+
+	</section>
+
+	<section id="output-resolutionmetadata"><div class="header-wrapper"><h3 id="x7-3-did-resolution-metadata"><bdi class="secno">7.3 </bdi>DID Resolution Metadata</h3><a class="self-link" href="#output-resolutionmetadata" aria-label="Permalink for Section 7.3"></a></div>
+		
+		<p>This is a metadata structure (see section <a href="https://www.w3.org/TR/did-core/#metadata-structure">Metadata Structure</a>
+		in [<cite><a class="bibref" data-link-type="biblio" href="#bib-did-core" title="Decentralized Identifiers (DIDs) v1.0">DID-CORE</a></cite>]) that contains metadata about the <a href="#dfn-did-resolution" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolution-24">DID Resolution</a> process.</p>
+		<p>This metadata typically changes between invocations of the <a href="#dfn-did-resolution" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolution-25">DID Resolution</a> functions as it represents data about the resolution process itself.</p>
+		<p>The source of this metadata is the DID resolver.</p>
+		<p>Examples of DID Resolution Metadata include:</p>
+		<ul>
+		<li>Media type of the returned content (the <b>contentType</b> metadata property).</li>
+		<li>Error code (the <b>error</b> metadata property).</li>
+		<li>Duration of the DID resolution process.</li>
+		<li>Caching information about the DID document (see Section <a href="#caching" class="sec-ref"><bdi class="secno">12.2 </bdi>Caching</a>).</li>
+		<li>Various URLs, IP addresses or other network information that was used during the DID resolution process.</li>
+		<li>Proofs added by a DID resolver (e.g., to establish trusted resolution).</li>
+		</ul>
+		<p>See also section <a href="https://www.w3.org/TR/did-core/#did-resolution-metadata">DID Resolution Metadata</a>
+		in [<cite><a class="bibref" data-link-type="biblio" href="#bib-did-core" title="Decentralized Identifiers (DIDs) v1.0">DID-CORE</a></cite>].</p>
+
+	</section>
+
+	<section id="output-documentmetadata"><div class="header-wrapper"><h3 id="x7-4-did-document-metadata"><bdi class="secno">7.4 </bdi>DID Document Metadata</h3><a class="self-link" href="#output-documentmetadata" aria-label="Permalink for Section 7.4"></a></div>
+		
+		<p>This is a metadata structure (see section <a href="https://www.w3.org/TR/did-core/#metadata-structure">Metadata Structure</a>
+		in [<cite><a class="bibref" data-link-type="biblio" href="#bib-did-core" title="Decentralized Identifiers (DIDs) v1.0">DID-CORE</a></cite>]) that contains metadata about a <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-75">DID Document</a>.</p>
+		<p>This metadata typically does not change between invocations of the <a href="#dfn-did-resolution" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolution-26">DID Resolution</a> function unless the <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-76">DID document</a> changes, as it represents data about the <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-77">DID document</a>.</p>
+		<p>The sources of this metadata are the <a href="#dfn-did-controllers" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-controllers-2">DID controller</a> and/or the <a href="#dfn-did-method-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-method-s-46">DID method</a>.</p>
+		<p>Examples of DID Document Metadata include:</p>
+		<ul>
+		<li>Timestamps when the DID and its associated DID document were created or updated (the <b>created</b> and <b>updated</b> metadata properties).</li>
+		<li>Metadata about controllers, capabilities, delegations, etc.</li>
+		<li>Versioning information about the DID document (see Section <a href="#versioning" class="sec-ref"><bdi class="secno">12.3 </bdi>Versioning</a>).</li>
+		<li>Proofs added by a DID controller (e.g., to establish control authority).</li>
+		</ul>
+		<p>DID Document Metadata may also include method-specific metadata, e.g.:</p>
+		<ul>
+		<li>State proofs from the <a href="#dfn-verifiable-data-registry" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-verifiable-data-registry-14">verifiable data registry</a>.</li>
+		<li>Block number, index, transaction hash, number of confirmations, etc. of a record in the blockchain or other <a href="#dfn-verifiable-data-registry" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-verifiable-data-registry-15">verifiable data registry</a>.</li>
+		</ul>
+		<p>See also section <a href="https://www.w3.org/TR/did-core/#did-document-metadata">DID Document Metadata</a>
+		in [<cite><a class="bibref" data-link-type="biblio" href="#bib-did-core" title="Decentralized Identifiers (DIDs) v1.0">DID-CORE</a></cite>].</p>
+
+	</section>
+
+	<div class="issue" id="issue-container-generatedID-16"><div role="heading" class="issue-title marker" id="h-issue-12" aria-level="3"><span>Issue</span></div><p class="">For certain data, it may be debatable whether it should be part of the DID document
+	(i.e., data that describes the DID Subject), or whether it is metadata (i.e., data about the DID document or about
+	the DID resolution process). For example the URL of the "Continuation DID document" in the BTCR method.
+	</p></div>
+
+</section>
+
+	<section id="did-url-dereferencing-result"><div class="header-wrapper"><h2 id="x8-did-url-dereferencing-result"><bdi class="secno">8. </bdi>DID URL Dereferencing Result</h2><a class="self-link" href="#did-url-dereferencing-result" aria-label="Permalink for Section 8."></a></div>
+		
+		<p>This section defines a data structure that represents the result of the algorithm described
+			in <a href="#dereferencing" class="sec-ref"><bdi class="secno">4. </bdi>DID URL Dereferencing</a>. A <a href="#dfn-did-url-dereferencing-result" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-url-dereferencing-result-1">DID URL dereferencing result</a> contains
+			arbitrary content as well as
+			<a href="#output-dereferencingmetadata">DID resolution metadata</a> and <a href="#output-contentmetadata">
+				content metadata</a>.</p>
+
+		<div class="issue" id="issue-container-number-69"><div role="heading" class="issue-title marker" id="h-issue-13" aria-level="3"><a href="https://github.com/w3c/did-resolution/issues/69"><span class="issue-number">Issue 69</span></a><span class="issue-label">: DID Resolution Result for DID URL Dereferencing <a class="respec-gh-label" style="background-color: rgb(162, 238, 239); color: rgb(0, 0, 0);" href="https://github.com/w3c/did-resolution/issues/?q=is%3Aissue+is%3Aopen+label%3A%22enhancement%22" aria-label="GitHub label: enhancement">enhancement</a></span></div><p class="">See corresponding open issue.</p></div>
+		<p>The media type of this data structure is defined to be <code>application/ld+json;profile="https://w3id.org/did-resolution"</code>.</p>
+
+		<section id="example-0"><div class="header-wrapper"><h3 id="x8-1-example"><bdi class="secno">8.1 </bdi>Example</h3><a class="self-link" href="#example-0" aria-label="Permalink for Section 8.1"></a></div>
+			
+
+			<div class="example" id="example-example-did-url-dereferencing-result">
+        <div class="marker">
+    <a class="self-link" href="#example-example-did-url-dereferencing-result">Example<bdi> 17</bdi></a><span class="example-title">: Example DID URL dereferencing result</span>
+  </div> <pre class="nohighlight">{
+	"@context": "https://w3id.org/did-resolution/v1",
+	"content": {
+		"@context": "https://www.w3.org/ns/did/v1",
+		"id": "did:example:123456789abcdefghi",
+		"authentication": [{
+			"id": "did:example:123456789abcdefghi#keys-1",
+			"type": "Ed25519VerificationKey2018",
+			"controller": "did:example:123456789abcdefghi",
+			"publicKeyBase58": "H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"
+		}],
+		"service": [{
+			"id":"did:example:123456789abcdefghi#vcs",
+			"type": "VerifiableCredentialService",
+			"serviceEndpoint": "https://example.com/vc/"
+		}]
+	},
+	"didUrlDereferencingMetadata": {
+		"contentType": "application/did+ld+json",
+		"retrieved": "2024-06-01T19:73:24Z",
+	},
+	"contentMetadata": {
+		"created": "2019-03-23T06:35:22Z",
+		"updated": "2023-08-10T13:40:06Z",
+		"method": {
+			"nymResponse": {
+				"result": {
+					"data": "{\"dest\":\"WRfXPg8dantKVubE3HX8pw\",\"identifier\":\"V4SGRU86Z58d6TV7PBUe6f\",\"role\":\"0\",\"seqNo\":11,\"txnTime\":1524055264,\"verkey\":\"H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV\"}",
+					"type": "105",
+					"txnTime": 1.524055264E9,
+					"seqNo": 11.0,
+					"reqId": 1.52725687080231475E18,
+					"identifier": "HixkhyA4dXGz9yxmLQC4PU",
+					"dest": "WRfXPg8dantKVubE3HX8pw"
+				},
+				"op": "REPLY"
+			},
+			"attrResponse": {
+				"result": {
+					"identifier": "HixkhyA4dXGz9yxmLQC4PU",
+					"seqNo": 12.0,
+					"raw": "endpoint",
+					"dest": "WRfXPg8dantKVubE3HX8pw",
+					"data": "{\"endpoint\":{\"xdi\":\"http://127.0.0.1:8080/xdi\"}}",
+					"txnTime": 1.524055265E9,
+					"type": "104",
+					"reqId": 1.52725687092557056E18
+				},
+				"op": "REPLY"
+			}
+		}
+	}
+}</pre>
+      </div>
+
+		</section>
+
+		<section id="output-content"><div class="header-wrapper"><h3 id="x8-2-content"><bdi class="secno">8.2 </bdi>Content</h3><a class="self-link" href="#output-content" aria-label="Permalink for Section 8.2"></a></div>
+			
+			<p>Arbitrary content associated with a <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-46">DID URL</a>. The result of <a href="#dereferencing" class="sec-ref"><bdi class="secno">4. </bdi>DID URL Dereferencing</a>.</p>
+
+		</section>
+
+		<section id="output-dereferencingmetadata"><div class="header-wrapper"><h3 id="x8-3-did-url-dereferencing-metadata"><bdi class="secno">8.3 </bdi>DID URL Dereferencing Metadata</h3><a class="self-link" href="#output-dereferencingmetadata" aria-label="Permalink for Section 8.3"></a></div>
+			
+			<p>This is a metadata structure (see section <a href="https://www.w3.org/TR/did-core/#metadata-structure">Metadata Structure</a>
+				in [<cite><a class="bibref" data-link-type="biblio" href="#bib-did-core" title="Decentralized Identifiers (DIDs) v1.0">DID-CORE</a></cite>]) that contains metadata about the <a href="#dfn-did-url-dereferencing" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-url-dereferencing-21">DID URL Dereferencing</a> process.</p>
+			<p>This metadata typically changes between invocations of the <a href="#dfn-did-url-dereferencing" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-url-dereferencing-22">DID URL Dereferencing</a> functions as it represents data about the dereferencing process itself.</p>
+			<div class="issue" id="issue-container-generatedID-17"><div role="heading" class="issue-title marker" id="h-issue-14" aria-level="4"><span>Issue</span></div><p class="">Add more details how DID URL dereferencing metadata works.</p></div>
+			<p>See also section <a href="https://www.w3.org/TR/did-core/#did-url-dereferencing-metadata">DID URL Dereferencing Metadata</a>
+				in [<cite><a class="bibref" data-link-type="biblio" href="#bib-did-core" title="Decentralized Identifiers (DIDs) v1.0">DID-CORE</a></cite>].</p>
+
+		</section>
+
+		<section id="output-contentmetadata"><div class="header-wrapper"><h3 id="x8-4-content-metadata"><bdi class="secno">8.4 </bdi>Content Metadata</h3><a class="self-link" href="#output-contentmetadata" aria-label="Permalink for Section 8.4"></a></div>
+			
+			<p>This is a metadata structure (see section <a href="https://www.w3.org/TR/did-core/#metadata-structure">Metadata Structure</a>
+				in [<cite><a class="bibref" data-link-type="biblio" href="#bib-did-core" title="Decentralized Identifiers (DIDs) v1.0">DID-CORE</a></cite>]) that contains metadata about the content.</p>
+			<p>This metadata typically does not change between invocations of the <a href="#dfn-did-url-dereferencing" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-url-dereferencing-23">DID URL Dereferencing</a> function unless the content changes, as it represents data about the content.</p>
+			<div class="issue" id="issue-container-generatedID-18"><div role="heading" class="issue-title marker" id="h-issue-15" aria-level="4"><span>Issue</span></div><p class="">Add more details how content metadata works.</p></div>
+
+		</section>
+
+	</section>
+
+<section id="errors"><div class="header-wrapper"><h2 id="x9-errors"><bdi class="secno">9. </bdi>Errors</h2><a class="self-link" href="#errors" aria-label="Permalink for Section 9."></a></div>
+	
+    <section id="invaliddid"><div class="header-wrapper"><h3 id="x9-1-invaliddid"><bdi class="secno">9.1 </bdi>invalidDid</h3><a class="self-link" href="#invaliddid" aria-label="Permalink for Section 9.1"></a></div>
+	<p>If an invalid DID is detected during <a href="#dfn-did-resolution" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolution-27">DID Resolution</a>,
+		the value of the DID Resolution Metadata <strong>error</strong> property <em class="rfc2119">MUST</em> be <strong>invalidDid</strong>
+        as defined in section <a href="https://www.w3.org/TR/did-core/#did-resolution-metadata">DID Resolution Metadata</a> in [<cite><a class="bibref" data-link-type="biblio" href="#bib-did-core" title="Decentralized Identifiers (DIDs) v1.0">DID-CORE</a></cite>].
+    </p>
+	</section><section id="invaliddidurl"><div class="header-wrapper"><h3 id="x9-2-invaliddidurl"><bdi class="secno">9.2 </bdi>invalidDidUrl</h3><a class="self-link" href="#invaliddidurl" aria-label="Permalink for Section 9.2"></a></div>
+	<p>If an invalid DID URL is detected during <a href="#dfn-did-resolution" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolution-28">DID Resolution</a> or <a href="#dfn-did-url-dereferencing" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-url-dereferencing-24">DID URL dereferencing</a>,
+		the value of the DID Resolution or DID URL Dereferencing Metadata <strong>error</strong> property <em class="rfc2119">MUST</em> be <strong>invalidDidUrl</strong>
+        as defined in section <a href="https://www.w3.org/TR/did-core/#did-url-dereferencing-metadata">DID URL Dereferencing Metadata</a> in [<cite><a class="bibref" data-link-type="biblio" href="#bib-did-core" title="Decentralized Identifiers (DIDs) v1.0">DID-CORE</a></cite>].
+    </p>
+    </section><section id="notfound"><div class="header-wrapper"><h3 id="x9-3-notfound"><bdi class="secno">9.3 </bdi>notFound</h3><a class="self-link" href="#notfound" aria-label="Permalink for Section 9.3"></a></div>
+    <p> If during <a href="#dfn-did-resolution" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolution-29">DID Resolution</a> or <a href="#dfn-did-url-dereferencing" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-url-dereferencing-25">DID URL dereferencing</a> a DID or DID URL doesn't exist,
+        the value of the DID Resolution or DID URL dereferencing Metadata <strong>error</strong> property <em class="rfc2119">MUST</em> be <strong>notFound</strong> as
+        defined in sections <a href="https://www.w3.org/TR/did-core/#did-resolution-metadata">DID Resolution Metadata</a> and
+        <a href="https://www.w3.org/TR/did-core/#did-url-dereferencing-metadata">DID URL Dereferencing Metadata</a> in [<cite><a class="bibref" data-link-type="biblio" href="#bib-did-core" title="Decentralized Identifiers (DIDs) v1.0">DID-CORE</a></cite>].
+    </p>
+    </section><section id="representationnotsupported"><div class="header-wrapper"><h3 id="x9-4-representationnotsupported"><bdi class="secno">9.4 </bdi>representationNotSupported</h3><a class="self-link" href="#representationnotsupported" aria-label="Permalink for Section 9.4"></a></div>
+    <p> If a DID document representation is not supported during <a href="#dfn-did-resolution" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolution-30">DID Resolution</a> or <a href="#dfn-did-url-dereferencing" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-url-dereferencing-26">DID URL dereferencing</a>,
+        the value of the DID Resolution Metadata <strong>error</strong> property <em class="rfc2119">MUST</em> be <strong>representationNotSupported</strong> as
+        defined in section <a href="https://www.w3.org/TR/did-core/#did-resolution-metadata">DID Resolution Metadata</a> in [<cite><a class="bibref" data-link-type="biblio" href="#bib-did-core" title="Decentralized Identifiers (DIDs) v1.0">DID-CORE</a></cite>].
+    </p>
+	</section><section id="methodnotsupported"><div class="header-wrapper"><h3 id="x9-5-methodnotsupported"><bdi class="secno">9.5 </bdi>methodNotSupported</h3><a class="self-link" href="#methodnotsupported" aria-label="Permalink for Section 9.5"></a></div>
+	<p> If a DID method is not supported during <a href="#dfn-did-resolution" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolution-31">DID Resolution</a> or <a href="#dfn-did-url-dereferencing" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-url-dereferencing-27">DID URL dereferencing</a>,
+		the value of the DID Resolution or DID URL Dereferencing Metadata <strong>error</strong> property <em class="rfc2119">MUST</em> be <strong>methodNotSupported</strong>.
+	</p>
+	</section><section id="internalerror"><div class="header-wrapper"><h3 id="x9-6-internalerror"><bdi class="secno">9.6 </bdi>internalError</h3><a class="self-link" href="#internalerror" aria-label="Permalink for Section 9.6"></a></div>
+	<p>When an unexpected error occurs during <a href="#dfn-did-resolution" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolution-32">DID Resolution</a> or <a href="#dfn-did-url-dereferencing" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-url-dereferencing-28">DID URL dereferencing</a>,
+		the value of the DID Resolution or DID URL Dereferencing Metadata <strong>error</strong> property <em class="rfc2119">MUST</em> be <strong>internalError</strong>.
+    </p>
+	</section><section id="invalidpublickey"><div class="header-wrapper"><h3 id="x9-7-invalidpublickey"><bdi class="secno">9.7 </bdi>invalidPublicKey</h3><a class="self-link" href="#invalidpublickey" aria-label="Permalink for Section 9.7"></a></div>
+	<p>If an invalid public key value is detected during <a href="#dfn-did-resolution" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolution-33">DID Resolution</a> or <a href="#dfn-did-url-dereferencing" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-url-dereferencing-29">DID URL dereferencing</a>,
+		the value of the DID Resolution or DID URL Dereferencing Metadata <strong>error</strong> property <em class="rfc2119">MUST</em> be <strong>invalidPublicKey</strong>.
+    </p>
+	</section><section id="invalidpublickeylength"><div class="header-wrapper"><h3 id="x9-8-invalidpublickeylength"><bdi class="secno">9.8 </bdi>invalidPublicKeyLength</h3><a class="self-link" href="#invalidpublickeylength" aria-label="Permalink for Section 9.8"></a></div>
+	<p>If the byte length of <i>rawPublicKeyBytes</i> does not match the expected public key length for the associated multicodecValue during <a href="#dfn-did-resolution" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolution-34">DID Resolution</a> or <a href="#dfn-did-url-dereferencing" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-url-dereferencing-30">DID URL dereferencing</a>,
+		the value of the DID Resolution or DID URL Dereferencing Metadata <strong>error</strong> property <em class="rfc2119">MUST</em> be <strong>invalidPublicKeyLength</strong>.
+    </p>
+	</section><section id="invalidpublickeytype"><div class="header-wrapper"><h3 id="x9-9-invalidpublickeytype"><bdi class="secno">9.9 </bdi>invalidPublicKeyType</h3><a class="self-link" href="#invalidpublickeytype" aria-label="Permalink for Section 9.9"></a></div>
+	<p>If an invalid public key type is detected during <a href="#dfn-did-resolution" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolution-35">DID Resolution</a> or <a href="#dfn-did-url-dereferencing" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-url-dereferencing-31">DID URL dereferencing</a>,
+		the value of the DID Resolution or DID URL Dereferencing Metadata <strong>error</strong> property <em class="rfc2119">MUST</em> be <strong>invalidPublicKeyType</strong>.
+    </p>
+	</section><section id="unsupportedpublickeytype"><div class="header-wrapper"><h3 id="x9-10-unsupportedpublickeytype"><bdi class="secno">9.10 </bdi>unsupportedPublicKeyType</h3><a class="self-link" href="#unsupportedpublickeytype" aria-label="Permalink for Section 9.10"></a></div>
+	<p>If an unsupported public key type is detected during <a href="#dfn-did-resolution" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolution-36">DID Resolution</a> or <a href="#dfn-did-url-dereferencing" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-url-dereferencing-32">DID URL dereferencing</a>,
+		the value of the DID Resolution or DID URL Dereferencing Metadata <strong>error</strong> property <em class="rfc2119">MUST</em> be <strong>unsupportedPublicKeyType</strong>.
+    </p>
+
+</section></section>
+
+<section id="bindings"><div class="header-wrapper"><h2 id="x10-bindings"><bdi class="secno">10. </bdi>Bindings</h2><a class="self-link" href="#bindings" aria-label="Permalink for Section 10."></a></div>
+	
+	<p>This section defines bindings for the abstract algorithms in sections <a href="#resolving" class="sec-ref"><bdi class="secno">3. </bdi>DID Resolution</a> and
+	<a href="#dereferencing" class="sec-ref"><bdi class="secno">4. </bdi>DID URL Dereferencing</a>.</p>
+
+	<section id="bindings-https"><div class="header-wrapper"><h3 id="x10-1-http-s-binding"><bdi class="secno">10.1 </bdi>HTTP(S) Binding</h3><a class="self-link" href="#bindings-https" aria-label="Permalink for Section 10.1"></a></div>
+		
+		<p>This section defines a <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-59">DID resolver</a> <a href="#dfn-binding" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-binding-7">binding</a> which exposes the
+			<a href="#dfn-did-resolution" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolution-37">DID resolution</a> and/or <a href="#dfn-did-url-dereferencing" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-url-dereferencing-33">DID URL dereferencing</a> functions (including all
+			resolution/dereferencing options and metadata) via an HTTP(S) endpoint. See <a href="#resolver-architectures" class="sec-ref"><bdi class="secno">6.2 </bdi>Resolver Architectures</a>.</p>
+
+		<p>The HTTP(S) binding is a <a href="#dfn-remote-binding" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-remote-binding-11">remote binding</a>. It requires a known HTTP(S) URL where a remote
+			<a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-60">DID resolver</a> can be invoked. This URL is called the <var><a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-61">DID resolver</a> HTTP(S) endpoint</var></p>
+
+		<p>Using this binding, the <a href="#dfn-did-resolution" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolution-38">DID resolution</a> function (see
+			<a href="#resolving" class="sec-ref"><bdi class="secno">3. </bdi>DID Resolution</a>) and/or <a href="#dfn-did-url-dereferencing" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-url-dereferencing-34">DID URL dereferencing</a> function (see <a href="#dereferencing" class="sec-ref"><bdi class="secno">4. </bdi>DID URL Dereferencing</a>)
+			can be executed as follows:</p>
+
+		<ol class="algorithm">
+			<li>Initialize a <var>request HTTP(S) URL</var> with the <var><a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-62">DID resolver</a> HTTP(S) endpoint</var>.</li>
+			<div class="example" id="example-18">
+        <div class="marker">
+    <a class="self-link" href="#example-18">Example<bdi> 18</bdi></a>
+  </div> <pre class="nohighlight">https://dev.uniresolver.io/1.0/identifiers/</pre>
+      </div>
+			<li>For the <a href="#dfn-did-resolution" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolution-39">DID resolution</a> function:
+				<ol class="algorithm">
+					<li>Append the <var>input <a href="#dfn-decentralized-identifiers" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-decentralized-identifiers-44">DID</a></var> to the <var>request HTTP(S) URL</var>.</li>
+					<div class="example" id="example-19">
+        <div class="marker">
+    <a class="self-link" href="#example-19">Example<bdi> 19</bdi></a>
+  </div> <pre class="nohighlight">https://dev.uniresolver.io/1.0/identifiers/did:example:1234</pre>
+      </div>
+					<li>Set the <code>Accept</code> <var>HTTP request header</var> to <code>application/ld+json;profile="https://w3id.org/did-resolution"</code>
+						in order to request a complete <a href="#did-resolution-result" class="sec-ref"><bdi class="secno">7. </bdi>DID Resolution Result</a>, OR</li>
+					<li>set the <code>Accept</code> <var>HTTP request header</var> to the value of the <b>accept</b> <var>resolution option</var>.</li>
+					<li>If any other <var>resolution options</var> are provided:
+						<ol class="algorithm">
+							<li>The <var>input <a href="#dfn-decentralized-identifiers" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-decentralized-identifiers-45">DID</a></var> <em class="rfc2119">MUST</em> be URL-encoded (as specified in <a href="https://www.rfc-editor.org/rfc/rfc3986#section-2.1">RFC3986 Section 2.1</a>).</li>
+							<li>Encode all <var>resolution options</var> except <b>accept</b> as
+								query parameters in the <var>request HTTP(S) URL</var>.</li>
+							<div class="example" id="example-20">
+        <div class="marker">
+    <a class="self-link" href="#example-20">Example<bdi> 20</bdi></a>
+  </div> <pre class="nohighlight">https://dev.uniresolver.io/1.0/identifiers/did%3Aexample%3A1234?option1=value1&amp;option2=value2</pre>
+      </div>
+						</ol>
+					</li>
+				</ol>
+			</li>
+			<li>For the <a href="#dfn-did-url-dereferencing" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-url-dereferencing-35">DID URL dereferencing</a> function:
+				<ol class="algorithm">
+					<li>Append the <var>input <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-47">DID URL</a></var> to the <var>request HTTP(S) URL</var>.</li>
+					<div class="example" id="example-21">
+        <div class="marker">
+    <a class="self-link" href="#example-21">Example<bdi> 21</bdi></a>
+  </div> <pre class="nohighlight">https://dev.uniresolver.io/1.0/identifiers/did:example:1234?service=files&amp;relativeRef=/resume.pdf</pre>
+      </div>
+					<li>Set the <code>Accept</code> <var>HTTP request header</var> to <code>application/ld+json;profile="https://w3id.org/did-url-dereferencing"</code>
+						in order to request a complete <a href="#did-url-dereferencing-result" class="sec-ref"><bdi class="secno">8. </bdi>DID URL Dereferencing Result</a>, OR</li>
+					<li>set the <code>Accept</code> <var>HTTP request header</var> to the value of the <b>accept</b> <var>dereferencing option</var>.</li>
+					<li>If any other <var>dereferencing options</var> are provided:
+						<ol class="algorithm">
+							<li>The <var>input <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-48">DID URL</a></var> <em class="rfc2119">MUST</em> be URL-encoded (as specified in <a href="https://www.rfc-editor.org/rfc/rfc3986#section-2.1">RFC3986 Section 2.1</a>).</li>
+							<li>Encode all <var>dereferencing options</var> except <b>accept</b> as
+								query parameters in the <var>request HTTP(S) URL</var>.</li>
+							<div class="example" id="example-22">
+        <div class="marker">
+    <a class="self-link" href="#example-22">Example<bdi> 22</bdi></a>
+  </div> <pre class="nohighlight">https://dev.uniresolver.io/1.0/identifiers/did%3Aexample%3A1234%3Fservice%3Dfiles%26relativeRef%3D%2Fresume.pdf?option1=value1&amp;option2=value2</pre>
+      </div>
+						</ol>
+					</li>
+				</ol>
+			</li>
+			<li>Execute an HTTP <code>GET</code> request on the <var>request HTTP(S) URL</var>. This invokes the <a href="#dfn-did-resolution" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolution-40">DID resolution</a> or
+				<a href="#dfn-did-url-dereferencing" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-url-dereferencing-36">DID URL dereferencing</a> function at the remote <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-63">DID resolver</a>.</li>
+			<li>If the <a href="#dfn-did-resolution" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolution-41">DID resolution</a> or <a href="#dfn-did-url-dereferencing" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-url-dereferencing-37">DID URL dereferencing</a> function returns an <b>error</b> metadata property in the
+				<b>didResolutionMetadata</b> or <b>dereferencingMetadata</b>,
+				then the HTTP response status code <em class="rfc2119">MUST</em> correspond to the value of the <b>error</b> metadata property,
+				according to the following table:
+				<table class="simple">
+					<thead>
+					<tr>
+						<th>
+							error
+						</th>
+						<th>
+							HTTP status code
+						</th>
+					</tr>
+					</thead>
+					<tbody>
+					<tr>
+						<td>
+							<code>invalidDid</code>
+						</td>
+						<td>
+							<code>400</code>
+						</td>
+					</tr>
+					<tr>
+						<td>
+							<code>invalidDidUrl</code>
+						</td>
+						<td>
+							<code>400</code>
+						</td>
+					</tr>
+					<tr>
+						<td>
+							<code>notFound</code>
+						</td>
+						<td>
+							<code>404</code>
+						</td>
+					</tr>
+					<tr>
+						<td>
+							<code>representationNotSupported</code>
+						</td>
+						<td>
+							<code>406</code>
+						</td>
+					</tr>
+					<tr>
+						<td>
+							<code>methodNotSupported</code>
+						</td>
+						<td>
+							<code>501</code>
+						</td>
+					</tr>
+					<tr>
+						<td>
+							<code>internalError</code>
+						</td>
+						<td>
+							<code>500</code>
+						</td>
+					</tr>
+					<tr>
+						<td>
+							(any other value)
+						</td>
+						<td>
+							<code>500</code>
+						</td>
+					</tr>
+					</tbody>
+				</table>
+			</li>
+			<li>If the <a href="#dfn-did-resolution" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolution-42">DID resolution</a> or <a href="#dfn-did-url-dereferencing" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-url-dereferencing-38">DID URL dereferencing</a> function returns a <b>deactivated</b> metadata property with
+				the value <code>true</code> in the <b>didDocumentMetadata</b> or <b>contentMetadata</b>:
+				<ol class="algorithm">
+					<li>The HTTP response status code <em class="rfc2119">MUST</em> be <code>410</code>.</li>
+				</ol>
+			</li>
+			<li>For the <a href="#dfn-did-resolution" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolution-43">DID resolution</a> function:
+				<ol class="algorithm">
+					<li>If the value of the <code>Content-Type</code> <var>HTTP response header</var> is <code>application/ld+json;profile="https://w3id.org/did-resolution"</code>:
+						<ol class="algorithm">
+							<li>The <var>HTTP body</var> <em class="rfc2119">MUST</em> contain a <a href="#dfn-did-resolution-result" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolution-result-3">DID resolution result</a> (see <a href="#did-resolution-result" class="sec-ref"><bdi class="secno">7. </bdi>DID Resolution Result</a>) that
+								is the result of the <a href="#dfn-did-resolution" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolution-44">DID resolution</a> function.</li>
+						</ol>
+					</li>
+					<li>If the function is successful and returns a <b>didDocument</b>:
+						<ol class="algorithm">
+							<li>The HTTP response status code <em class="rfc2119">MUST</em> be <code>200</code>.</li>
+							<li>The HTTP response <em class="rfc2119">MUST</em> contain a <code>Content-Type</code> <var>HTTP response header</var>. Its value <em class="rfc2119">MUST</em> be the value of the
+								<b>contentType</b> metadata property in the <b>didResolutionMetadata</b> (see <a href="#did-resolution-metadata" class="sec-ref"><bdi class="secno">3.2 </bdi>DID Resolution Metadata</a>).</li>
+							<li>The HTTP response body <em class="rfc2119">MUST</em> contain the <b>didDocument</b> that is the result of the
+								<a href="#dfn-did-resolution" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolution-45">DID resolution</a> function, in the representation corresponding to the <code>Content-Type</code> <var>HTTP response header</var>.</li>
+						</ol>
+					</li>
+				</ol>
+			</li>
+			<li>For the <a href="#dfn-did-url-dereferencing" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-url-dereferencing-39">DID URL dereferencing</a> function:
+				<ol class="algorithm">
+					<li>If the value of the <code>Content-Type</code> <var>HTTP response header</var> is <code>application/ld+json;profile="https://w3id.org/did-url-dereferencing"</code>:
+						<ol class="algorithm">
+							<li>The <var>HTTP body</var> <em class="rfc2119">MUST</em> contain a <a href="#dfn-did-url-dereferencing-result" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-url-dereferencing-result-2">DID URL dereferencing result</a> (see <a href="#did-url-dereferencing-result" class="sec-ref"><bdi class="secno">8. </bdi>DID URL Dereferencing Result</a>) that
+								is the result of the <a href="#dfn-did-url-dereferencing" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-url-dereferencing-40">DID URL dereferencing</a> function.</li>
+						</ol>
+					</li>
+					<li>If the function is successful and returns a <b>contentStream</b> and a <b>contentType</b> metadata property with the value <code>text/uri-list</code> in the <b>dereferencingMetadata</b>:
+						<ol class="algorithm">
+							<li>The HTTP response status code <em class="rfc2119">MUST</em> be <code>303</code>.</li>
+							<li>The HTTP response <em class="rfc2119">MUST</em> contain an <code>Location</code> header. The value of this header
+								<em class="rfc2119">MUST</em> be the <var>output <a href="#dfn-service-endpoints" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-service-endpoints-17">service endpoint</a> URL</var>.</li>
+							<li>the HTTP response body <em class="rfc2119">MUST</em> be empty.</li>
+						</ol>
+					</li>
+					<li>If the function is successful and returns a <b>contentStream</b> with any other <b>contentType</b>:
+						<ol class="algorithm">
+							<li>The HTTP response status code <em class="rfc2119">MUST</em> be <code>200</code>.</li>
+							<li>The HTTP response <em class="rfc2119">MUST</em> contain a <code>Content-Type</code> <var>HTTP response header</var>. Its value <em class="rfc2119">MUST</em> be the value of the
+								<b>contentType</b> metadata property in the <b>dereferencingMetadata</b> (see <a href="#did-url-dereferencing-metadata" class="sec-ref"><bdi class="secno">4.2 </bdi>DID URL Dereferencing Metadata</a>).</li>
+							<li>The HTTP response body <em class="rfc2119">MUST</em> contain the <b>contentStream</b> that is the result of the
+								<a href="#dfn-did-url-dereferencing" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-url-dereferencing-41">DID URL dereferencing</a> function, in the representation corresponding to the <code>Content-Type</code> <var>HTTP response header</var>.</li>
+						</ol>
+					</li>
+				</ol>
+			</li>
+		</ol>
+
+		<div>
+			<p>See <a href="https://github.com/decentralized-identity/universal-resolver/blob/main/openapi/openapi.yaml">here</a> for an OpenAPI definition.</p>
+		</div>
+
+	</section>
+
+	<section id="did-resolution-examples"><div class="header-wrapper"><h3 id="x10-2-did-resolution-examples"><bdi class="secno">10.2 </bdi>DID Resolution Examples</h3><a class="self-link" href="#did-resolution-examples" aria-label="Permalink for Section 10.2"></a></div>
+		
+		<p>Given the following <var><a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-64">DID resolver</a> HTTP(S) endpoint</var>:</p><p>
+		</p><p><code>
+https://dev.uniresolver.io/1.0/identifiers/</code></p>
+		<p>And given the following <var>input <a href="#dfn-decentralized-identifiers" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-decentralized-identifiers-46">DID</a></var>:</p>
+		<p><code>
+did:sov:WRfXPg8dantKVubE3HX8pw</code></p>
+		<p>Then the <var>request HTTP(S) URL</var> is:</p>
+		<p><code>
+https://dev.uniresolver.io/1.0/identifiers/did:sov:WRfXPg8dantKVubE3HX8pw</code></p>
+		<p>The HTTP(S) binding can be invoked as follows:</p>
+		<div class="example" id="example-example-curl-call-to-a-did-resolver-via-http-s-binding">
+        <div class="marker">
+    <a class="self-link" href="#example-example-curl-call-to-a-did-resolver-via-http-s-binding">Example<bdi> 23</bdi></a><span class="example-title">: Example curl call to a DID resolver via HTTP(S) binding</span>
+  </div> <pre class="nohighlight">curl -X GET https://dev.uniresolver.io/1.0/identifiers/did:sov:WRfXPg8dantKVubE3HX8pw</pre>
+      </div>
+
+		<p>Additional examples of the HTTP(S) binding:</p>
+
+		<figure id="https-resolverepresentation-example-1">
+			<img style="margin: auto; display: block; width: 100%;" src="diagrams/https-resolverepresentation-example-1.png" alt="Diagram showing the invocation of resolveRepresentation() over HTTPS">
+			<figcaption style="text-align: center;"><a class="self-link" href="#https-resolverepresentation-example-1">Figure <bdi class="figno">14</bdi></a> <span class="fig-title">
+				Invocation of resolveRepresentation() over HTTP(S).
+			</span></figcaption>
+		</figure>
+
+		<figure id="https-resolverepresentation-example-2">
+			<img style="margin: auto; display: block; width: 100%;" src="diagrams/https-resolverepresentation-example-2.png" alt="Diagram showing the invocation of resolveRepresentation() over HTTPS">
+			<figcaption style="text-align: center;"><a class="self-link" href="#https-resolverepresentation-example-2">Figure <bdi class="figno">15</bdi></a> <span class="fig-title">
+				Invocation of resolveRepresentation() over HTTP(S).
+			</span></figcaption>
+		</figure>
+
+	</section>
+
+	<section id="did-url-dereferencing-examples"><div class="header-wrapper"><h3 id="x10-3-did-url-dereferencing-examples"><bdi class="secno">10.3 </bdi>DID URL Dereferencing Examples</h3><a class="self-link" href="#did-url-dereferencing-examples" aria-label="Permalink for Section 10.3"></a></div>
+		
+
+		<p>Additional examples of the HTTP(S) binding:</p>
+
+		<figure id="https-dereference-example-1">
+			<img style="margin: auto; display: block; width: 100%;" src="diagrams/https-dereference-example-1.png" alt="Diagram showing the invocation of dereference() over HTTPS">
+			<figcaption style="text-align: center;"><a class="self-link" href="#https-dereference-example-1">Figure <bdi class="figno">16</bdi></a> <span class="fig-title">
+				Invocation of dereference() over HTTP(S).
+			</span></figcaption>
+		</figure>
+
+		<figure id="https-dereference-example-2">
+			<img style="margin: auto; display: block; width: 100%;" src="diagrams/https-dereference-example-2.png" alt="Diagram showing the invocation of dereference() over HTTPS">
+			<figcaption style="text-align: center;"><a class="self-link" href="#https-dereference-example-2">Figure <bdi class="figno">17</bdi></a> <span class="fig-title">
+				Invocation of dereference() over HTTP(S).
+			</span></figcaption>
+		</figure>
+
+	</section>
+
+</section>
+
+<section id="service-endpoint-construction"><div class="header-wrapper"><h2 id="x11-service-endpoint-construction"><bdi class="secno">11. </bdi>Service Endpoint Construction</h2><a class="self-link" href="#service-endpoint-construction" aria-label="Permalink for Section 11."></a></div>
+	
+
+	<p>This section defines the inputs and the algorithm of <a href="#dfn-service-endpoint-construction" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-service-endpoint-construction-1">Service Endpoint Construction</a>,
+	which returns a <a href="#dfn-service-endpoints" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-service-endpoints-18">service endpoint</a> URL as output. This algorithm is used when service endpoints
+	are selected during <a href="#dfn-did-url-dereferencing" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-url-dereferencing-42">DID URL dereferencing</a> (see <a href="#dereferencing" class="sec-ref"><bdi class="secno">4. </bdi>DID URL Dereferencing</a>).</p>
+
+	<p>In this section, <code>path</code>, <code>query</code>, and <code>fragment</code> are understood as defined in [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc3986" title="Uniform Resource Identifier (URI): Generic Syntax">RFC3986</a></cite>].</p>
+
+	<section id="input"><div class="header-wrapper"><h3 id="x11-1-input"><bdi class="secno">11.1 </bdi>Input</h3><a class="self-link" href="#input" aria-label="Permalink for Section 11.1"></a></div>
+		
+
+		<p>The inputs of the <a href="#dfn-service-endpoint-construction" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-service-endpoint-construction-2">Service Endpoint Construction</a> algorithm are an <var>input <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-49">DID URL</a></var> and an
+		<var>input <a href="#dfn-service-endpoints" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-service-endpoints-19">service endpoint</a> URL</var>.</p>
+
+		<p>The requirements for the inputs of the <a href="#dfn-service-endpoint-construction" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-service-endpoint-construction-3">Service Endpoint Construction</a> algorithm are as follows:</p>
+		<ul>
+			<li>The <var>input <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-50">DID URL</a></var> and <var>input <a href="#dfn-service-endpoints" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-service-endpoints-20">service endpoint</a> URL</var> <em class="rfc2119">MAY</em> both have a <code>path</code> component.</li>
+			<li>The <var>input <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-51">DID URL</a></var> and <var>input <a href="#dfn-service-endpoints" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-service-endpoints-21">service endpoint</a> URL</var> <em class="rfc2119">MUST NOT</em> both have a <code>query</code> component.</li>
+			<li>The <var>input <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-52">DID URL</a></var> and <var>input <a href="#dfn-service-endpoints" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-service-endpoints-22">service endpoint</a> URL</var> <em class="rfc2119">MUST NOT</em> both have a <code>fragment</code> component.</li>
+			<li>The <var>input <a href="#dfn-service-endpoints" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-service-endpoints-23">service endpoint</a> URL</var> <em class="rfc2119">MUST</em> be an HTTP(S) URL.</li>
+		</ul>
+
+	</section>
+
+	<section id="algorithm"><div class="header-wrapper"><h3 id="x11-2-algorithm"><bdi class="secno">11.2 </bdi>Algorithm</h3><a class="self-link" href="#algorithm" aria-label="Permalink for Section 11.2"></a></div>
+		
+		<ol class="algorithm">
+			<li>Initialize a string <var>output <a href="#dfn-service-endpoints" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-service-endpoints-24">service endpoint</a> URL</var> to the value of the <var>input <a href="#dfn-service-endpoints" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-service-endpoints-25">service endpoint</a> URL</var></li>
+			<li>If the <var>output <a href="#dfn-service-endpoints" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-service-endpoints-26">service endpoint</a> URL</var> has a <code>query</code> component, remove it.</li>
+			<li>If the <var>output <a href="#dfn-service-endpoints" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-service-endpoints-27">service endpoint</a> URL</var> has a <code>fragment</code> component, remove it.</li>
+			<li>Append the <code>path</code> component of the <var>input <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-53">DID URL</a></var> to the <var>output <a href="#dfn-service-endpoints" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-service-endpoints-28">service endpoint</a> URL</var>.</li>
+			<li>If the <var>input <a href="#dfn-service-endpoints" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-service-endpoints-29">service endpoint</a> URL</var> has a <code>query</code> component, append <code>?</code> plus the <code>query</code> to the <var>output <a href="#dfn-service-endpoints" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-service-endpoints-30">service endpoint</a> URL</var>.</li>
+			<li>If the <var>input <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-54">DID URL</a></var> has a <code>query</code> component, append <code>?</code> plus the <code>query</code> to the <var>output <a href="#dfn-service-endpoints" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-service-endpoints-31">service endpoint</a> URL</var>.</li>
+			<li>If the <var>input <a href="#dfn-service-endpoints" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-service-endpoints-32">service endpoint</a> URL</var> has a <code>fragment</code> component, append <code>#</code> plus the <code>fragment</code> to the <var>output <a href="#dfn-service-endpoints" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-service-endpoints-33">service endpoint</a> URL</var>.</li>
+			<li>If the <var>input <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-55">DID URL</a></var> has a <code>fragment</code> component, append <code>#</code> plus the <code>fragment</code> to the <var>output <a href="#dfn-service-endpoints" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-service-endpoints-34">service endpoint</a> URL</var>.</li>
+			<li>Return the <var>output <a href="#dfn-service-endpoints" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-service-endpoints-35">service endpoint</a> URL</var>.</li>
+		</ol>
+
+		<div class="issue" id="issue-container-generatedID-19"><div role="heading" class="issue-title marker" id="h-issue-16" aria-level="4"><span>Issue</span></div><p class="">We could potentially allow <code>query</code> components on both the
+		<var>input <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-56">DID URL</a></var> and <var>input <a href="#dfn-service-endpoints" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-service-endpoints-36">service endpoint</a> URL</var>, if they both contain lists of
+		key/value parameters that can be merged.</p></div>
+
+		<div class="issue" id="issue-container-generatedID-20"><div role="heading" class="issue-title marker" id="h-issue-17" aria-level="4"><span>Issue</span></div><p class="">Details of the Service Endpoint Construction algorithm have been discussed in April 2019
+		on the CCG mailing list, e.g., <a href="https://lists.w3.org/Archives/Public/public-credentials/2019Apr/0021.html">here</a>
+		or <a href="https://lists.w3.org/Archives/Public/public-credentials/2019Apr/0032.html">here</a>.</p></div>
+
+		<div class="issue" id="issue-container-generatedID-21"><div role="heading" class="issue-title marker" id="h-issue-18" aria-level="4"><span>Issue</span></div><p class="">Instead of defining our own algorithm, we could potentially re-use the "Relative Resolution"
+		algorithm defined in [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc3986" title="Uniform Resource Identifier (URI): Generic Syntax">RFC3986</a></cite>].</p></div>
+
+		<div class="issue" id="issue-container-number-61"><div role="heading" class="issue-title marker" id="h-issue-19" aria-level="4"><a href="https://github.com/w3c/did-resolution/issues/61"><span class="issue-number">Issue 61</span></a><span class="issue-label">: Service Endpoint Construction inconsistency <a class="respec-gh-label" style="background-color: rgb(215, 58, 74); color: rgb(0, 0, 0);" href="https://github.com/w3c/did-resolution/issues/?q=is%3Aissue+is%3Aopen+label%3A%22bug%22" aria-label="GitHub label: bug">bug</a><a class="respec-gh-label" style="background-color: rgb(140, 133, 133); color: rgb(0, 0, 0);" href="https://github.com/w3c/did-resolution/issues/?q=is%3Aissue+is%3Aopen+label%3A%22ready-for-pr%22" aria-label="GitHub label: ready-for-pr">ready-for-pr</a></span></div><p class="">See corresponding open issue.</p></div>
+
+	</section>
+
+	<section id="example-10"><div class="header-wrapper"><h3 id="x11-3-example"><bdi class="secno">11.3 </bdi>Example</h3><a class="self-link" href="#example-10" aria-label="Permalink for Section 11.3"></a></div>
+		
+		<p>Given the following <var>input <a href="#dfn-service-endpoints" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-service-endpoints-37">service endpoint</a> URL</var>:</p><p>
+		</p><p><code>
+https://example.com/messages/8377464</code></p>
+		<p>And given the following <var>input <a href="#dfn-did-urls" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-urls-57">DID URL</a></var>:</p>
+		<p><code>
+did:example:123456789abcdefghi?service=messages&amp;relativeRef=%2Fsome%2Fpath%3Fquery#frag
+</code></p>
+		<p>Then the <var>output <a href="#dfn-service-endpoints" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-service-endpoints-38">service endpoint</a> URL</var> is:</p>
+		<p><code>
+https://example.com/messages/8377464/some/path?query#frag
+</code></p>
+
+	</section>
+
+</section>
+
+<section id="security-privacy-considerations"><div class="header-wrapper"><h2 id="x12-security-and-privacy-considerations"><bdi class="secno">12. </bdi>Security and Privacy Considerations</h2><a class="self-link" href="#security-privacy-considerations" aria-label="Permalink for Section 12."></a></div>
+	
+
+	<section id="authentication"><div class="header-wrapper"><h3 id="x12-1-authentication-authorization"><bdi class="secno">12.1 </bdi>Authentication/Authorization</h3><a class="self-link" href="#authentication" aria-label="Permalink for Section 12.1"></a></div>
+		
+		<p><a href="#dfn-did-resolution" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolution-46">DID resolution</a> and <a href="#dfn-did-url-dereferencing" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-url-dereferencing-43">DID URL dereferencing</a> do not involve any authentication or authorization
+		functionality. Similar to DNS resolution, anybody can perform the process, without requiring any credentials
+		or non-public knowledge.</p>
+
+		<div class="issue" id="issue-container-number-38"><div role="heading" class="issue-title marker" id="h-issue-20" aria-level="4"><a href="https://github.com/w3c/did-resolution/issues/38"><span class="issue-number">Issue 38</span></a><span class="issue-label">: Restricted access/Authentication/Authorization <a class="respec-gh-label" style="background-color: rgb(162, 238, 239); color: rgb(0, 0, 0);" href="https://github.com/w3c/did-resolution/issues/?q=is%3Aissue+is%3Aopen+label%3A%22enhancement%22" aria-label="GitHub label: enhancement">enhancement</a></span></div><p dir="auto">The spec should clarify whether or not conformant resolvers MUST be public or MAY restrict access via some authentication and authorization scheme.</p>
+<p dir="auto">The current language doesn't make it clear if authentication is just out of scope or if it is disallowed.</p></div>
+
+		<div class="issue" id="issue-container-generatedID-22"><div role="heading" class="issue-title marker" id="h-issue-21" aria-level="4"><span>Issue</span></div><div class="">
+		<p>Explain that DIDs are not necessarily <em>globally</em> resolvable, such as pairwise or N-wise
+		"peer" DIDs.</p>
+		<p>See [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc3339" title="Date and Time on the Internet: Timestamps">RFC3339</a></cite>]:
+		<em> URIs have a global scope and are interpreted consistently regardless of context, though the
+		result of that interpretation may be in relation to the end-user's context.</em>
+		</p>
+		<p>An advanced idea is that the result of DID resolution could be contextual or depend on policies,
+		see <a href="https://github.com/w3c/did-resolution/issues/28#issuecomment-510592199">this comment</a>.</p>
+		</div></div>
+
+		<div class="issue" id="issue-container-generatedID-23"><div role="heading" class="issue-title marker" id="h-issue-22" aria-level="4"><span>Issue</span></div><p class="">A related topic is whether (parts of) DID document could be encrypted, e.g.,
+		<a href="https://github.com/w3c/did-core/issues/25">w3c/did-core/issues/25</a>. Also see the use
+		of the fragment in the <a href="https://did-ipid.github.io/ipid-did-method/">IPID</a> DID method.</p></div>
+
+	</section>
+
+	<section id="caching"><div class="header-wrapper"><h3 id="x12-2-caching"><bdi class="secno">12.2 </bdi>Caching</h3><a class="self-link" href="#caching" aria-label="Permalink for Section 12.2"></a></div>
+		
+		<p>A <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-65">DID resolver</a> may maintain a generic cache of <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-78">DID documents</a>. It may also
+			maintain caches specific to certain <a href="#dfn-did-method-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-method-s-47">DID methods</a>.</p>
+		<p>The <code>noCache</code> resolution option can be used to
+			request a certain kind of caching behavior.</p>
+			<p>This <var>resolution option</var> is <em class="rfc2119">OPTIONAL</em>.</p>
+			<p>Possible values of this property are:</p>
+			<ul>
+			<li><code>"false"</code> (default value): Caching of <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-79">DID documents</a> is allowed.</li>
+			<li><code>"true"</code>: Request that caching is disabled and a fresh <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-80">DID document</a> is retrieved from
+			the <a href="#dfn-verifiable-data-registry" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-verifiable-data-registry-16">verifiable data registry</a>.</li>
+			</ul>
+		<p>Caching behavior can be controlled by configuration of the <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-66">DID resolver</a>,
+			by the <code>noCache</code> resolution option, or by contents of the DID document
+			(e.g., a <code>cacheMaxTtl</code> field), or by a combination of these properties.</p>
+		<div class="issue" id="issue-container-number-10"><div role="heading" class="issue-title marker" id="h-issue-23" aria-level="4"><a href="https://github.com/w3c/did-resolution/issues/10"><span class="issue-number">Issue 10</span></a><span class="issue-label">: need TTL construct? <a class="respec-gh-label" style="background-color: rgb(162, 238, 239); color: rgb(0, 0, 0);" href="https://github.com/w3c/did-resolution/issues/?q=is%3Aissue+is%3Aopen+label%3A%22enhancement%22" aria-label="GitHub label: enhancement">enhancement</a></span></div><p class="">See corresponding open issue.</p></div>
+		<div class="issue" id="issue-container-generatedID-24"><div role="heading" class="issue-title marker" id="h-issue-24" aria-level="4"><span>Issue</span></div><p class="">Perhaps we can re-use caching mechanisms of other protocols such as HTTP.</p></div>
+	
+	</section>
+
+	<section id="versioning"><div class="header-wrapper"><h3 id="x12-3-versioning"><bdi class="secno">12.3 </bdi>Versioning</h3><a class="self-link" href="#versioning" aria-label="Permalink for Section 12.3"></a></div>
+		
+		<p>If a <a href="https://www.w3.org/TR/did-core/#did-parameters"><code>versionId</code></a> or
+			<a href="https://www.w3.org/TR/did-core/#did-parameters"><code>versionTime</code></a> DID parameter
+			is provided, the <a href="#dfn-did-resolution" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolution-47">DID resolution</a>
+			algorithm returns a specific version of the <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-81">DID document</a>.</p>
+		<p>The DID parameters <a href="https://www.w3.org/TR/did-core/#did-parameters"><code>versionId</code></a>
+			and <a href="https://www.w3.org/TR/did-core/#did-parameters"><code>versionTime</code></a>
+			are mutually exclusive.</p>
+		<p>The use of the <a href="https://www.w3.org/TR/did-core/#did-parameters"><code>versionId</code></a> DID parameter is specific to the <a href="#dfn-did-method-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-method-s-48">DID method</a>.
+			Its possible values may include sequential numbers, random UUIDs, content hashes, etc..</p>
+		<p>DID document metadata <em class="rfc2119">MAY</em> contain a <a href="https://www.w3.org/TR/did-core/#did-parameters"><code>versionId</code></a>
+			property that changes with each  <a href="https://www.w3.org/TR/did-core/#method-operations">Update</a> operation that is performed
+			on a DID document.</p>
+		<div class="note" role="note" id="issue-container-generatedID-25"><div role="heading" class="note-title marker" id="h-note-8" aria-level="4"><span>Note</span></div><p class="">While most <a href="#dfn-did-method-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-method-s-49">DID methods</a> support the <a href="https://www.w3.org/TR/did-core/#method-operations">Update</a>
+			operation, there is no requirement for <a href="#dfn-did-method-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-method-s-50">DID methods</a> to keep all previous <a href="#dfn-did-documents" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-documents-82">DID document</a> versions, therefore
+			not all <a href="#dfn-did-method-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-method-s-51">DID methods</a> support versioning.</p></div>
+			<div class="issue" id="issue-container-number-12"><div role="heading" class="issue-title marker" id="h-issue-25" aria-level="4"><a href="https://github.com/w3c/did-resolution/issues/12"><span class="issue-number">Issue 12</span></a><span class="issue-label">: Design versioning features</span></div><p class="">See corresponding open issue.</p></div>
+
+	</section>
+	
+	<section id="non-did-identifiers"><div class="header-wrapper"><h3 id="x12-4-non-did-identifiers"><bdi class="secno">12.4 </bdi>Non-DID Identifiers</h3><a class="self-link" href="#non-did-identifiers" aria-label="Permalink for Section 12.4"></a></div>
+		
+		<div class="issue" id="issue-container-number-8"><div role="heading" class="issue-title marker" id="h-issue-26" aria-level="4"><a href="https://github.com/w3c/did-resolution/issues/8"><span class="issue-number">Issue 8</span></a><span class="issue-label">: Discover DIDs from other identifiers <a class="respec-gh-label" style="background-color: rgb(23, 174, 243); color: rgb(0, 0, 0);" href="https://github.com/w3c/did-resolution/issues/?q=is%3Aissue+is%3Aopen+label%3A%22discuss%22" aria-label="GitHub label: discuss">discuss</a></span></div><p class="">There is discussion on the relationship between <a href="#dfn-did-resolution" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolution-48">DID resolution</a> and
+		resolution of non-DID identifiers such as domain names, HTTP URIs, or e-mail addresses. This includes the
+		questions how DIDs can be discovered from non-DID identifiers, and how links between identifiers can
+		be verifiable.</p></div>
+	
+	</section>
+
+	<section id="did-method-governance"><div class="header-wrapper"><h3 id="x12-5-did-method-governance"><bdi class="secno">12.5 </bdi>DID Method Governance</h3><a class="self-link" href="#did-method-governance" aria-label="Permalink for Section 12.5"></a></div>
+		
+		<div class="issue" id="issue-container-number-6"><div role="heading" class="issue-title marker" id="h-issue-27" aria-level="4"><a href="https://github.com/w3c/did-resolution/issues/6"><span class="issue-number">Issue 6</span></a><span class="issue-label">: DID method governance</span></div><p class="">Describe which methods a <a href="#dfn-did-resolver-s" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-resolver-s-67">DID resolver</a> should support, and potential implications.</p></div>
+
+	</section>
+
+</section>
+
+<section id="future-work"><div class="header-wrapper"><h2 id="x13-future-work"><bdi class="secno">13. </bdi>Future Work</h2><a class="self-link" href="#future-work" aria-label="Permalink for Section 13."></a></div>
+	
+	<div class="note" role="note" id="issue-container-generatedID-26"><div role="heading" class="note-title marker" id="h-note-9" aria-level="3"><span>Note</span></div><p class="">This section lists additional <a href="#dfn-did-url-dereferencing" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-did-url-dereferencing-44">DID URL dereferencing</a> features that are under discussion and
+	have not yet been incorporated into the algorithm.</p></div>
+
+	<section id="redirect"><div class="header-wrapper"><h3 id="x13-1-redirect"><bdi class="secno">13.1 </bdi>Redirect</h3><a class="self-link" href="#redirect" aria-label="Permalink for Section 13.1"></a></div>
+		
+		<p>A <a href="https://www.w3.org/TR/did-core/#services">service endpoint</a> may have
+		a <code>serviceEndpoint</code> property with a value that is itself
+		a DID. This is interpreted as a "DID redirect" from the input DID to another. In this case, a "child"
+		DID resolution process can be launched to get to a "final" service endpoint.</p>
+
+		<p>The <code>follow-redirect</code> resolution option can be supplied by a client as a hint to
+			instruct whether redirects should be followed. This <var>resolution option</var> is <em class="rfc2119">OPTIONAL</em>.</p>
+
+		<div class="issue" id="issue-container-number-7"><div role="heading" class="issue-title marker" id="h-issue-28" aria-level="4"><a href="https://github.com/w3c/did-resolution/issues/7"><span class="issue-number">Issue 7</span></a><span class="issue-label">: Support DIDs as serviceEndpoint? <a class="respec-gh-label" style="background-color: rgb(162, 238, 239); color: rgb(0, 0, 0);" href="https://github.com/w3c/did-resolution/issues/?q=is%3Aissue+is%3Aopen+label%3A%22enhancement%22" aria-label="GitHub label: enhancement">enhancement</a></span></div><p class="">See corresponding open issue.
+		</p></div>
+
+		<div class="issue closed" id="issue-container-number-36"><div role="heading" class="issue-title marker" id="h-issue-29" aria-level="4"><a href="https://github.com/w3c/did-resolution/issues/36"><span class="issue-number">Issue 36</span></a><span class="issue-label">: Portable DID resolution</span></div><p class="">DID redirects could not only apply to a single service endpoint, but
+		to an entire DID document, therefore enabling portability use cases.
+		</p></div>
+
+		<div class="example" id="example-24">
+        <div class="marker">
+    <a class="self-link" href="#example-24">Example<bdi> 24</bdi></a>
+  </div> <pre class="nohighlight">{
+   "id": "did:example:123456789abcdefghi#hub1",
+   "type": "HubService",
+   "serviceEndpoint": "did:example:xyz"
+}</pre>
+      </div>
+
+	</section>
+
+	<section id="proxy"><div class="header-wrapper"><h3 id="x13-2-proxy"><bdi class="secno">13.2 </bdi>Proxy</h3><a class="self-link" href="#proxy" aria-label="Permalink for Section 13.2"></a></div>
+		
+		<p>A DID document may contain a "proxy" service type which would provide a mapping that 
+		needs to be followed in order to resolve to a final service URL.</p>
+
+		<div class="issue closed" id="issue-container-number-35"><div role="heading" class="issue-title marker" id="h-issue-30" aria-level="4"><a href="https://github.com/w3c/did-resolution/issues/35"><span class="issue-number">Issue 35</span></a><span class="issue-label">: Support "proxy" service type? <a class="respec-gh-label" style="background-color: rgb(162, 238, 239); color: rgb(0, 0, 0);" href="https://github.com/w3c/did-resolution/issues/?q=is%3Aissue+is%3Aopen+label%3A%22enhancement%22" aria-label="GitHub label: enhancement">enhancement</a><a class="respec-gh-label" style="background-color: rgb(101, 159, 43); color: rgb(0, 0, 0);" href="https://github.com/w3c/did-resolution/issues/?q=is%3Aissue+is%3Aopen+label%3A%22pending-close%22" aria-label="GitHub label: pending-close">pending-close</a></span></div><p dir="auto">Keeping track of a proposal here <a class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="332071991" data-permission-text="Title is private" data-url="https://github.com/w3c-ccg/did-spec/issues/90" data-hovercard-type="issue" data-hovercard-url="/w3c-ccg/did-spec/issues/90/hovercard?comment_id=439936749&amp;comment_type=issue_comment" href="https://github.com/w3c-ccg/did-spec/issues/90#issuecomment-439936749">w3c-ccg/did-spec#90 (comment)</a> that a DID Document could contain a "proxy" service type which would provide a mapping that needs to be followed in order to resolve to a final service URL.</p></div>
+		<p></p>
+
+		<div class="example" id="example-25">
+        <div class="marker">
+    <a class="self-link" href="#example-25">Example<bdi> 25</bdi></a>
+  </div> <pre class="nohighlight">{
+   "id": "did:example:123456789abcdefghi",
+   "type": "ProxyService",
+   "serviceEndpoint": "https://mydomain.com/proxy"
+}</pre>
+      </div>
+
+	</section>
+
+	<section id="json-pointer"><div class="header-wrapper"><h3 id="x13-3-json-pointer"><bdi class="secno">13.3 </bdi>JSON Pointer</h3><a class="self-link" href="#json-pointer" aria-label="Permalink for Section 13.3"></a></div>
+		
+		<div class="issue" id="issue-container-generatedID-27"><div role="heading" class="issue-title marker" id="h-issue-31" aria-level="4"><span>Issue</span></div><div class="">
+		<p>Several ways of selecting parts of a DID document are being discussed, including the use
+		of JSON pointer.</p>
+		<p>See corresponding PRs <a href="https://github.com/w3c/did-spec/pull/161">here</a>
+		and <a href="https://github.com/w3c/did-core/pull/257">here</a>.</p>
+		</div></div>
+
+	</section>
+
+</section>
+
+<section class="appendix" id="did-resolution-resources"><div class="header-wrapper"><h2 id="a-did-resolution-resources"><bdi class="secno">A. </bdi>DID Resolution Resources</h2><a class="self-link" href="#did-resolution-resources" aria-label="Permalink for Appendix A."></a></div>
+	
+
+	<ol>
+	<li><a href="https://www.w3.org/TR/did-core/#resolution">DID resolvers in DID Core specification</a></li>
+	<li><a href="https://github.com/decentralized-identity/universal-resolver/">Universal Resolver</a></li>
+	<li><a href="https://github.com/digitalbazaar/did-client">did-client</a></li>
+	<li><a href="https://github.com/uport-project/did-resolver">uPort DID resolver</a></li>
+	</ol>
+
+</section>
+
+
+
+<section id="references" class="appendix"><div class="header-wrapper"><h2 id="b-references"><bdi class="secno">B. </bdi>References</h2><a class="self-link" href="#references" aria-label="Permalink for Appendix B."></a></div><section id="normative-references"><div class="header-wrapper"><h3 id="b-1-normative-references"><bdi class="secno">B.1 </bdi>Normative references</h3><a class="self-link" href="#normative-references" aria-label="Permalink for Appendix B.1"></a></div>
+    
+    <dl class="bibliography"><dt id="bib-did-core">[DID-CORE]</dt><dd>
+      <a href="https://www.w3.org/TR/did-core/"><cite>Decentralized Identifiers (DIDs) v1.0</cite></a>. Manu Sporny; Amy Guy; Markus Sabadello; Drummond Reed.  W3C. 19 July 2022. W3C Recommendation. URL: <a href="https://www.w3.org/TR/did-core/">https://www.w3.org/TR/did-core/</a>
+    </dd><dt id="bib-infra">[INFRA]</dt><dd>
+      <a href="https://infra.spec.whatwg.org/"><cite>Infra Standard</cite></a>. Anne van Kesteren; Domenic Denicola.  WHATWG. Living Standard. URL: <a href="https://infra.spec.whatwg.org/">https://infra.spec.whatwg.org/</a>
+    </dd><dt id="bib-rfc2046">[RFC2046]</dt><dd>
+      <a href="https://www.rfc-editor.org/rfc/rfc2046"><cite>Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types</cite></a>. N. Freed; N. Borenstein.  IETF. November 1996. Draft Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc2046">https://www.rfc-editor.org/rfc/rfc2046</a>
+    </dd><dt id="bib-rfc2119">[RFC2119]</dt><dd>
+      <a href="https://www.rfc-editor.org/rfc/rfc2119"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. S. Bradner.  IETF. March 1997. Best Current Practice. URL: <a href="https://www.rfc-editor.org/rfc/rfc2119">https://www.rfc-editor.org/rfc/rfc2119</a>
+    </dd><dt id="bib-rfc3986">[RFC3986]</dt><dd>
+      <a href="https://www.rfc-editor.org/rfc/rfc3986"><cite>Uniform Resource Identifier (URI): Generic Syntax</cite></a>. T. Berners-Lee; R. Fielding; L. Masinter.  IETF. January 2005. Internet Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc3986">https://www.rfc-editor.org/rfc/rfc3986</a>
+    </dd><dt id="bib-rfc7231">[RFC7231]</dt><dd>
+      <a href="https://httpwg.org/specs/rfc7231.html"><cite>Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</cite></a>. R. Fielding, Ed.; J. Reschke, Ed. IETF. June 2014. Proposed Standard. URL: <a href="https://httpwg.org/specs/rfc7231.html">https://httpwg.org/specs/rfc7231.html</a>
+    </dd><dt id="bib-rfc8174">[RFC8174]</dt><dd>
+      <a href="https://www.rfc-editor.org/rfc/rfc8174"><cite>Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words</cite></a>. B. Leiba.  IETF. May 2017. Best Current Practice. URL: <a href="https://www.rfc-editor.org/rfc/rfc8174">https://www.rfc-editor.org/rfc/rfc8174</a>
+    </dd><dt id="bib-vc-data-model">[VC-DATA-MODEL]</dt><dd>
+      <a href="https://www.w3.org/TR/vc-data-model/"><cite>Verifiable Credentials Data Model v1.1</cite></a>. Manu Sporny; Grant Noble; Dave Longley; Daniel Burnett; Brent Zundel; Kyle Den Hartog.  W3C. 3 March 2022. W3C Recommendation. URL: <a href="https://www.w3.org/TR/vc-data-model/">https://www.w3.org/TR/vc-data-model/</a>
+    </dd><dt id="bib-xmlschema11-2">[XMLSCHEMA11-2]</dt><dd>
+      <a href="https://www.w3.org/TR/xmlschema11-2/"><cite>W3C XML Schema Definition Language (XSD) 1.1 Part 2: Datatypes</cite></a>. David Peterson; Sandy Gao; Ashok Malhotra; Michael Sperberg-McQueen; Henry Thompson; Paul V. Biron et al.  W3C. 5 April 2012. W3C Recommendation. URL: <a href="https://www.w3.org/TR/xmlschema11-2/">https://www.w3.org/TR/xmlschema11-2/</a>
+    </dd></dl>
+  </section><section id="informative-references"><div class="header-wrapper"><h3 id="b-2-informative-references"><bdi class="secno">B.2 </bdi>Informative references</h3><a class="self-link" href="#informative-references" aria-label="Permalink for Appendix B.2"></a></div>
+    
+    <dl class="bibliography"><dt id="bib-data-integrity">[DATA-INTEGRITY]</dt><dd>
+      <a href="https://www.w3.org/TR/vc-data-integrity/"><cite>Verifiable Credential Data Integrity 1.0</cite></a>. Dave Longley; Manu Sporny.  W3C Verifiable Credentials Working Group. CRD. URL: <a href="https://www.w3.org/TR/vc-data-integrity/">https://www.w3.org/TR/vc-data-integrity/</a>
+    </dd><dt id="bib-did-key">[DID-KEY]</dt><dd>
+      <a href="https://w3c-ccg.github.io/did-method-key/"><cite>The did:key Method</cite></a>. Manu Sporny; Dmitri Zagidulin; Dave Longley.  09 June 2020. unofficial. URL: <a href="https://w3c-ccg.github.io/did-method-key/">https://w3c-ccg.github.io/did-method-key/</a>
+    </dd><dt id="bib-did-peer">[DID-PEER]</dt><dd>
+      <a href="https://identity.foundation/peer-did-method-spec/"><cite>Peer DID Method Specification</cite></a>. Oskar Deventer; Christian Lundkvist; Márton Csernai; Kyle Den Hartog; Markus Sabadello; Sam Curren; Dan Gisolfi; Mike Varley; Sven Hammann; John Jordan; Lovesh Harchandani; Devin Fisher; Tobias Looker; Brent Zundel; Stephen Curran. 10 July 2020. W3C Editor's Draft. URL: <a href="https://identity.foundation/peer-did-method-spec/">https://identity.foundation/peer-did-method-spec/</a>
+    </dd><dt id="bib-did-spec-registries">[DID-SPEC-REGISTRIES]</dt><dd>
+      <a href="https://www.w3.org/TR/did-extensions/"><cite>Decentralized Identifier Extensions</cite></a>. Manu Sporny; Markus Sabadello.  W3C. 20 January 2025. W3C Working Group Note. URL: <a href="https://www.w3.org/TR/did-extensions/">https://www.w3.org/TR/did-extensions/</a>
+    </dd><dt id="bib-keri">[KERI]</dt><dd>
+      <a href="https://arxiv.org/abs/1907.02143"><cite>Key Event Receipt Infrastructure (KERI)</cite></a>. Samuel M. Smith. July 2019. URL: <a href="https://arxiv.org/abs/1907.02143">https://arxiv.org/abs/1907.02143</a>
+    </dd><dt id="bib-rfc3339">[RFC3339]</dt><dd>
+      <a href="https://www.rfc-editor.org/rfc/rfc3339"><cite>Date and Time on the Internet: Timestamps</cite></a>. G. Klyne; C. Newman.  IETF. July 2002. Proposed Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc3339">https://www.rfc-editor.org/rfc/rfc3339</a>
+    </dd></dl>
+  </section></section><p role="navigation" id="back-to-top">
+    <a href="#title"><abbr title="Back to Top">↑</abbr></a>
+  </p><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-conforming-did-resolver" aria-label="Links in this document to definition: conforming DID resolver">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-conforming-did-resolver" aria-label="Permalink for definition: conforming DID resolver. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+      <li>Not referenced in this document.</li>
+    </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-conforming-did-url-dereferencer" aria-label="Links in this document to definition: conforming DID URL dereferencer">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-conforming-did-url-dereferencer" aria-label="Permalink for definition: conforming DID URL dereferencer. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+      <li>Not referenced in this document.</li>
+    </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-authenticated" aria-label="Links in this document to definition: authenticate">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-authenticated" aria-label="Permalink for definition: authenticate. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-authenticated-1" title="§ 2. Terminology">§ 2. Terminology</a> <a href="#ref-for-dfn-authenticated-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-authenticated-3" title="Reference 3">(3)</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-binding" aria-label="Links in this document to definition: binding">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-binding" aria-label="Permalink for definition: binding. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-binding-1" title="§ 2. Terminology">§ 2. Terminology</a> <a href="#ref-for-dfn-binding-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-binding-3" title="Reference 3">(3)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-binding-4" title="§ 6.2 Resolver Architectures">§ 6.2 Resolver Architectures</a> 
+    </li><li>
+      <a href="#ref-for-dfn-binding-5" title="§ 6.2.1 Proxied Resolution">§ 6.2.1 Proxied Resolution</a> <a href="#ref-for-dfn-binding-6" title="Reference 2">(2)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-binding-7" title="§ 10.1 HTTP(S) Binding">§ 10.1 HTTP(S) Binding</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-client" aria-label="Links in this document to definition: client">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-client" aria-label="Permalink for definition: client. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-client-1" title="§ 2. Terminology">§ 2. Terminology</a> <a href="#ref-for-dfn-client-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-client-3" title="Reference 3">(3)</a> <a href="#ref-for-dfn-client-4" title="Reference 4">(4)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-client-5" title="§ 6.2 Resolver Architectures">§ 6.2 Resolver Architectures</a> 
+    </li><li>
+      <a href="#ref-for-dfn-client-6" title="§ 6.2.1 Proxied Resolution">§ 6.2.1 Proxied Resolution</a> 
+    </li><li>
+      <a href="#ref-for-dfn-client-7" title="§ 6.2.2 Client-Side Dereferencing">§ 6.2.2 Client-Side Dereferencing</a> <a href="#ref-for-dfn-client-8" title="Reference 2">(2)</a> <a href="#ref-for-dfn-client-9" title="Reference 3">(3)</a> <a href="#ref-for-dfn-client-10" title="Reference 4">(4)</a> <a href="#ref-for-dfn-client-11" title="Reference 5">(5)</a> <a href="#ref-for-dfn-client-12" title="Reference 6">(6)</a> <a href="#ref-for-dfn-client-13" title="Reference 7">(7)</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-decentralized-identifiers" aria-label="Links in this document to definition: decentralized identifier">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-decentralized-identifiers" aria-label="Permalink for definition: decentralized identifier. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-decentralized-identifiers-1" title="§ 1. Introduction">§ 1. Introduction</a> <a href="#ref-for-dfn-decentralized-identifiers-2" title="Reference 2">(2)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-decentralized-identifiers-3" title="§ 2. Terminology">§ 2. Terminology</a> <a href="#ref-for-dfn-decentralized-identifiers-4" title="Reference 2">(2)</a> <a href="#ref-for-dfn-decentralized-identifiers-5" title="Reference 3">(3)</a> <a href="#ref-for-dfn-decentralized-identifiers-6" title="Reference 4">(4)</a> <a href="#ref-for-dfn-decentralized-identifiers-7" title="Reference 5">(5)</a> <a href="#ref-for-dfn-decentralized-identifiers-8" title="Reference 6">(6)</a> <a href="#ref-for-dfn-decentralized-identifiers-9" title="Reference 7">(7)</a> <a href="#ref-for-dfn-decentralized-identifiers-10" title="Reference 8">(8)</a> <a href="#ref-for-dfn-decentralized-identifiers-11" title="Reference 9">(9)</a> <a href="#ref-for-dfn-decentralized-identifiers-12" title="Reference 10">(10)</a> <a href="#ref-for-dfn-decentralized-identifiers-13" title="Reference 11">(11)</a> <a href="#ref-for-dfn-decentralized-identifiers-14" title="Reference 12">(12)</a> <a href="#ref-for-dfn-decentralized-identifiers-15" title="Reference 13">(13)</a> <a href="#ref-for-dfn-decentralized-identifiers-16" title="Reference 14">(14)</a> <a href="#ref-for-dfn-decentralized-identifiers-17" title="Reference 15">(15)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-decentralized-identifiers-18" title="§ 3. DID Resolution">§ 3. DID Resolution</a> <a href="#ref-for-dfn-decentralized-identifiers-19" title="Reference 2">(2)</a> <a href="#ref-for-dfn-decentralized-identifiers-20" title="Reference 3">(3)</a> <a href="#ref-for-dfn-decentralized-identifiers-21" title="Reference 4">(4)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-decentralized-identifiers-22" title="§ 3.2 DID Resolution Metadata">§ 3.2 DID Resolution Metadata</a> 
+    </li><li>
+      <a href="#ref-for-dfn-decentralized-identifiers-23" title="§ 3.3 DID Document Metadata">§ 3.3 DID Document Metadata</a> <a href="#ref-for-dfn-decentralized-identifiers-24" title="Reference 2">(2)</a> <a href="#ref-for-dfn-decentralized-identifiers-25" title="Reference 3">(3)</a> <a href="#ref-for-dfn-decentralized-identifiers-26" title="Reference 4">(4)</a> <a href="#ref-for-dfn-decentralized-identifiers-27" title="Reference 5">(5)</a> <a href="#ref-for-dfn-decentralized-identifiers-28" title="Reference 6">(6)</a> <a href="#ref-for-dfn-decentralized-identifiers-29" title="Reference 7">(7)</a> <a href="#ref-for-dfn-decentralized-identifiers-30" title="Reference 8">(8)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-decentralized-identifiers-31" title="§ 3.4 Algorithm">§ 3.4 Algorithm</a> <a href="#ref-for-dfn-decentralized-identifiers-32" title="Reference 2">(2)</a> <a href="#ref-for-dfn-decentralized-identifiers-33" title="Reference 3">(3)</a> <a href="#ref-for-dfn-decentralized-identifiers-34" title="Reference 4">(4)</a> <a href="#ref-for-dfn-decentralized-identifiers-35" title="Reference 5">(5)</a> <a href="#ref-for-dfn-decentralized-identifiers-36" title="Reference 6">(6)</a> <a href="#ref-for-dfn-decentralized-identifiers-37" title="Reference 7">(7)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-decentralized-identifiers-38" title="§ 4. DID URL Dereferencing">§ 4. DID URL Dereferencing</a> 
+    </li><li>
+      <a href="#ref-for-dfn-decentralized-identifiers-39" title="§ 4.3.1 Dereferencing the Resource">§ 4.3.1 Dereferencing the Resource</a> <a href="#ref-for-dfn-decentralized-identifiers-40" title="Reference 2">(2)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-decentralized-identifiers-41" title="§ 5. Metadata Structure">§ 5. Metadata Structure</a> 
+    </li><li>
+      <a href="#ref-for-dfn-decentralized-identifiers-42" title="§ 6.1 Method Architectures">§ 6.1 Method Architectures</a> 
+    </li><li>
+      <a href="#ref-for-dfn-decentralized-identifiers-43" title="§ 7.2 DID Document">§ 7.2 DID Document</a> 
+    </li><li>
+      <a href="#ref-for-dfn-decentralized-identifiers-44" title="§ 10.1 HTTP(S) Binding">§ 10.1 HTTP(S) Binding</a> <a href="#ref-for-dfn-decentralized-identifiers-45" title="Reference 2">(2)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-decentralized-identifiers-46" title="§ 10.2 DID Resolution Examples">§ 10.2 DID Resolution Examples</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-did-controllers" aria-label="Links in this document to definition: DID controller">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-did-controllers" aria-label="Permalink for definition: DID controller. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-did-controllers-1" title="§ 2. Terminology">§ 2. Terminology</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-controllers-2" title="§ 7.4 DID Document Metadata">§ 7.4 DID Document Metadata</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-did-delegate" aria-label="Links in this document to definition: DID delegate">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-did-delegate" aria-label="Permalink for definition: DID delegate. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-did-delegate-1" title="§ 2. Terminology">§ 2. Terminology</a> <a href="#ref-for-dfn-did-delegate-2" title="Reference 2">(2)</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-did-documents" aria-label="Links in this document to definition: DID document">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-did-documents" aria-label="Permalink for definition: DID document. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-did-documents-1" title="§ 1. Introduction">§ 1. Introduction</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-documents-2" title="§ 2. Terminology">§ 2. Terminology</a> <a href="#ref-for-dfn-did-documents-3" title="Reference 2">(2)</a> <a href="#ref-for-dfn-did-documents-4" title="Reference 3">(3)</a> <a href="#ref-for-dfn-did-documents-5" title="Reference 4">(4)</a> <a href="#ref-for-dfn-did-documents-6" title="Reference 5">(5)</a> <a href="#ref-for-dfn-did-documents-7" title="Reference 6">(6)</a> <a href="#ref-for-dfn-did-documents-8" title="Reference 7">(7)</a> <a href="#ref-for-dfn-did-documents-9" title="Reference 8">(8)</a> <a href="#ref-for-dfn-did-documents-10" title="Reference 9">(9)</a> <a href="#ref-for-dfn-did-documents-11" title="Reference 10">(10)</a> <a href="#ref-for-dfn-did-documents-12" title="Reference 11">(11)</a> <a href="#ref-for-dfn-did-documents-13" title="Reference 12">(12)</a> <a href="#ref-for-dfn-did-documents-14" title="Reference 13">(13)</a> <a href="#ref-for-dfn-did-documents-15" title="Reference 14">(14)</a> <a href="#ref-for-dfn-did-documents-16" title="Reference 15">(15)</a> <a href="#ref-for-dfn-did-documents-17" title="Reference 16">(16)</a> <a href="#ref-for-dfn-did-documents-18" title="Reference 17">(17)</a> <a href="#ref-for-dfn-did-documents-19" title="Reference 18">(18)</a> <a href="#ref-for-dfn-did-documents-20" title="Reference 19">(19)</a> <a href="#ref-for-dfn-did-documents-21" title="Reference 20">(20)</a> <a href="#ref-for-dfn-did-documents-22" title="Reference 21">(21)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-documents-23" title="§ 3. DID Resolution">§ 3. DID Resolution</a> <a href="#ref-for-dfn-did-documents-24" title="Reference 2">(2)</a> <a href="#ref-for-dfn-did-documents-25" title="Reference 3">(3)</a> <a href="#ref-for-dfn-did-documents-26" title="Reference 4">(4)</a> <a href="#ref-for-dfn-did-documents-27" title="Reference 5">(5)</a> <a href="#ref-for-dfn-did-documents-28" title="Reference 6">(6)</a> <a href="#ref-for-dfn-did-documents-29" title="Reference 7">(7)</a> <a href="#ref-for-dfn-did-documents-30" title="Reference 8">(8)</a> <a href="#ref-for-dfn-did-documents-31" title="Reference 9">(9)</a> <a href="#ref-for-dfn-did-documents-32" title="Reference 10">(10)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-documents-33" title="§ 3.1 DID Resolution Options">§ 3.1 DID Resolution Options</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-documents-34" title="§ 3.2 DID Resolution Metadata">§ 3.2 DID Resolution Metadata</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-documents-35" title="§ 3.3 DID Document Metadata">§ 3.3 DID Document Metadata</a> <a href="#ref-for-dfn-did-documents-36" title="Reference 2">(2)</a> <a href="#ref-for-dfn-did-documents-37" title="Reference 3">(3)</a> <a href="#ref-for-dfn-did-documents-38" title="Reference 4">(4)</a> <a href="#ref-for-dfn-did-documents-39" title="Reference 5">(5)</a> <a href="#ref-for-dfn-did-documents-40" title="Reference 6">(6)</a> <a href="#ref-for-dfn-did-documents-41" title="Reference 7">(7)</a> <a href="#ref-for-dfn-did-documents-42" title="Reference 8">(8)</a> <a href="#ref-for-dfn-did-documents-43" title="Reference 9">(9)</a> <a href="#ref-for-dfn-did-documents-44" title="Reference 10">(10)</a> <a href="#ref-for-dfn-did-documents-45" title="Reference 11">(11)</a> <a href="#ref-for-dfn-did-documents-46" title="Reference 12">(12)</a> <a href="#ref-for-dfn-did-documents-47" title="Reference 13">(13)</a> <a href="#ref-for-dfn-did-documents-48" title="Reference 14">(14)</a> <a href="#ref-for-dfn-did-documents-49" title="Reference 15">(15)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-documents-50" title="§ 3.4 Algorithm">§ 3.4 Algorithm</a> <a href="#ref-for-dfn-did-documents-51" title="Reference 2">(2)</a> <a href="#ref-for-dfn-did-documents-52" title="Reference 3">(3)</a> <a href="#ref-for-dfn-did-documents-53" title="Reference 4">(4)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-documents-54" title="§ 4. DID URL Dereferencing">§ 4. DID URL Dereferencing</a> <a href="#ref-for-dfn-did-documents-55" title="Reference 2">(2)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-documents-56" title="§ 4.3.1 Dereferencing the Resource">§ 4.3.1 Dereferencing the Resource</a> <a href="#ref-for-dfn-did-documents-57" title="Reference 2">(2)</a> <a href="#ref-for-dfn-did-documents-58" title="Reference 3">(3)</a> <a href="#ref-for-dfn-did-documents-59" title="Reference 4">(4)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-documents-60" title="§ 4.3.2 Dereferencing the Fragment">§ 4.3.2 Dereferencing the Fragment</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-documents-61" title="§ 4.4 Examples">§ 4.4 Examples</a> <a href="#ref-for-dfn-did-documents-62" title="Reference 2">(2)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-documents-63" title="§ 5. Metadata Structure">§ 5. Metadata Structure</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-documents-64" title="§ 6.1 Method Architectures">§ 6.1 Method Architectures</a> <a href="#ref-for-dfn-did-documents-65" title="Reference 2">(2)</a> <a href="#ref-for-dfn-did-documents-66" title="Reference 3">(3)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-documents-67" title="§ 6.2 Resolver Architectures">§ 6.2 Resolver Architectures</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-documents-68" title="§ 6.2.2 Client-Side Dereferencing">§ 6.2.2 Client-Side Dereferencing</a> <a href="#ref-for-dfn-did-documents-69" title="Reference 2">(2)</a> <a href="#ref-for-dfn-did-documents-70" title="Reference 3">(3)</a> <a href="#ref-for-dfn-did-documents-71" title="Reference 4">(4)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-documents-72" title="§ 7. DID Resolution Result">§ 7. DID Resolution Result</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-documents-73" title="§ 7.1 Example">§ 7.1 Example</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-documents-74" title="§ 7.2 DID Document">§ 7.2 DID Document</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-documents-75" title="§ 7.4 DID Document Metadata">§ 7.4 DID Document Metadata</a> <a href="#ref-for-dfn-did-documents-76" title="Reference 2">(2)</a> <a href="#ref-for-dfn-did-documents-77" title="Reference 3">(3)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-documents-78" title="§ 12.2 Caching">§ 12.2 Caching</a> <a href="#ref-for-dfn-did-documents-79" title="Reference 2">(2)</a> <a href="#ref-for-dfn-did-documents-80" title="Reference 3">(3)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-documents-81" title="§ 12.3 Versioning">§ 12.3 Versioning</a> <a href="#ref-for-dfn-did-documents-82" title="Reference 2">(2)</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-did-fragments" aria-label="Links in this document to definition: DID fragment">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-did-fragments" aria-label="Permalink for definition: DID fragment. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-did-fragments-1" title="§ 2. Terminology">§ 2. Terminology</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-fragments-2" title="§ 4. DID URL Dereferencing">§ 4. DID URL Dereferencing</a> <a href="#ref-for-dfn-did-fragments-3" title="Reference 2">(2)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-fragments-4" title="§ 4.3 Algorithm">§ 4.3 Algorithm</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-fragments-5" title="§ 4.3.1 Dereferencing the Resource">§ 4.3.1 Dereferencing the Resource</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-fragments-6" title="§ 4.3.2 Dereferencing the Fragment">§ 4.3.2 Dereferencing the Fragment</a> <a href="#ref-for-dfn-did-fragments-7" title="Reference 2">(2)</a> <a href="#ref-for-dfn-did-fragments-8" title="Reference 3">(3)</a> <a href="#ref-for-dfn-did-fragments-9" title="Reference 4">(4)</a> <a href="#ref-for-dfn-did-fragments-10" title="Reference 5">(5)</a> <a href="#ref-for-dfn-did-fragments-11" title="Reference 6">(6)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-fragments-12" title="§ 6.2.2 Client-Side Dereferencing">§ 6.2.2 Client-Side Dereferencing</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-did-method-s" aria-label="Links in this document to definition: DID method">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-did-method-s" aria-label="Permalink for definition: DID method. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-did-method-s-1" title="§ 1. Introduction">§ 1. Introduction</a> <a href="#ref-for-dfn-did-method-s-2" title="Reference 2">(2)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-method-s-3" title="§ 2. Terminology">§ 2. Terminology</a> <a href="#ref-for-dfn-did-method-s-4" title="Reference 2">(2)</a> <a href="#ref-for-dfn-did-method-s-5" title="Reference 3">(3)</a> <a href="#ref-for-dfn-did-method-s-6" title="Reference 4">(4)</a> <a href="#ref-for-dfn-did-method-s-7" title="Reference 5">(5)</a> <a href="#ref-for-dfn-did-method-s-8" title="Reference 6">(6)</a> <a href="#ref-for-dfn-did-method-s-9" title="Reference 7">(7)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-method-s-10" title="§ 3. DID Resolution">§ 3. DID Resolution</a> <a href="#ref-for-dfn-did-method-s-11" title="Reference 2">(2)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-method-s-12" title="§ 3.2 DID Resolution Metadata">§ 3.2 DID Resolution Metadata</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-method-s-13" title="§ 3.3 DID Document Metadata">§ 3.3 DID Document Metadata</a> <a href="#ref-for-dfn-did-method-s-14" title="Reference 2">(2)</a> <a href="#ref-for-dfn-did-method-s-15" title="Reference 3">(3)</a> <a href="#ref-for-dfn-did-method-s-16" title="Reference 4">(4)</a> <a href="#ref-for-dfn-did-method-s-17" title="Reference 5">(5)</a> <a href="#ref-for-dfn-did-method-s-18" title="Reference 6">(6)</a> <a href="#ref-for-dfn-did-method-s-19" title="Reference 7">(7)</a> <a href="#ref-for-dfn-did-method-s-20" title="Reference 8">(8)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-method-s-21" title="§ 3.4 Algorithm">§ 3.4 Algorithm</a> <a href="#ref-for-dfn-did-method-s-22" title="Reference 2">(2)</a> <a href="#ref-for-dfn-did-method-s-23" title="Reference 3">(3)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-method-s-24" title="§ 4. DID URL Dereferencing">§ 4. DID URL Dereferencing</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-method-s-25" title="§ 4.3.1 Dereferencing the Resource">§ 4.3.1 Dereferencing the Resource</a> <a href="#ref-for-dfn-did-method-s-26" title="Reference 2">(2)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-method-s-27" title="§ 6. DID Resolution Architectures">§ 6. DID Resolution Architectures</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-method-s-28" title="§ 6.1 Method Architectures">§ 6.1 Method Architectures</a> <a href="#ref-for-dfn-did-method-s-29" title="Reference 2">(2)</a> <a href="#ref-for-dfn-did-method-s-30" title="Reference 3">(3)</a> <a href="#ref-for-dfn-did-method-s-31" title="Reference 4">(4)</a> <a href="#ref-for-dfn-did-method-s-32" title="Reference 5">(5)</a> <a href="#ref-for-dfn-did-method-s-33" title="Reference 6">(6)</a> <a href="#ref-for-dfn-did-method-s-34" title="Reference 7">(7)</a> <a href="#ref-for-dfn-did-method-s-35" title="Reference 8">(8)</a> <a href="#ref-for-dfn-did-method-s-36" title="Reference 9">(9)</a> <a href="#ref-for-dfn-did-method-s-37" title="Reference 10">(10)</a> <a href="#ref-for-dfn-did-method-s-38" title="Reference 11">(11)</a> <a href="#ref-for-dfn-did-method-s-39" title="Reference 12">(12)</a> <a href="#ref-for-dfn-did-method-s-40" title="Reference 13">(13)</a> <a href="#ref-for-dfn-did-method-s-41" title="Reference 14">(14)</a> <a href="#ref-for-dfn-did-method-s-42" title="Reference 15">(15)</a> <a href="#ref-for-dfn-did-method-s-43" title="Reference 16">(16)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-method-s-44" title="§ 6.2.1 Proxied Resolution">§ 6.2.1 Proxied Resolution</a> <a href="#ref-for-dfn-did-method-s-45" title="Reference 2">(2)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-method-s-46" title="§ 7.4 DID Document Metadata">§ 7.4 DID Document Metadata</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-method-s-47" title="§ 12.2 Caching">§ 12.2 Caching</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-method-s-48" title="§ 12.3 Versioning">§ 12.3 Versioning</a> <a href="#ref-for-dfn-did-method-s-49" title="Reference 2">(2)</a> <a href="#ref-for-dfn-did-method-s-50" title="Reference 3">(3)</a> <a href="#ref-for-dfn-did-method-s-51" title="Reference 4">(4)</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-did-paths" aria-label="Links in this document to definition: DID path">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-did-paths" aria-label="Permalink for definition: DID path. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-did-paths-1" title="§ 2. Terminology">§ 2. Terminology</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-paths-2" title="§ 4.3.1 Dereferencing the Resource">§ 4.3.1 Dereferencing the Resource</a> <a href="#ref-for-dfn-did-paths-3" title="Reference 2">(2)</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-did-queries" aria-label="Links in this document to definition: DID query">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-did-queries" aria-label="Permalink for definition: DID query. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-did-queries-1" title="§ 2. Terminology">§ 2. Terminology</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-queries-2" title="§ 4.3.1 Dereferencing the Resource">§ 4.3.1 Dereferencing the Resource</a> <a href="#ref-for-dfn-did-queries-3" title="Reference 2">(2)</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-did-resolution" aria-label="Links in this document to definition: DID resolution">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-did-resolution" aria-label="Permalink for definition: DID resolution. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-did-resolution-1" title="§ 1. Introduction">§ 1. Introduction</a> <a href="#ref-for-dfn-did-resolution-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-did-resolution-3" title="Reference 3">(3)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-resolution-4" title="§ 2. Terminology">§ 2. Terminology</a> <a href="#ref-for-dfn-did-resolution-5" title="Reference 2">(2)</a> <a href="#ref-for-dfn-did-resolution-6" title="Reference 3">(3)</a> <a href="#ref-for-dfn-did-resolution-7" title="Reference 4">(4)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-resolution-8" title="§ 3. DID Resolution">§ 3. DID Resolution</a> <a href="#ref-for-dfn-did-resolution-9" title="Reference 2">(2)</a> <a href="#ref-for-dfn-did-resolution-10" title="Reference 3">(3)</a> <a href="#ref-for-dfn-did-resolution-11" title="Reference 4">(4)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-resolution-12" title="§ 3.2 DID Resolution Metadata">§ 3.2 DID Resolution Metadata</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-resolution-13" title="§ 3.4 Algorithm">§ 3.4 Algorithm</a> <a href="#ref-for-dfn-did-resolution-14" title="Reference 2">(2)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-resolution-15" title="§ 4. DID URL Dereferencing">§ 4. DID URL Dereferencing</a> <a href="#ref-for-dfn-did-resolution-16" title="Reference 2">(2)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-resolution-17" title="§ 4.3.1 Dereferencing the Resource">§ 4.3.1 Dereferencing the Resource</a> <a href="#ref-for-dfn-did-resolution-18" title="Reference 2">(2)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-resolution-19" title="§ 5. Metadata Structure">§ 5. Metadata Structure</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-resolution-20" title="§ 6.1 Method Architectures">§ 6.1 Method Architectures</a> <a href="#ref-for-dfn-did-resolution-21" title="Reference 2">(2)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-resolution-22" title="§ 6.2 Resolver Architectures">§ 6.2 Resolver Architectures</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-resolution-23" title="§ 6.2.1 Proxied Resolution">§ 6.2.1 Proxied Resolution</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-resolution-24" title="§ 7.3 DID Resolution Metadata">§ 7.3 DID Resolution Metadata</a> <a href="#ref-for-dfn-did-resolution-25" title="Reference 2">(2)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-resolution-26" title="§ 7.4 DID Document Metadata">§ 7.4 DID Document Metadata</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-resolution-27" title="§ 9.1 invalidDid">§ 9.1 invalidDid</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-resolution-28" title="§ 9.2 invalidDidUrl">§ 9.2 invalidDidUrl</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-resolution-29" title="§ 9.3 notFound">§ 9.3 notFound</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-resolution-30" title="§ 9.4 representationNotSupported">§ 9.4 representationNotSupported</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-resolution-31" title="§ 9.5 methodNotSupported">§ 9.5 methodNotSupported</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-resolution-32" title="§ 9.6 internalError">§ 9.6 internalError</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-resolution-33" title="§ 9.7 invalidPublicKey">§ 9.7 invalidPublicKey</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-resolution-34" title="§ 9.8 invalidPublicKeyLength">§ 9.8 invalidPublicKeyLength</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-resolution-35" title="§ 9.9 invalidPublicKeyType">§ 9.9 invalidPublicKeyType</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-resolution-36" title="§ 9.10 unsupportedPublicKeyType">§ 9.10 unsupportedPublicKeyType</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-resolution-37" title="§ 10.1 HTTP(S) Binding">§ 10.1 HTTP(S) Binding</a> <a href="#ref-for-dfn-did-resolution-38" title="Reference 2">(2)</a> <a href="#ref-for-dfn-did-resolution-39" title="Reference 3">(3)</a> <a href="#ref-for-dfn-did-resolution-40" title="Reference 4">(4)</a> <a href="#ref-for-dfn-did-resolution-41" title="Reference 5">(5)</a> <a href="#ref-for-dfn-did-resolution-42" title="Reference 6">(6)</a> <a href="#ref-for-dfn-did-resolution-43" title="Reference 7">(7)</a> <a href="#ref-for-dfn-did-resolution-44" title="Reference 8">(8)</a> <a href="#ref-for-dfn-did-resolution-45" title="Reference 9">(9)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-resolution-46" title="§ 12.1 Authentication/Authorization">§ 12.1 Authentication/Authorization</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-resolution-47" title="§ 12.3 Versioning">§ 12.3 Versioning</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-resolution-48" title="§ 12.4 Non-DID Identifiers">§ 12.4 Non-DID Identifiers</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-did-resolver-s" aria-label="Links in this document to definition: DID resolver">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-did-resolver-s" aria-label="Permalink for definition: DID resolver. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-did-resolver-s-1" title="§ 1. Introduction">§ 1. Introduction</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-resolver-s-2" title="§ 2. Terminology">§ 2. Terminology</a> <a href="#ref-for-dfn-did-resolver-s-3" title="Reference 2">(2)</a> <a href="#ref-for-dfn-did-resolver-s-4" title="Reference 3">(3)</a> <a href="#ref-for-dfn-did-resolver-s-5" title="Reference 4">(4)</a> <a href="#ref-for-dfn-did-resolver-s-6" title="Reference 5">(5)</a> <a href="#ref-for-dfn-did-resolver-s-7" title="Reference 6">(6)</a> <a href="#ref-for-dfn-did-resolver-s-8" title="Reference 7">(7)</a> <a href="#ref-for-dfn-did-resolver-s-9" title="Reference 8">(8)</a> <a href="#ref-for-dfn-did-resolver-s-10" title="Reference 9">(9)</a> <a href="#ref-for-dfn-did-resolver-s-11" title="Reference 10">(10)</a> <a href="#ref-for-dfn-did-resolver-s-12" title="Reference 11">(11)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-resolver-s-13" title="§ 3. DID Resolution">§ 3. DID Resolution</a> <a href="#ref-for-dfn-did-resolver-s-14" title="Reference 2">(2)</a> <a href="#ref-for-dfn-did-resolver-s-15" title="Reference 3">(3)</a> <a href="#ref-for-dfn-did-resolver-s-16" title="Reference 4">(4)</a> <a href="#ref-for-dfn-did-resolver-s-17" title="Reference 5">(5)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-resolver-s-18" title="§ 3.1 DID Resolution Options">§ 3.1 DID Resolution Options</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-resolver-s-19" title="§ 3.2 DID Resolution Metadata">§ 3.2 DID Resolution Metadata</a> <a href="#ref-for-dfn-did-resolver-s-20" title="Reference 2">(2)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-resolver-s-21" title="§ 3.4 Algorithm">§ 3.4 Algorithm</a> <a href="#ref-for-dfn-did-resolver-s-22" title="Reference 2">(2)</a> <a href="#ref-for-dfn-did-resolver-s-23" title="Reference 3">(3)</a> <a href="#ref-for-dfn-did-resolver-s-24" title="Reference 4">(4)</a> <a href="#ref-for-dfn-did-resolver-s-25" title="Reference 5">(5)</a> <a href="#ref-for-dfn-did-resolver-s-26" title="Reference 6">(6)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-resolver-s-27" title="§ 4. DID URL Dereferencing">§ 4. DID URL Dereferencing</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-resolver-s-28" title="§ 4.3 Algorithm">§ 4.3 Algorithm</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-resolver-s-29" title="§ 6. DID Resolution Architectures">§ 6. DID Resolution Architectures</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-resolver-s-30" title="§ 6.1 Method Architectures">§ 6.1 Method Architectures</a> <a href="#ref-for-dfn-did-resolver-s-31" title="Reference 2">(2)</a> <a href="#ref-for-dfn-did-resolver-s-32" title="Reference 3">(3)</a> <a href="#ref-for-dfn-did-resolver-s-33" title="Reference 4">(4)</a> <a href="#ref-for-dfn-did-resolver-s-34" title="Reference 5">(5)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-resolver-s-35" title="§ 6.2 Resolver Architectures">§ 6.2 Resolver Architectures</a> <a href="#ref-for-dfn-did-resolver-s-36" title="Reference 2">(2)</a> <a href="#ref-for-dfn-did-resolver-s-37" title="Reference 3">(3)</a> <a href="#ref-for-dfn-did-resolver-s-38" title="Reference 4">(4)</a> <a href="#ref-for-dfn-did-resolver-s-39" title="Reference 5">(5)</a> <a href="#ref-for-dfn-did-resolver-s-40" title="Reference 6">(6)</a> <a href="#ref-for-dfn-did-resolver-s-41" title="Reference 7">(7)</a> <a href="#ref-for-dfn-did-resolver-s-42" title="Reference 8">(8)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-resolver-s-43" title="§ 6.2.1 Proxied Resolution">§ 6.2.1 Proxied Resolution</a> <a href="#ref-for-dfn-did-resolver-s-44" title="Reference 2">(2)</a> <a href="#ref-for-dfn-did-resolver-s-45" title="Reference 3">(3)</a> <a href="#ref-for-dfn-did-resolver-s-46" title="Reference 4">(4)</a> <a href="#ref-for-dfn-did-resolver-s-47" title="Reference 5">(5)</a> <a href="#ref-for-dfn-did-resolver-s-48" title="Reference 6">(6)</a> <a href="#ref-for-dfn-did-resolver-s-49" title="Reference 7">(7)</a> <a href="#ref-for-dfn-did-resolver-s-50" title="Reference 8">(8)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-resolver-s-51" title="§ 6.2.2 Client-Side Dereferencing">§ 6.2.2 Client-Side Dereferencing</a> <a href="#ref-for-dfn-did-resolver-s-52" title="Reference 2">(2)</a> <a href="#ref-for-dfn-did-resolver-s-53" title="Reference 3">(3)</a> <a href="#ref-for-dfn-did-resolver-s-54" title="Reference 4">(4)</a> <a href="#ref-for-dfn-did-resolver-s-55" title="Reference 5">(5)</a> <a href="#ref-for-dfn-did-resolver-s-56" title="Reference 6">(6)</a> <a href="#ref-for-dfn-did-resolver-s-57" title="Reference 7">(7)</a> <a href="#ref-for-dfn-did-resolver-s-58" title="Reference 8">(8)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-resolver-s-59" title="§ 10.1 HTTP(S) Binding">§ 10.1 HTTP(S) Binding</a> <a href="#ref-for-dfn-did-resolver-s-60" title="Reference 2">(2)</a> <a href="#ref-for-dfn-did-resolver-s-61" title="Reference 3">(3)</a> <a href="#ref-for-dfn-did-resolver-s-62" title="Reference 4">(4)</a> <a href="#ref-for-dfn-did-resolver-s-63" title="Reference 5">(5)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-resolver-s-64" title="§ 10.2 DID Resolution Examples">§ 10.2 DID Resolution Examples</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-resolver-s-65" title="§ 12.2 Caching">§ 12.2 Caching</a> <a href="#ref-for-dfn-did-resolver-s-66" title="Reference 2">(2)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-resolver-s-67" title="§ 12.5 DID Method Governance">§ 12.5 DID Method Governance</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-did-resolution-result" aria-label="Links in this document to definition: DID resolution result">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-did-resolution-result" aria-label="Permalink for definition: DID resolution result. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-did-resolution-result-1" title="§ 6.2 Resolver Architectures">§ 6.2 Resolver Architectures</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-resolution-result-2" title="§ 7. DID Resolution Result">§ 7. DID Resolution Result</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-resolution-result-3" title="§ 10.1 HTTP(S) Binding">§ 10.1 HTTP(S) Binding</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-did-schemes" aria-label="Links in this document to definition: DID scheme">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-did-schemes" aria-label="Permalink for definition: DID scheme. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-did-schemes-1" title="§ 2. Terminology">§ 2. Terminology</a> <a href="#ref-for-dfn-did-schemes-2" title="Reference 2">(2)</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-did-subjects" aria-label="Links in this document to definition: DID subject">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-did-subjects" aria-label="Permalink for definition: DID subject. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-did-subjects-1" title="§ 2. Terminology">§ 2. Terminology</a> <a href="#ref-for-dfn-did-subjects-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-did-subjects-3" title="Reference 3">(3)</a> <a href="#ref-for-dfn-did-subjects-4" title="Reference 4">(4)</a> <a href="#ref-for-dfn-did-subjects-5" title="Reference 5">(5)</a> <a href="#ref-for-dfn-did-subjects-6" title="Reference 6">(6)</a> <a href="#ref-for-dfn-did-subjects-7" title="Reference 7">(7)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-subjects-8" title="§ 3.3 DID Document Metadata">§ 3.3 DID Document Metadata</a> <a href="#ref-for-dfn-did-subjects-9" title="Reference 2">(2)</a> <a href="#ref-for-dfn-did-subjects-10" title="Reference 3">(3)</a> <a href="#ref-for-dfn-did-subjects-11" title="Reference 4">(4)</a> <a href="#ref-for-dfn-did-subjects-12" title="Reference 5">(5)</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-did-urls" aria-label="Links in this document to definition: DID URL">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-did-urls" aria-label="Permalink for definition: DID URL. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-did-urls-1" title="§ 1. Introduction">§ 1. Introduction</a> <a href="#ref-for-dfn-did-urls-2" title="Reference 2">(2)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-urls-3" title="§ 2. Terminology">§ 2. Terminology</a> <a href="#ref-for-dfn-did-urls-4" title="Reference 2">(2)</a> <a href="#ref-for-dfn-did-urls-5" title="Reference 3">(3)</a> <a href="#ref-for-dfn-did-urls-6" title="Reference 4">(4)</a> <a href="#ref-for-dfn-did-urls-7" title="Reference 5">(5)</a> <a href="#ref-for-dfn-did-urls-8" title="Reference 6">(6)</a> <a href="#ref-for-dfn-did-urls-9" title="Reference 7">(7)</a> <a href="#ref-for-dfn-did-urls-10" title="Reference 8">(8)</a> <a href="#ref-for-dfn-did-urls-11" title="Reference 9">(9)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-urls-12" title="§ 4. DID URL Dereferencing">§ 4. DID URL Dereferencing</a> <a href="#ref-for-dfn-did-urls-13" title="Reference 2">(2)</a> <a href="#ref-for-dfn-did-urls-14" title="Reference 3">(3)</a> <a href="#ref-for-dfn-did-urls-15" title="Reference 4">(4)</a> <a href="#ref-for-dfn-did-urls-16" title="Reference 5">(5)</a> <a href="#ref-for-dfn-did-urls-17" title="Reference 6">(6)</a> <a href="#ref-for-dfn-did-urls-18" title="Reference 7">(7)</a> <a href="#ref-for-dfn-did-urls-19" title="Reference 8">(8)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-urls-20" title="§ 4.2 DID URL Dereferencing Metadata">§ 4.2 DID URL Dereferencing Metadata</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-urls-21" title="§ 4.3 Algorithm">§ 4.3 Algorithm</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-urls-22" title="§ 4.3.1 Dereferencing the Resource">§ 4.3.1 Dereferencing the Resource</a> <a href="#ref-for-dfn-did-urls-23" title="Reference 2">(2)</a> <a href="#ref-for-dfn-did-urls-24" title="Reference 3">(3)</a> <a href="#ref-for-dfn-did-urls-25" title="Reference 4">(4)</a> <a href="#ref-for-dfn-did-urls-26" title="Reference 5">(5)</a> <a href="#ref-for-dfn-did-urls-27" title="Reference 6">(6)</a> <a href="#ref-for-dfn-did-urls-28" title="Reference 7">(7)</a> <a href="#ref-for-dfn-did-urls-29" title="Reference 8">(8)</a> <a href="#ref-for-dfn-did-urls-30" title="Reference 9">(9)</a> <a href="#ref-for-dfn-did-urls-31" title="Reference 10">(10)</a> <a href="#ref-for-dfn-did-urls-32" title="Reference 11">(11)</a> <a href="#ref-for-dfn-did-urls-33" title="Reference 12">(12)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-urls-34" title="§ 4.3.2 Dereferencing the Fragment">§ 4.3.2 Dereferencing the Fragment</a> <a href="#ref-for-dfn-did-urls-35" title="Reference 2">(2)</a> <a href="#ref-for-dfn-did-urls-36" title="Reference 3">(3)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-urls-37" title="§ 4.4 Examples">§ 4.4 Examples</a> <a href="#ref-for-dfn-did-urls-38" title="Reference 2">(2)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-urls-39" title="§ 6.2.2 Client-Side Dereferencing">§ 6.2.2 Client-Side Dereferencing</a> <a href="#ref-for-dfn-did-urls-40" title="Reference 2">(2)</a> <a href="#ref-for-dfn-did-urls-41" title="Reference 3">(3)</a> <a href="#ref-for-dfn-did-urls-42" title="Reference 4">(4)</a> <a href="#ref-for-dfn-did-urls-43" title="Reference 5">(5)</a> <a href="#ref-for-dfn-did-urls-44" title="Reference 6">(6)</a> <a href="#ref-for-dfn-did-urls-45" title="Reference 7">(7)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-urls-46" title="§ 8.2 Content">§ 8.2 Content</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-urls-47" title="§ 10.1 HTTP(S) Binding">§ 10.1 HTTP(S) Binding</a> <a href="#ref-for-dfn-did-urls-48" title="Reference 2">(2)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-urls-49" title="§ 11.1 Input">§ 11.1 Input</a> <a href="#ref-for-dfn-did-urls-50" title="Reference 2">(2)</a> <a href="#ref-for-dfn-did-urls-51" title="Reference 3">(3)</a> <a href="#ref-for-dfn-did-urls-52" title="Reference 4">(4)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-urls-53" title="§ 11.2 Algorithm">§ 11.2 Algorithm</a> <a href="#ref-for-dfn-did-urls-54" title="Reference 2">(2)</a> <a href="#ref-for-dfn-did-urls-55" title="Reference 3">(3)</a> <a href="#ref-for-dfn-did-urls-56" title="Reference 4">(4)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-urls-57" title="§ 11.3 Example">§ 11.3 Example</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-did-url-dereferencing" aria-label="Links in this document to definition: DID URL dereferencing">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-did-url-dereferencing" aria-label="Permalink for definition: DID URL dereferencing. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-did-url-dereferencing-1" title="§ 1. Introduction">§ 1. Introduction</a> <a href="#ref-for-dfn-did-url-dereferencing-2" title="Reference 2">(2)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-url-dereferencing-3" title="§ 2. Terminology">§ 2. Terminology</a> <a href="#ref-for-dfn-did-url-dereferencing-4" title="Reference 2">(2)</a> <a href="#ref-for-dfn-did-url-dereferencing-5" title="Reference 3">(3)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-url-dereferencing-6" title="§ 4. DID URL Dereferencing">§ 4. DID URL Dereferencing</a> <a href="#ref-for-dfn-did-url-dereferencing-7" title="Reference 2">(2)</a> <a href="#ref-for-dfn-did-url-dereferencing-8" title="Reference 3">(3)</a> <a href="#ref-for-dfn-did-url-dereferencing-9" title="Reference 4">(4)</a> <a href="#ref-for-dfn-did-url-dereferencing-10" title="Reference 5">(5)</a> <a href="#ref-for-dfn-did-url-dereferencing-11" title="Reference 6">(6)</a> <a href="#ref-for-dfn-did-url-dereferencing-12" title="Reference 7">(7)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-url-dereferencing-13" title="§ 4.1 DID URL Dereferencing Options">§ 4.1 DID URL Dereferencing Options</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-url-dereferencing-14" title="§ 4.2 DID URL Dereferencing Metadata">§ 4.2 DID URL Dereferencing Metadata</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-url-dereferencing-15" title="§ 4.3 Algorithm">§ 4.3 Algorithm</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-url-dereferencing-16" title="§ 5. Metadata Structure">§ 5. Metadata Structure</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-url-dereferencing-17" title="§ 6.2 Resolver Architectures">§ 6.2 Resolver Architectures</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-url-dereferencing-18" title="§ 6.2.2 Client-Side Dereferencing">§ 6.2.2 Client-Side Dereferencing</a> <a href="#ref-for-dfn-did-url-dereferencing-19" title="Reference 2">(2)</a> <a href="#ref-for-dfn-did-url-dereferencing-20" title="Reference 3">(3)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-url-dereferencing-21" title="§ 8.3 DID URL Dereferencing Metadata">§ 8.3 DID URL Dereferencing Metadata</a> <a href="#ref-for-dfn-did-url-dereferencing-22" title="Reference 2">(2)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-url-dereferencing-23" title="§ 8.4 Content Metadata">§ 8.4 Content Metadata</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-url-dereferencing-24" title="§ 9.2 invalidDidUrl">§ 9.2 invalidDidUrl</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-url-dereferencing-25" title="§ 9.3 notFound">§ 9.3 notFound</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-url-dereferencing-26" title="§ 9.4 representationNotSupported">§ 9.4 representationNotSupported</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-url-dereferencing-27" title="§ 9.5 methodNotSupported">§ 9.5 methodNotSupported</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-url-dereferencing-28" title="§ 9.6 internalError">§ 9.6 internalError</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-url-dereferencing-29" title="§ 9.7 invalidPublicKey">§ 9.7 invalidPublicKey</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-url-dereferencing-30" title="§ 9.8 invalidPublicKeyLength">§ 9.8 invalidPublicKeyLength</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-url-dereferencing-31" title="§ 9.9 invalidPublicKeyType">§ 9.9 invalidPublicKeyType</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-url-dereferencing-32" title="§ 9.10 unsupportedPublicKeyType">§ 9.10 unsupportedPublicKeyType</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-url-dereferencing-33" title="§ 10.1 HTTP(S) Binding">§ 10.1 HTTP(S) Binding</a> <a href="#ref-for-dfn-did-url-dereferencing-34" title="Reference 2">(2)</a> <a href="#ref-for-dfn-did-url-dereferencing-35" title="Reference 3">(3)</a> <a href="#ref-for-dfn-did-url-dereferencing-36" title="Reference 4">(4)</a> <a href="#ref-for-dfn-did-url-dereferencing-37" title="Reference 5">(5)</a> <a href="#ref-for-dfn-did-url-dereferencing-38" title="Reference 6">(6)</a> <a href="#ref-for-dfn-did-url-dereferencing-39" title="Reference 7">(7)</a> <a href="#ref-for-dfn-did-url-dereferencing-40" title="Reference 8">(8)</a> <a href="#ref-for-dfn-did-url-dereferencing-41" title="Reference 9">(9)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-url-dereferencing-42" title="§ 11. Service Endpoint Construction">§ 11. Service Endpoint Construction</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-url-dereferencing-43" title="§ 12.1 Authentication/Authorization">§ 12.1 Authentication/Authorization</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-url-dereferencing-44" title="§ 13. Future Work">§ 13. Future Work</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-did-url-dereferencers" aria-label="Links in this document to definition: DID URL dereferencer">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-did-url-dereferencers" aria-label="Permalink for definition: DID URL dereferencer. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-did-url-dereferencers-1" title="§ 4.2 DID URL Dereferencing Metadata">§ 4.2 DID URL Dereferencing Metadata</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-url-dereferencers-2" title="§ 4.3.1 Dereferencing the Resource">§ 4.3.1 Dereferencing the Resource</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-did-url-dereferencing-result" aria-label="Links in this document to definition: DID URL dereferencing result">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-did-url-dereferencing-result" aria-label="Permalink for definition: DID URL dereferencing result. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-did-url-dereferencing-result-1" title="§ 8. DID URL Dereferencing Result">§ 8. DID URL Dereferencing Result</a> 
+    </li><li>
+      <a href="#ref-for-dfn-did-url-dereferencing-result-2" title="§ 10.1 HTTP(S) Binding">§ 10.1 HTTP(S) Binding</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-distributed-ledger-technology" aria-label="Links in this document to definition: distributed ledger">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-distributed-ledger-technology" aria-label="Permalink for definition: distributed ledger. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-distributed-ledger-technology-1" title="§ 2. Terminology">§ 2. Terminology</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-resources" aria-label="Links in this document to definition: resource">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-resources" aria-label="Permalink for definition: resource. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-resources-1" title="§ 2. Terminology">§ 2. Terminology</a> 
+    </li><li>
+      <a href="#ref-for-dfn-resources-2" title="§ 4. DID URL Dereferencing">§ 4. DID URL Dereferencing</a> <a href="#ref-for-dfn-resources-3" title="Reference 2">(2)</a> <a href="#ref-for-dfn-resources-4" title="Reference 3">(3)</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-representations" aria-label="Links in this document to definition: representation">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-representations" aria-label="Permalink for definition: representation. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-representations-1" title="§ 2. Terminology">§ 2. Terminology</a> 
+    </li><li>
+      <a href="#ref-for-dfn-representations-2" title="§ 3. DID Resolution">§ 3. DID Resolution</a> 
+    </li><li>
+      <a href="#ref-for-dfn-representations-3" title="§ 3.1 DID Resolution Options">§ 3.1 DID Resolution Options</a> <a href="#ref-for-dfn-representations-4" title="Reference 2">(2)</a> <a href="#ref-for-dfn-representations-5" title="Reference 3">(3)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-representations-6" title="§ 3.2 DID Resolution Metadata">§ 3.2 DID Resolution Metadata</a> <a href="#ref-for-dfn-representations-7" title="Reference 2">(2)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-representations-8" title="§ 4. DID URL Dereferencing">§ 4. DID URL Dereferencing</a> 
+    </li><li>
+      <a href="#ref-for-dfn-representations-9" title="§ 4.1 DID URL Dereferencing Options">§ 4.1 DID URL Dereferencing Options</a> <a href="#ref-for-dfn-representations-10" title="Reference 2">(2)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-representations-11" title="§ 5. Metadata Structure">§ 5. Metadata Structure</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-local-binding" aria-label="Links in this document to definition: local binding">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-local-binding" aria-label="Permalink for definition: local binding. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-local-binding-1" title="§ 2. Terminology">§ 2. Terminology</a> 
+    </li><li>
+      <a href="#ref-for-dfn-local-binding-2" title="§ 6.2 Resolver Architectures">§ 6.2 Resolver Architectures</a> <a href="#ref-for-dfn-local-binding-3" title="Reference 2">(2)</a> <a href="#ref-for-dfn-local-binding-4" title="Reference 3">(3)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-local-binding-5" title="§ 6.2.1 Proxied Resolution">§ 6.2.1 Proxied Resolution</a> <a href="#ref-for-dfn-local-binding-6" title="Reference 2">(2)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-local-binding-7" title="§ 6.2.2 Client-Side Dereferencing">§ 6.2.2 Client-Side Dereferencing</a> <a href="#ref-for-dfn-local-binding-8" title="Reference 2">(2)</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-remote-binding" aria-label="Links in this document to definition: remote binding">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-remote-binding" aria-label="Permalink for definition: remote binding. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-remote-binding-1" title="§ 2. Terminology">§ 2. Terminology</a> 
+    </li><li>
+      <a href="#ref-for-dfn-remote-binding-2" title="§ 6.2 Resolver Architectures">§ 6.2 Resolver Architectures</a> <a href="#ref-for-dfn-remote-binding-3" title="Reference 2">(2)</a> <a href="#ref-for-dfn-remote-binding-4" title="Reference 3">(3)</a> <a href="#ref-for-dfn-remote-binding-5" title="Reference 4">(4)</a> <a href="#ref-for-dfn-remote-binding-6" title="Reference 5">(5)</a> <a href="#ref-for-dfn-remote-binding-7" title="Reference 6">(6)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-remote-binding-8" title="§ 6.2.1 Proxied Resolution">§ 6.2.1 Proxied Resolution</a> <a href="#ref-for-dfn-remote-binding-9" title="Reference 2">(2)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-remote-binding-10" title="§ 6.2.2 Client-Side Dereferencing">§ 6.2.2 Client-Side Dereferencing</a> 
+    </li><li>
+      <a href="#ref-for-dfn-remote-binding-11" title="§ 10.1 HTTP(S) Binding">§ 10.1 HTTP(S) Binding</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-service" aria-label="Links in this document to definition: services">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-service" aria-label="Permalink for definition: services. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-service-1" title="§ 2. Terminology">§ 2. Terminology</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-service-endpoints" aria-label="Links in this document to definition: service endpoint">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-service-endpoints" aria-label="Permalink for definition: service endpoint. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-service-endpoints-1" title="§ 2. Terminology">§ 2. Terminology</a> <a href="#ref-for-dfn-service-endpoints-2" title="Reference 2">(2)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-service-endpoints-3" title="§ 4.3.1 Dereferencing the Resource">§ 4.3.1 Dereferencing the Resource</a> <a href="#ref-for-dfn-service-endpoints-4" title="Reference 2">(2)</a> <a href="#ref-for-dfn-service-endpoints-5" title="Reference 3">(3)</a> <a href="#ref-for-dfn-service-endpoints-6" title="Reference 4">(4)</a> <a href="#ref-for-dfn-service-endpoints-7" title="Reference 5">(5)</a> <a href="#ref-for-dfn-service-endpoints-8" title="Reference 6">(6)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-service-endpoints-9" title="§ 4.3.2 Dereferencing the Fragment">§ 4.3.2 Dereferencing the Fragment</a> <a href="#ref-for-dfn-service-endpoints-10" title="Reference 2">(2)</a> <a href="#ref-for-dfn-service-endpoints-11" title="Reference 3">(3)</a> <a href="#ref-for-dfn-service-endpoints-12" title="Reference 4">(4)</a> <a href="#ref-for-dfn-service-endpoints-13" title="Reference 5">(5)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-service-endpoints-14" title="§ 4.4 Examples">§ 4.4 Examples</a> 
+    </li><li>
+      <a href="#ref-for-dfn-service-endpoints-15" title="§ 6.2.2 Client-Side Dereferencing">§ 6.2.2 Client-Side Dereferencing</a> <a href="#ref-for-dfn-service-endpoints-16" title="Reference 2">(2)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-service-endpoints-17" title="§ 10.1 HTTP(S) Binding">§ 10.1 HTTP(S) Binding</a> 
+    </li><li>
+      <a href="#ref-for-dfn-service-endpoints-18" title="§ 11. Service Endpoint Construction">§ 11. Service Endpoint Construction</a> 
+    </li><li>
+      <a href="#ref-for-dfn-service-endpoints-19" title="§ 11.1 Input">§ 11.1 Input</a> <a href="#ref-for-dfn-service-endpoints-20" title="Reference 2">(2)</a> <a href="#ref-for-dfn-service-endpoints-21" title="Reference 3">(3)</a> <a href="#ref-for-dfn-service-endpoints-22" title="Reference 4">(4)</a> <a href="#ref-for-dfn-service-endpoints-23" title="Reference 5">(5)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-service-endpoints-24" title="§ 11.2 Algorithm">§ 11.2 Algorithm</a> <a href="#ref-for-dfn-service-endpoints-25" title="Reference 2">(2)</a> <a href="#ref-for-dfn-service-endpoints-26" title="Reference 3">(3)</a> <a href="#ref-for-dfn-service-endpoints-27" title="Reference 4">(4)</a> <a href="#ref-for-dfn-service-endpoints-28" title="Reference 5">(5)</a> <a href="#ref-for-dfn-service-endpoints-29" title="Reference 6">(6)</a> <a href="#ref-for-dfn-service-endpoints-30" title="Reference 7">(7)</a> <a href="#ref-for-dfn-service-endpoints-31" title="Reference 8">(8)</a> <a href="#ref-for-dfn-service-endpoints-32" title="Reference 9">(9)</a> <a href="#ref-for-dfn-service-endpoints-33" title="Reference 10">(10)</a> <a href="#ref-for-dfn-service-endpoints-34" title="Reference 11">(11)</a> <a href="#ref-for-dfn-service-endpoints-35" title="Reference 12">(12)</a> <a href="#ref-for-dfn-service-endpoints-36" title="Reference 13">(13)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-service-endpoints-37" title="§ 11.3 Example">§ 11.3 Example</a> <a href="#ref-for-dfn-service-endpoints-38" title="Reference 2">(2)</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-service-endpoint-construction" aria-label="Links in this document to definition: service endpoint construction">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-service-endpoint-construction" aria-label="Permalink for definition: service endpoint construction. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-service-endpoint-construction-1" title="§ 11. Service Endpoint Construction">§ 11. Service Endpoint Construction</a> 
+    </li><li>
+      <a href="#ref-for-dfn-service-endpoint-construction-2" title="§ 11.1 Input">§ 11.1 Input</a> <a href="#ref-for-dfn-service-endpoint-construction-3" title="Reference 2">(2)</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-unverifiable-read" aria-label="Links in this document to definition: unverifiable read">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-unverifiable-read" aria-label="Permalink for definition: unverifiable read. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-unverifiable-read-1" title="§ 6.1 Method Architectures">§ 6.1 Method Architectures</a> <a href="#ref-for-dfn-unverifiable-read-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-unverifiable-read-3" title="Reference 3">(3)</a> <a href="#ref-for-dfn-unverifiable-read-4" title="Reference 4">(4)</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-verifiable-data-registry" aria-label="Links in this document to definition: verifiable data registry">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-verifiable-data-registry" aria-label="Permalink for definition: verifiable data registry. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-verifiable-data-registry-1" title="§ 1. Introduction">§ 1. Introduction</a> 
+    </li><li>
+      <a href="#ref-for-dfn-verifiable-data-registry-2" title="§ 2. Terminology">§ 2. Terminology</a> <a href="#ref-for-dfn-verifiable-data-registry-3" title="Reference 2">(2)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-verifiable-data-registry-4" title="§ 3.3 DID Document Metadata">§ 3.3 DID Document Metadata</a> 
+    </li><li>
+      <a href="#ref-for-dfn-verifiable-data-registry-5" title="§ 3.4 Algorithm">§ 3.4 Algorithm</a> 
+    </li><li>
+      <a href="#ref-for-dfn-verifiable-data-registry-6" title="§ 6.1 Method Architectures">§ 6.1 Method Architectures</a> <a href="#ref-for-dfn-verifiable-data-registry-7" title="Reference 2">(2)</a> <a href="#ref-for-dfn-verifiable-data-registry-8" title="Reference 3">(3)</a> <a href="#ref-for-dfn-verifiable-data-registry-9" title="Reference 4">(4)</a> <a href="#ref-for-dfn-verifiable-data-registry-10" title="Reference 5">(5)</a> <a href="#ref-for-dfn-verifiable-data-registry-11" title="Reference 6">(6)</a> <a href="#ref-for-dfn-verifiable-data-registry-12" title="Reference 7">(7)</a> <a href="#ref-for-dfn-verifiable-data-registry-13" title="Reference 8">(8)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-verifiable-data-registry-14" title="§ 7.4 DID Document Metadata">§ 7.4 DID Document Metadata</a> <a href="#ref-for-dfn-verifiable-data-registry-15" title="Reference 2">(2)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-verifiable-data-registry-16" title="§ 12.2 Caching">§ 12.2 Caching</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-verification-method" aria-label="Links in this document to definition: verification method">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-verification-method" aria-label="Permalink for definition: verification method. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-verification-method-1" title="§ 2. Terminology">§ 2. Terminology</a> <a href="#ref-for-dfn-verification-method-2" title="Reference 2">(2)</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-verifiable-read" aria-label="Links in this document to definition: verifiable read">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-verifiable-read" aria-label="Permalink for definition: verifiable read. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-verifiable-read-1" title="§ 6.1 Method Architectures">§ 6.1 Method Architectures</a> <a href="#ref-for-dfn-verifiable-read-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-verifiable-read-3" title="Reference 3">(3)</a> <a href="#ref-for-dfn-verifiable-read-4" title="Reference 4">(4)</a> <a href="#ref-for-dfn-verifiable-read-5" title="Reference 5">(5)</a> <a href="#ref-for-dfn-verifiable-read-6" title="Reference 6">(6)</a> <a href="#ref-for-dfn-verifiable-read-7" title="Reference 7">(7)</a> <a href="#ref-for-dfn-verifiable-read-8" title="Reference 8">(8)</a> <a href="#ref-for-dfn-verifiable-read-9" title="Reference 9">(9)</a> <a href="#ref-for-dfn-verifiable-read-10" title="Reference 10">(10)</a> <a href="#ref-for-dfn-verifiable-read-11" title="Reference 11">(11)</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-didresolutionmetadata" aria-label="Links in this document to definition: didResolutionMetadata">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-didresolutionmetadata" aria-label="Permalink for definition: didResolutionMetadata. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-didresolutionmetadata-1" title="§ 3. DID Resolution">§ 3. DID Resolution</a> <a href="#ref-for-dfn-didresolutionmetadata-2" title="Reference 2">(2)</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-diddocument" aria-label="Links in this document to definition: didDocument">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-diddocument" aria-label="Permalink for definition: didDocument. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-diddocument-1" title="§ 3. DID Resolution">§ 3. DID Resolution</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-diddocumentstream" aria-label="Links in this document to definition: didDocumentStream">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-diddocumentstream" aria-label="Permalink for definition: didDocumentStream. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-diddocumentstream-1" title="§ 3. DID Resolution">§ 3. DID Resolution</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-diddocumentmetadata" aria-label="Links in this document to definition: didDocumentMetadata">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-diddocumentmetadata" aria-label="Permalink for definition: didDocumentMetadata. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-diddocumentmetadata-1" title="§ 3. DID Resolution">§ 3. DID Resolution</a> <a href="#ref-for-dfn-diddocumentmetadata-2" title="Reference 2">(2)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-diddocumentmetadata-3" title="§ 4. DID URL Dereferencing">§ 4. DID URL Dereferencing</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-created" aria-label="Links in this document to definition: created">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-created" aria-label="Permalink for definition: created. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+      <li>Not referenced in this document.</li>
+    </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-updated" aria-label="Links in this document to definition: updated">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-updated" aria-label="Permalink for definition: updated. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+      <li>Not referenced in this document.</li>
+    </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-deactivated" aria-label="Links in this document to definition: deactivated">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-deactivated" aria-label="Permalink for definition: deactivated. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+      <li>Not referenced in this document.</li>
+    </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-nextupdate" aria-label="Links in this document to definition: nextUpdate">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-nextupdate" aria-label="Permalink for definition: nextUpdate. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+      <li>Not referenced in this document.</li>
+    </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-versionid" aria-label="Links in this document to definition: versionId">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-versionid" aria-label="Permalink for definition: versionId. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+      <li>Not referenced in this document.</li>
+    </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-nextversionid" aria-label="Links in this document to definition: nextVersionId">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-nextversionid" aria-label="Permalink for definition: nextVersionId. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+      <li>Not referenced in this document.</li>
+    </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-equivalentid" aria-label="Links in this document to definition: equivalentId">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-equivalentid" aria-label="Permalink for definition: equivalentId. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-equivalentid-1" title="§ 3.3 DID Document Metadata">§ 3.3 DID Document Metadata</a> <a href="#ref-for-dfn-equivalentid-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-equivalentid-3" title="Reference 3">(3)</a> <a href="#ref-for-dfn-equivalentid-4" title="Reference 4">(4)</a> <a href="#ref-for-dfn-equivalentid-5" title="Reference 5">(5)</a> <a href="#ref-for-dfn-equivalentid-6" title="Reference 6">(6)</a> <a href="#ref-for-dfn-equivalentid-7" title="Reference 7">(7)</a> <a href="#ref-for-dfn-equivalentid-8" title="Reference 8">(8)</a> <a href="#ref-for-dfn-equivalentid-9" title="Reference 9">(9)</a> <a href="#ref-for-dfn-equivalentid-10" title="Reference 10">(10)</a> <a href="#ref-for-dfn-equivalentid-11" title="Reference 11">(11)</a> <a href="#ref-for-dfn-equivalentid-12" title="Reference 12">(12)</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-canonicalid" aria-label="Links in this document to definition: canonicalId">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-canonicalid" aria-label="Permalink for definition: canonicalId. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-canonicalid-1" title="§ 3.3 DID Document Metadata">§ 3.3 DID Document Metadata</a> <a href="#ref-for-dfn-canonicalid-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-canonicalid-3" title="Reference 3">(3)</a> <a href="#ref-for-dfn-canonicalid-4" title="Reference 4">(4)</a> <a href="#ref-for-dfn-canonicalid-5" title="Reference 5">(5)</a> <a href="#ref-for-dfn-canonicalid-6" title="Reference 6">(6)</a> <a href="#ref-for-dfn-canonicalid-7" title="Reference 7">(7)</a> <a href="#ref-for-dfn-canonicalid-8" title="Reference 8">(8)</a> <a href="#ref-for-dfn-canonicalid-9" title="Reference 9">(9)</a> <a href="#ref-for-dfn-canonicalid-10" title="Reference 10">(10)</a> 
+    </li>
+  </ul>
+    </div><script id="respec-dfn-panel">(() => {
+// @ts-check
+if (document.respec) {
+  document.respec.ready.then(setupPanel);
+} else {
+  setupPanel();
+}
+
+function setupPanel() {
+  const listener = panelListener();
+  document.body.addEventListener("keydown", listener);
+  document.body.addEventListener("click", listener);
+}
+
+function panelListener() {
+  /** @type {HTMLElement} */
+  let panel = null;
+  return event => {
+    const { target, type } = event;
+
+    if (!(target instanceof HTMLElement)) return;
+
+    // For keys, we only care about Enter key to activate the panel
+    // otherwise it's activated via a click.
+    if (type === "keydown" && event.key !== "Enter") return;
+
+    const action = deriveAction(event);
+
+    switch (action) {
+      case "show": {
+        hidePanel(panel);
+        /** @type {HTMLElement} */
+        const dfn = target.closest("dfn, .index-term");
+        panel = document.getElementById(`dfn-panel-for-${dfn.id}`);
+        const coords = deriveCoordinates(event);
+        displayPanel(dfn, panel, coords);
+        break;
+      }
+      case "dock": {
+        panel.style.left = null;
+        panel.style.top = null;
+        panel.classList.add("docked");
+        break;
+      }
+      case "hide": {
+        hidePanel(panel);
+        panel = null;
+        break;
+      }
+    }
+  };
+}
+
+/**
+ * @param {MouseEvent|KeyboardEvent} event
+ */
+function deriveCoordinates(event) {
+  const target = /** @type HTMLElement */ (event.target);
+
+  // We prevent synthetic AT clicks from putting
+  // the dialog in a weird place. The AT events sometimes
+  // lack coordinates, so they have clientX/Y = 0
+  const rect = target.getBoundingClientRect();
+  if (
+    event instanceof MouseEvent &&
+    event.clientX >= rect.left &&
+    event.clientY >= rect.top
+  ) {
+    // The event probably happened inside the bounding rect...
+    return { x: event.clientX, y: event.clientY };
+  }
+
+  // Offset to the middle of the element
+  const x = rect.x + rect.width / 2;
+  // Placed at the bottom of the element
+  const y = rect.y + rect.height;
+  return { x, y };
+}
+
+/**
+ * @param {Event} event
+ */
+function deriveAction(event) {
+  const target = /** @type {HTMLElement} */ (event.target);
+  const hitALink = !!target.closest("a");
+  if (target.closest("dfn:not([data-cite]), .index-term")) {
+    return hitALink ? "none" : "show";
+  }
+  if (target.closest(".dfn-panel")) {
+    if (hitALink) {
+      return target.classList.contains("self-link") ? "hide" : "dock";
+    }
+    const panel = target.closest(".dfn-panel");
+    return panel.classList.contains("docked") ? "hide" : "none";
+  }
+  if (document.querySelector(".dfn-panel:not([hidden])")) {
+    return "hide";
+  }
+  return "none";
+}
+
+/**
+ * @param {HTMLElement} dfn
+ * @param {HTMLElement} panel
+ * @param {{ x: number, y: number }} clickPosition
+ */
+function displayPanel(dfn, panel, { x, y }) {
+  panel.hidden = false;
+  // distance (px) between edge of panel and the pointing triangle (caret)
+  const MARGIN = 20;
+
+  const dfnRects = dfn.getClientRects();
+  // Find the `top` offset when the `dfn` can be spread across multiple lines
+  let closestTop = 0;
+  let minDiff = Infinity;
+  for (const rect of dfnRects) {
+    const { top, bottom } = rect;
+    const diffFromClickY = Math.abs((top + bottom) / 2 - y);
+    if (diffFromClickY < minDiff) {
+      minDiff = diffFromClickY;
+      closestTop = top;
+    }
+  }
+
+  const top = window.scrollY + closestTop + dfnRects[0].height;
+  const left = x - MARGIN;
+  panel.style.left = `${left}px`;
+  panel.style.top = `${top}px`;
+
+  // Find if the panel is flowing out of the window
+  const panelRect = panel.getBoundingClientRect();
+  const SCREEN_WIDTH = Math.min(window.innerWidth, window.screen.width);
+  if (panelRect.right > SCREEN_WIDTH) {
+    const newLeft = Math.max(MARGIN, x + MARGIN - panelRect.width);
+    const newCaretOffset = left - newLeft;
+    panel.style.left = `${newLeft}px`;
+    /** @type {HTMLElement} */
+    const caret = panel.querySelector(".caret");
+    caret.style.left = `${newCaretOffset}px`;
+  }
+
+  // As it's a dialog, we trap focus.
+  // TODO: when <dialog> becomes a implemented, we should really
+  // use that.
+  trapFocus(panel, dfn);
+}
+
+/**
+ * @param {HTMLElement} panel
+ * @param {HTMLElement} dfn
+ * @returns
+ */
+function trapFocus(panel, dfn) {
+  /** @type NodeListOf<HTMLAnchorElement> elements */
+  const anchors = panel.querySelectorAll("a[href]");
+  // No need to trap focus
+  if (!anchors.length) return;
+
+  // Move focus to first anchor element
+  const first = anchors.item(0);
+  first.focus();
+
+  const trapListener = createTrapListener(anchors, panel, dfn);
+  panel.addEventListener("keydown", trapListener);
+
+  // Hiding the panel releases the trap
+  const mo = new MutationObserver(records => {
+    const [record] = records;
+    const target = /** @type HTMLElement */ (record.target);
+    if (target.hidden) {
+      panel.removeEventListener("keydown", trapListener);
+      mo.disconnect();
+    }
+  });
+  mo.observe(panel, { attributes: true, attributeFilter: ["hidden"] });
+}
+
+/**
+ *
+ * @param {NodeListOf<HTMLAnchorElement>} anchors
+ * @param {HTMLElement} panel
+ * @param {HTMLElement} dfn
+ * @returns
+ */
+function createTrapListener(anchors, panel, dfn) {
+  const lastIndex = anchors.length - 1;
+  let currentIndex = 0;
+  return event => {
+    switch (event.key) {
+      // Hitting "Tab" traps us in a nice loop around elements.
+      case "Tab": {
+        event.preventDefault();
+        currentIndex += event.shiftKey ? -1 : +1;
+        if (currentIndex < 0) {
+          currentIndex = lastIndex;
+        } else if (currentIndex > lastIndex) {
+          currentIndex = 0;
+        }
+        anchors.item(currentIndex).focus();
+        break;
+      }
+
+      // Hitting "Enter" on an anchor releases the trap.
+      case "Enter":
+        hidePanel(panel);
+        break;
+
+      // Hitting "Escape" returns focus to dfn.
+      case "Escape":
+        hidePanel(panel);
+        dfn.focus();
+        return;
+    }
+  };
+}
+
+/** @param {HTMLElement} panel */
+function hidePanel(panel) {
+  if (!panel) return;
+  panel.hidden = true;
+  panel.classList.remove("docked");
+}
+})()</script><script src="https://www.w3.org/scripts/TR/2021/fixup.js"></script></body></html>

--- a/index.html
+++ b/index.html
@@ -1840,12 +1840,12 @@ https://example.com/messages/8377464/some/path?query#frag
 			can be executed as follows:</p>
 
 		<ol class="algorithm">
-			<li>Initialize a <var>request HTTP(S) URL</var> with the <var><a>DID resolver</a> HTTP(S) endpoint</var>.</li>
-			<pre class="example nohighlight">https://dev.uniresolver.io/1.0/identifiers/</pre>
+			<li>Initialize a <var>request HTTP(S) URL</var> with the <var><a>DID resolver</a> HTTP(S) endpoint</var>.
+			<pre class="example nohighlight">https://dev.uniresolver.io/1.0/identifiers/</pre></li>
 			<li>For the <a>DID resolution</a> function:
 				<ol class="algorithm">
-					<li>Append the <var>input <a>DID</a></var> to the <var>request HTTP(S) URL</var>.</li>
-					<pre class="example nohighlight">https://dev.uniresolver.io/1.0/identifiers/did:example:1234</pre>
+					<li>Append the <var>input <a>DID</a></var> to the <var>request HTTP(S) URL</var>.
+					<pre class="example nohighlight">https://dev.uniresolver.io/1.0/identifiers/did:example:1234</pre></li>
 					<li>Set the <code>Accept</code> <var>HTTP request header</var> to `application/ld+json;profile="https://w3id.org/did-resolution"`
 						in order to request a complete <a href="#did-resolution-result"></a>, OR</li>
 					<li>set the <code>Accept</code> <var>HTTP request header</var> to the value of the <b>accept</b> <var>resolution option</var>.</li>
@@ -1854,16 +1854,16 @@ https://example.com/messages/8377464/some/path?query#frag
 							<li>The <var>input <a>DID</a></var> MUST be URL-encoded (as specified in <a
 									data-cite="RFC3986#section-2.1">RFC3986 Section 2.1</a>).</li>
 							<li>Encode all <var>resolution options</var> except <b>accept</b> as
-								query parameters in the <var>request HTTP(S) URL</var>.</li>
-							<pre class="example nohighlight">https://dev.uniresolver.io/1.0/identifiers/did%3Aexample%3A1234?option1=value1&option2=value2</pre>
+								query parameters in the <var>request HTTP(S) URL</var>.
+							<pre class="example nohighlight">https://dev.uniresolver.io/1.0/identifiers/did%3Aexample%3A1234?option1=value1&option2=value2</pre></li>
 						</ol>
 					</li>
 				</ol>
 			</li>
 			<li>For the <a>DID URL dereferencing</a> function:
 				<ol class="algorithm">
-					<li>Append the <var>input <a>DID URL</a></var> to the <var>request HTTP(S) URL</var>.</li>
-					<pre class="example nohighlight">https://dev.uniresolver.io/1.0/identifiers/did:example:1234?service=files&relativeRef=/resume.pdf</pre>
+					<li>Append the <var>input <a>DID URL</a></var> to the <var>request HTTP(S) URL</var>.
+					<pre class="example nohighlight">https://dev.uniresolver.io/1.0/identifiers/did:example:1234?service=files&relativeRef=/resume.pdf</pre></li>
 					<li>Set the <code>Accept</code> <var>HTTP request header</var> to `application/ld+json;profile="https://w3id.org/did-url-dereferencing"`
 						in order to request a complete <a href="#did-url-dereferencing-result"></a>, OR</li>
 					<li>set the <code>Accept</code> <var>HTTP request header</var> to the value of the <b>accept</b> <var>dereferencing option</var>.</li>
@@ -1872,8 +1872,8 @@ https://example.com/messages/8377464/some/path?query#frag
 							<li>The <var>input <a>DID URL</a></var> MUST be URL-encoded (as specified in <a
 									data-cite="RFC3986#section-2.1">RFC3986 Section 2.1</a>).</li>
 							<li>Encode all <var>dereferencing options</var> except <b>accept</b> as
-								query parameters in the <var>request HTTP(S) URL</var>.</li>
-							<pre class="example nohighlight">https://dev.uniresolver.io/1.0/identifiers/did%3Aexample%3A1234%3Fservice%3Dfiles%26relativeRef%3D%2Fresume.pdf?option1=value1&option2=value2</pre>
+								query parameters in the <var>request HTTP(S) URL</var>.
+							<pre class="example nohighlight">https://dev.uniresolver.io/1.0/identifiers/did%3Aexample%3A1234%3Fservice%3Dfiles%26relativeRef%3D%2Fresume.pdf?option1=value1&option2=value2</pre></li>
 						</ol>
 					</li>
 				</ol>

--- a/index.html
+++ b/index.html
@@ -1828,32 +1828,60 @@ https://example.com/messages/8377464/some/path?query#frag
 	<section id="bindings-https">
 		<h2>HTTP(S) Binding</h2>
 		<p>This section defines a <a>DID resolver</a> <a>binding</a> which exposes the
-		<a>DID resolution</a> and/or <a>DID URL dereferencing</a> functions (including all
-		resolution options and output data) via an HTTP(S) endpoint. See <a href="#resolver-architectures"></a>.</p>
+			<a>DID resolution</a> and/or <a>DID URL dereferencing</a> functions (including all
+			resolution/dereferencing options and metadata) via an HTTP(S) endpoint. See <a href="#resolver-architectures"></a>.</p>
 
-		<p>The HTTP(S) binding for <a>DID resolvers</a> requires a known HTTP(S) URL called the
-		<var><a>DID resolver</a> HTTP(S) endpoint</var>.</p>
+		<p>The HTTP(S) binding is a <a>remote binding</a>. It requires a known HTTP(S) URL where a remote
+			<a>DID resolver</a> can be invoked. This URL is called <var><a>DID resolver</a> HTTP(S) endpoint</var></p>
+
 		<p>Using this binding, the <a>DID resolution</a> function (see
-		<a href="#resolving"></a>) and/or <a>DID URL dereferencing</a> function (see <a href="#dereferencing"></a>)
-		can be executed as follows:</p>
+			<a href="#resolving"></a>) and/or <a>DID URL dereferencing</a> function (see <a href="#dereferencing"></a>)
+			can be executed as follows:</p>
+
 		<ol class="algorithm">
-			<li>Initialize a <var>request HTTP(S) URL</var> with the <var><a>DID resolver</a> HTTP(S) endpoint</var>.
-			<ol class="algorithm">
-				<li>Append the <var>input <a>DID</a></var> or
-				<var>input <a>DID URL</a></var> to the <var>request HTTP(S) URL</var>. Certain characters
-				MUST be percent-encoded (as specified in <a
-data-cite="RFC3986#section-2.1">RFC3986 Section 2.1</a>).</li>
-				<li>Encode the <code>accept</code> <var>resolution option</var>
-					as the <code>Accept</code> HTTP header in the request.</li>
-				<li>Encode all other resolution options as
-				query parameters in the <var>request HTTP(S) URL</var>.</li>
-			</ol>
+			<li>Initialize a <var>request HTTP(S) URL</var> with the <var><a>DID resolver</a> HTTP(S) endpoint</var>.</li>
+			<pre class="example nohighlight">https://dev.uniresolver.io/1.0/identifiers/</pre>
+			<li>For the <a>DID resolution</a> function:
+				<ol class="algorithm">
+					<li>Append the <var>input <a>DID</a></var> to the <var>request HTTP(S) URL</var>.</li>
+					<pre class="example nohighlight">https://dev.uniresolver.io/1.0/identifiers/did:example:1234</pre>
+					<li>Set the <code>Accept</code> <var>HTTP request header</var> to `application/ld+json;profile="https://w3id.org/did-resolution"`
+						in order to request a complete <a href="#did-resolution-result"></a>, OR</li>
+					<li>set the <code>Accept</code> <var>HTTP request header</var> to the value of the <b>accept</b> <var>resolution option</var>.</li>
+					<li>If any other <var>resolution options</var> are provided:
+						<ol class="algorithm">
+							<li>The <var>input <a>DID</a></var> MUST be URL-encoded (as specified in <a
+									data-cite="RFC3986#section-2.1">RFC3986 Section 2.1</a>).</li>
+							<li>Encode all <var>resolution options</var> except <b>accept</b> as
+								query parameters in the <var>request HTTP(S) URL</var>.</li>
+							<pre class="example nohighlight">https://dev.uniresolver.io/1.0/identifiers/did%3Aexample%3A1234?option1=value1&option2=value2</pre>
+						</ol>
+					</li>
+				</ol>
 			</li>
-			<li>Execute an HTTP <code>GET</code> request on the <var>request HTTP(S) URL</var>.</li>
-			<li>Dereference the <var>input <a>DID</a></var> or <var>input <a>DID URL</a></var> by executing the
-				<a>DID URL dereferencing</a> algorithm as defined in <a href="#dereferencing"></a></li>
-			<li>If the output of the <a>DID URL dereferencing</a> function contains the <b>dereferencingMetadata</b> property <b>error</b>,
-				then the HTTP response status code MUST be set to the value that corresponds to the value of the <b>error</b> property,
+			<li>For the <a>DID URL dereferencing</a> function:
+				<ol class="algorithm">
+					<li>Append the <var>input <a>DID URL</a></var> to the <var>request HTTP(S) URL</var>.</li>
+					<pre class="example nohighlight">https://dev.uniresolver.io/1.0/identifiers/did:example:1234?service=files&relativeRef=/resume.pdf</pre>
+					<li>Set the <code>Accept</code> <var>HTTP request header</var> to `application/ld+json;profile="https://w3id.org/did-url-dereferencing"`
+						in order to request a complete <a href="#did-url-dereferencing-result"></a>, OR</li>
+					<li>set the <code>Accept</code> <var>HTTP request header</var> to the value of the <b>accept</b> <var>dereferencing option</var>.</li>
+					<li>If any other <var>dereferencing options</var> are provided:
+						<ol class="algorithm">
+							<li>The <var>input <a>DID URL</a></var> MUST be URL-encoded (as specified in <a
+									data-cite="RFC3986#section-2.1">RFC3986 Section 2.1</a>).</li>
+							<li>Encode all <var>dereferencing options</var> except <b>accept</b> as
+								query parameters in the <var>request HTTP(S) URL</var>.</li>
+							<pre class="example nohighlight">https://dev.uniresolver.io/1.0/identifiers/did%3Aexample%3A1234%3Fservice%3Dfiles%26relativeRef%3D%2Fresume.pdf?option1=value1&option2=value2</pre>
+						</ol>
+					</li>
+				</ol>
+			</li>
+			<li>Execute an HTTP <code>GET</code> request on the <var>request HTTP(S) URL</var>. This invokes the <a>DID resolution</a> or
+				<a>DID URL dereferencing</a> function at the remote <a>DID resolver</a>.</li>
+			<li>If the <a>DID resolution</a> or <a>DID URL dereferencing</a> function returns an <b>error</b> metadata property in the
+				<b>didResolutionMetadata</b> or <b>dereferencingMetadata</b>,
+				then the HTTP response status code MUST correspond to the value of the <b>error</b> metadata property,
 				according to the following table:
 				<table class="simple">
 					<thead>
@@ -1926,59 +1954,62 @@ data-cite="RFC3986#section-2.1">RFC3986 Section 2.1</a>).</li>
 					</tbody>
 				</table>
 			</li>
-			<li>If the output of the <a>DID URL dereferencing</a> function contains the <b>didDocumentMetadata</b> property <b>deactivated</b> with value <b>true</b>:
+			<li>If the <a>DID resolution</a> or <a>DID URL dereferencing</a> function returns a <b>deactivated</b> metadata property with
+				the value <code>true</code> in the <b>didDocumentMetadata</b> or <b>contentMetadata</b>:
 				<ol class="algorithm">
 					<li>The HTTP response status code MUST be <code>410</code>.</li>
 				</ol>
 			</li>
-			<li>If the output of the <a>DID URL dereferencing</a> function contains the <b>didDocumentStream</b>:
+			<li>For the <a>DID resolution</a> function:
 				<ol class="algorithm">
-					<li>If the value of the <code>Accept</code> HTTP header is absent or `application/did+ld+json` (or other media type of a conformant representation of a <a>DID document</a>):
-					<ol class="algorithm">
-						<li>The HTTP response status code MUST be <code>200</code>.</li>
-						<li>The HTTP response MUST contain a <code>Content-Type</code> header. The
-						value of this header MUST be `application/did+ld+json` (or other media type of a conformant representation of a <a>DID document</a>).</li>
-						<li>The HTTP response body MUST contain the <b>didDocumentStream</b>, in the representation corresponding to the <code>Accept</code> HTTP header.</li>
-					</ol>
+					<li>If the value of the <code>Content-Type</code> <var>HTTP response header</var> is `application/ld+json;profile="https://w3id.org/did-resolution"`:
+						<ol class="algorithm">
+							<li>The <var>HTTP body</var> MUST contain a <a>DID resolution result</a> (see <a href="#did-resolution-result"></a>) that
+								is the result of the <a>DID resolution</a> function.</li>
+						</ol>
 					</li>
-					<li>If the value of the <code>Accept</code> HTTP header is `application/ld+json;profile="https://w3id.org/did-resolution"`:
-					<ol class="algorithm">
-						<li>Produce a <a>DID resolution result</a> (see (see <a href="#did-resolution-result"></a>) and populate it with the <b>didDocumentStream</b>,
-							<b>didResolutionMetadata</b>, and <b>didDocumentMetadata</b> that are the output of the
-							<a>DID resolution</a> function.</li>
-						<li>The HTTP response status code MUST be <code>200</code>.</li>
-						<li>The HTTP response MUST contain a <code>Content-Type</code> header. The
-							value of this header MUST be `application/ld+json;profile="https://w3id.org/did-resolution"`.</li>
-						<li>The HTTP response body MUST contain the produced <a>DID resolution result</a>.</li>
-					</ol>
+					<li>If the function is successful and returns a <b>didDocument</b>:
+						<ol class="algorithm">
+							<li>The HTTP response status code MUST be <code>200</code>.</li>
+							<li>The HTTP response MUST contain a <code>Content-Type</code> <var>HTTP response header</var>. Its value MUST be the value of the
+								<b>contentType</b> metadata property in the <b>didResolutionMetadata</b> (see <a href="#did-resolution-metadata"></a>).</li>
+							<li>The HTTP response body MUST contain the <b>didDocument</b> that is the result of the
+								<a>DID resolution</a> function, in the representation corresponding to the <code>Content-Type</code> <var>HTTP response header</var>.</li>
+						</ol>
 					</li>
 				</ol>
 			</li>
-			<li>If the output of the <a>DID URL dereferencing</a> function is a <a>service endpoint</a> URL:
-			<ol class="algorithm">
-				<li>The HTTP response status code MUST be <code>303</code>.</li>
-				<li>The HTTP response MUST contain an <code>Location</code> header. The value of this header
-				MUST be the <var>output <a>service endpoint</a> URL</a></var>.</li>
-			</ol>
+			<li>For the <a>DID URL dereferencing</a> function:
+				<ol class="algorithm">
+					<li>If the value of the <code>Content-Type</code> <var>HTTP response header</var> is `application/ld+json;profile="https://w3id.org/did-url-dereferencing"`:
+						<ol class="algorithm">
+							<li>The <var>HTTP body</var> MUST contain a <a>DID URL dereferencing result</a> (see <a href="#did-url-dereferencing-result"></a>) that
+								is the result of the <a>DID URL dereferencing</a> function.</li>
+						</ol>
+					</li>
+					<li>If the function is successful and returns a <b>contentStream</b> and a <b>contentType</b> metadata property with the value <code>text/uri-list</code> in the <b>dereferencingMetadata</b>:
+						<ol class="algorithm">
+							<li>The HTTP response status code MUST be <code>303</code>.</li>
+							<li>The HTTP response MUST contain an <code>Location</code> header. The value of this header
+								MUST be the <var>output <a>service endpoint</a> URL</var>.</li>
+							<li>the HTTP response body MUST be empty.</li>
+						</ol>
+					</li>
+					<li>If the function is successful and returns a <b>contentStream</b> with any other <b>contentType</b>:
+						<ol class="algorithm">
+							<li>The HTTP response status code MUST be <code>200</code>.</li>
+							<li>The HTTP response MUST contain a <code>Content-Type</code> <var>HTTP response header</var>. Its value MUST be the value of the
+								<b>contentType</b> metadata property in the <b>dereferencingMetadata</b> (see <a href="#did-url-dereferencing-metadata"></a>).</li>
+							<li>The HTTP response body MUST contain the <b>contentStream</b> that is the result of the
+								<a>DID URL dereferencing</a> function, in the representation corresponding to the <code>Content-Type</code> <var>HTTP response header</var>.</li>
+						</ol>
+					</li>
+				</ol>
 			</li>
 		</ol>
 
 		<div>
 			<p>See <a href="https://github.com/decentralized-identity/universal-resolver/blob/main/openapi/openapi.yaml">here</a> for an OpenAPI definition.</p>
-		</div>
-
-		<div class="issue">
-			<p>TODO: Review HTTP(S) binding for <a>DID resolution</a> and <a>DID URL dereferencing</a>,
-			including the following topics:</p>
-			<ul>
-				<li>How are <var>resolution options</var> passed via HTTP(S)? Using the query string and/or HTTP headers?</li>
-				<li>How is the output data (<a>DID document</a>, <a>DID resolution result</a>) returned via HTTP(S)?</li>
-				<li>How should <code>Accept</code> and <code>Content-Type</code> HTTP headers be used? How are
-				the <code>resolve()</code> and <code>resolveRepresentation()</code> functions called? See <a href="https://github.com/w3c/did-core/issues/417">
-				this issue</a> for a discussion.</li>
-				<li>Are two separate HTTP(S) endpoints required/allowed for the <code>resolve()</code> and
-				<code>dereference()</code> functions, or can/must a single HTTP(S) endpoint be used?</li>
-			</ul>
 		</div>
 
 	</section>

--- a/index.html
+++ b/index.html
@@ -1101,12 +1101,13 @@ dereference(didUrl, dereferenceOptions) →
 					<var>input <a>DID URL</a></var>.</li>
 					<li>Return the <var>output <a>service endpoint</a> URL</var>.</li>
 				</ol>
+				</li>
 				<li>Otherwise, dereference the DID fragment as defined by the media type ([[RFC2046]]) of the resource.
 				For example, if the resource is a representation of a DID document with media type <code>application/did</code>, then
 				the fragment is treated according to the rules associated with the
 				<a href="https://www.w3.org/TR/json-ld11/#iana-considerations">JSON-LD 1.1: application/ld+json media type</a>
 				[JSON-LD11].
-			</li>
+				</li>
 			</ol>
 
 			<p class="note">

--- a/index.html
+++ b/index.html
@@ -1832,7 +1832,7 @@ https://example.com/messages/8377464/some/path?query#frag
 			resolution/dereferencing options and metadata) via an HTTP(S) endpoint. See <a href="#resolver-architectures"></a>.</p>
 
 		<p>The HTTP(S) binding is a <a>remote binding</a>. It requires a known HTTP(S) URL where a remote
-			<a>DID resolver</a> can be invoked. This URL is called <var><a>DID resolver</a> HTTP(S) endpoint</var></p>
+			<a>DID resolver</a> can be invoked. This URL is called the <var><a>DID resolver</a> HTTP(S) endpoint</var></p>
 
 		<p>Using this binding, the <a>DID resolution</a> function (see
 			<a href="#resolving"></a>) and/or <a>DID URL dereferencing</a> function (see <a href="#dereferencing"></a>)


### PR DESCRIPTION
This PR adds some details on how the HTTP(S) binding works, i.e. how the resolve() and dereference() functions can be invoked via an HTTP(S) endpoint, and how resolution options, metadata, status codes, etc. are handled.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-resolution/pull/108.html" title="Last updated on Jan 22, 2025, 6:50 PM UTC (d41aaba)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-resolution/108/c982825...d41aaba.html" title="Last updated on Jan 22, 2025, 6:50 PM UTC (d41aaba)">Diff</a>