### PR TITLE
Add versionId and versionTime to DID resolution options

### DIFF
--- a/index.html
+++ b/index.html
@@ -587,6 +587,29 @@ string">ASCII string</a>. The <a>DID resolver</a> implementation SHOULD use this
 				function and MUST NOT be used with the <code>resolve</code> function.
 			</dd>
 		</dl>
+		<dl>
+			<dt>versionId</dt>
+			<dd>
+				Identifies a specific version of a <a>DID document</a> to be resolved (the
+				version ID could be sequential, or a <a>UUID</a>, or method-specific).
+				If present, the associated value MUST be an <a
+					data-lt="ascii string">ASCII string</a>.
+			</dd>
+		</dl>
+		<dl>
+			<dt>versionTime</dt>
+			<dd>
+				Identifies a certain version timestamp of a <a>DID document</a> to be resolved.
+				That is, the <a>DID document</a> that was valid for a <a>DID</a> at a certain
+				time. If present, the associated value
+				MUST be an <a data-lt="ascii string">ASCII string</a> which is a valid XML
+				datetime value, as defined in section 3.3.7 of <a
+					href="https://www.w3.org/TR/xmlschema11-2/">W3C XML Schema Definition Language
+				(XSD) 1.1 Part 2: Datatypes</a> [[XMLSCHEMA11-2]]. This datetime value MUST be
+				normalized to UTC 00:00:00 and without sub-second decimal precision.
+				For example: <code>2020-12-20T19:17:47Z</code>.
+			</dd>
+		</dl>
 	</section>
 
 	<section>


### PR DESCRIPTION
This is to address part of the issue raised in #66 

I have just copied the definitions from DID parameters section - https://w3c.github.io/did-resolution/#did-parameters

Is there a better way to do this. I suppose I could just put some text like:

`See description of the versionId parameter in https://w3c.github.io/did-resolution/#did-parameters`