### PR TITLE
Pass all dereferencing options to resolution algorithm.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1211,6 +1211,7 @@ dereference(didUrl, dereferenceOptions) →
 				</li>
 				<li>Obtain the <a>DID document</a> for the <var>input <a>DID</a></var> by executing the
 					<a>DID resolution</a> algorithm as defined in <a href="#resolving"></a>. All
+					<var>dereferencing options</var> and all
 					<a href="https://www.w3.org/TR/did-core/#did-parameters">
 						DID parameters</a> of the <var>input <a>DID URL</a></var> MUST be passed as <var>resolution options</var> to the
 						<a>DID Resolution</a> algorithm.</li>
@@ -1240,21 +1241,6 @@ dereference(didUrl, dereferenceOptions) →
 					<pre class="example nohighlight">did:example:1234?hl=zQmWvQxTqbG2Z9HPJgG57jjwR154cKhbtJenbyYTWkjgF3e</pre>
 					<ol class="algorithm"><li>
 						<p class="issue">TODO: Specify the algorithm for processing the `hl` DID parameter.</p>
-					</li></ol>
-				</li>
-				<li>If the <var>input <a>DID URL</a></var> contains the
-					<a href="https://www.w3.org/TR/did-core/#did-parameters">DID parameter</a> <code>versionId</code>:
-					<pre class="example nohighlight">did:example:1234?versionId=1</pre>
-					<ol class="algorithm"><li>
-						<p class="issue">TODO: Specify the algorithm for processing the `versionId` DID parameter.</p>
-					</li></ol>
-				</li>
-
-				<li>If the <var>input <a>DID URL</a></var> contains the
-					<a href="https://www.w3.org/TR/did-core/#did-parameters">DID parameter</a> <code>versionTime</code>:
-					<pre class="example nohighlight">did:example:1234?versionTime=2021-05-10T17:00:00Z</pre>
-					<ol class="algorithm"><li>
-						<p class="issue">TODO: Specify the algorithm for processing the `versionTime` DID parameter.</p>
 					</li></ol>
 				</li>
 				<li>If the <var>input <a>DID URL</a></var> contains the


### PR DESCRIPTION
This clarifies that the derefencing algorithm passes dereferencing options and DID parameters as resolution options to the DID Resolution algorithm.

This also means that the `versionId` and `versionTime` DID parameters don't have to be mentioned as part of the dereferencing algorithm.

Addresses https://github.com/w3c/did-resolution/issues/127.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-resolution/pull/129.html" title="Last updated on Feb 27, 2025, 9:58 PM UTC (096763e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-resolution/129/0c2fb34...096763e.html" title="Last updated on Feb 27, 2025, 9:58 PM UTC (096763e)">Diff</a>