### PR TITLE
Migrate errors to use problem details

### DIFF
--- a/index.html
+++ b/index.html
@@ -2153,6 +2153,14 @@ The `detail` value SHOULD provide a longer human-readable string for the error.
 							<code>400</code>
 						</td>
 					</tr>
+          <tr>
+						<td>
+							<code>INVALID_OPTIONS</code>
+						</td>
+						<td>
+							<code>400</code>
+						</td>
+					</tr>
 					<tr>
 						<td>
 							<code>NOT_FOUND</code>
@@ -2169,9 +2177,49 @@ The `detail` value SHOULD provide a longer human-readable string for the error.
 							<code>406</code>
 						</td>
 					</tr>
+          <tr>
+						<td>
+							<code>INVALID_DID_DOCUMENT</code>
+						</td>
+						<td>
+							<code>500</code>
+						</td>
+					</tr>
 					<tr>
 						<td>
 							<code>METHOD_NOT_SUPPORTED</code>
+						</td>
+						<td>
+							<code>501</code>
+						</td>
+					</tr>
+          <tr>
+						<td>
+							<code>INVALID_PUBLIC_KEY</code>
+						</td>
+						<td>
+							<code>500</code>
+						</td>
+					</tr>
+          <tr>
+						<td>
+							<code>INVALID_PUBLIC_KEY_LENGTH</code>
+						</td>
+						<td>
+							<code>500</code>
+						</td>
+					</tr>
+          <tr>
+						<td>
+							<code>INVALID_PUBLIC_KEY_TYPE</code>
+						</td>
+						<td>
+							<code>500</code>
+						</td>
+					</tr>
+          <tr>
+						<td>
+							<code>UNSUPPORTED_PUBLIC_KEY_TYPE</code>
 						</td>
 						<td>
 							<code>501</code>
@@ -2185,6 +2233,7 @@ The `detail` value SHOULD provide a longer human-readable string for the error.
 							<code>500</code>
 						</td>
 					</tr>
+          
 					<tr>
 						<td>
 							(any other value)

--- a/index.html
+++ b/index.html
@@ -460,7 +460,7 @@ resolve(did, resolutionOptions) →
 			error in the resolution process, this MUST NOT be empty. This metadata is
 			defined by <a href="#did-resolution-metadata"></a>. If the resolution is
 			not successful, this structure MUST contain an <code>error</code> property
-			describing the error.
+			describing the error. See Section <a href="#errors"></a>.
 		</dd>
 		<dt>
 			<dfn>didDocument</dfn>

--- a/index.html
+++ b/index.html
@@ -2025,18 +2025,6 @@ The `detail` value SHOULD provide a longer human-readable string for the error.
 		<dd>
             The [=DID document=] was malformed. See Section <a href="#resolving-algorithm"></a>.
 		</dd>
-		<!-- <dt id="INVALID_VERIFICATION_METHOD">INVALID_VERIFICATION_METHOD</dt>
-		<dd>
-The [=verification method=] in a [=controlled identifier document=] was malformed. See Section
-[[[#retrieve-verification-method]]].
-		</dd>
-		<dt id="INVALID_RELATIONSHIP_FOR_VERIFICATION_METHOD">INVALID_RELATIONSHIP_FOR_VERIFICATION_METHOD</dt>
-		<dd>
-The [=verification method=] in a [=controlled identifier document=] was not
-associated using the expected [=verification relationship=] as expressed in
-the `proofPurpose` property in the [=proof=]. See Section
-[[[#retrieve-verification-method]]].
-		</dd> -->
         <dt id="NOT_FOUND">NOT_FOUND</dt>
 		<dd>
             The <a>DID resolver</a> was unable to find the <a>DID document</a>
@@ -2056,6 +2044,10 @@ the `proofPurpose` property in the [=proof=]. See Section
         <dt id="METHOD_NOT_SUPPORTED">METHOD_NOT_SUPPORTED</dt>
 		<dd>
 			The DID method of the DID is not supported by the <a>DID resolver</a>. See Section <a href="#resolving-algorithm"></a>.
+		</dd>
+        <dt id="INVALID_OPTIONS">INVALID_OPTIONS</dt>
+		<dd>
+			One or more of the options provided for <a>DID Resolution</a> or <a>DID URL dereferencing</a> are invalid.
 		</dd>
         <dt id="INTERNAL_ERROR">INTERNAL_ERROR</dt>
 		<dd>

--- a/index.html
+++ b/index.html
@@ -753,7 +753,7 @@ string">ASCII string</a>.
 			<a href="https://www.w3.org/TR/did-core/#did-syntax">DID Syntax</a>.
 			If not, the <a>DID resolver</a> MUST return the following result:
 			<ol class="algorithm">
-				<li><b>didResolutionMetadata</b>: <code>«[ "error" → "invalidDid", ... ]»</code></li>
+				<li><b>didResolutionMetadata</b>: <var>error object</var> with type set to <a href="#INVALID_DID">INVALID_DID</a></li>
 				<li><b>didDocument</b>: <code>null</code></li>
 				<li><b>didDocumentMetadata</b>: <code>«[ ]»</code></li>
 			</ol>
@@ -761,7 +761,7 @@ string">ASCII string</a>.
 			<li>Determine whether the DID method of the <var>input <a>DID</a></var> is supported by the <a>DID resolver</a>
 			that implements this algorithm. If not, the <a>DID resolver</a> MUST return the following result:
 			<ol class="algorithm">
-				<li><b>didResolutionMetadata</b>: <code>«[ "error" → "methodNotSupported", ... ]»</code></li>
+				<li><b>didResolutionMetadata</b>: <var>error object</var> with type set to <a href="#METHOD_NOT_SUPPORTED"></a></li>
 				<li><b>didDocument</b>: <code>null</code></li>
 				<li><b>didDocumentMetadata</b>: <code>«[ ]»</code></li>
 			</ol>
@@ -776,7 +776,7 @@ string">ASCII string</a>.
 				<var>input <a>DID method</a></var>.</li>
 				<li>If the <var>input <a>DID</a></var> does not exist, return the following result:
 				<ol class="algorithm">
-					<li><b>didResolutionMetadata</b>: <code>«[ "error" → "notFound", ... ]»</code></li>
+					<li><b>didResolutionMetadata</b>: <var>error object</var> with type set to <a href="#NOT_FOUND"></a></li>
 					<li><b>didDocument</b>: <code>null</code></li>
 					<li><b>didDocumentMetadata</b>: <code>«[ ]»</code></li>
 				</ol>
@@ -978,7 +978,7 @@ dereference(didUrl, dereferenceOptions) →
 			this MUST NOT be empty. Properties defined by this specification are in <a
 				href="#did-url-dereferencing-metadata"></a>. If the dereferencing is not
 			successful, this structure MUST contain an <code>error</code> property
-			describing the error.
+			describing the error. See Section <a href="#errors"></a>.
 		</dd>
 		<dt>
 			contentStream
@@ -1075,28 +1075,13 @@ dereference(didUrl, dereferenceOptions) →
 				error
 			</dt>
 			<dd>
+                An error data structure defined in [[RFC9457]]. This property is REQUIRED when there is an error
+                in the dereferencing process. The errors defined by this specification and can be found in
+                Section <a href="#errors"></a>.
 				The error code from the dereferencing process. This property is REQUIRED when
-				there is an error in the dereferencing process. The value of this property
-				MUST be a single keyword expressed as an <a data-lt="ascii string">ASCII
-				string</a>. The possible property values of this field SHOULD be registered in
-				the DID Specification Registries [[?DID-SPEC-REGISTRIES]]. This specification
-				defines the following common error values:
-				<dl>
-					<dt>
-						invalidDidUrl
-					</dt>
-					<dd>
-						The <a>DID URL</a> supplied to the <a>DID URL dereferencing</a> function does
-						not conform to valid syntax. (See <a data-cite="did-core#did-url-syntax"></a>.)
-					</dd>
-					<dt>
-						notFound
-					</dt>
-					<dd>
-						The <a>DID URL dereferencer</a> was unable to find the
-						<code>contentStream</code> resulting from this dereferencing request.
-					</dd>
-				</dl>
+				there is an error in the dereferencing process. The errors defined in this 
+                specification can be found in Section <a href="#errors"></a>. 
+                Additional errors SHOULD be registered in the DID Specification Registries [[?DID-SPEC-REGISTRIES]].
 			</dd>
 		</dl>
 	</section>
@@ -1115,7 +1100,7 @@ dereference(didUrl, dereferenceOptions) →
 					<a href="https://www.w3.org/TR/did-core/#did-url-syntax">DID URL Syntax</a>.
 					If not, the <a>DID URL dereferencer</a> MUST return the following result:
 					<ol class="algorithm">
-						<li><b>dereferencingMetadata</b>: <code>«[ "error" → "invalidDidUrl" ]»</code></li>
+						<li><b>dereferencingMetadata</b>: <var>error object</var> with type set to <a href="#INVALID_DID_URL">INVALID_DID_URL</a></li>
 						<li><b>contentStream</b>: <code>null</code></li>
 						<li><b>contentMetadata</b>: <code>«[ ]»</code></li>
 					</ol>
@@ -1129,7 +1114,7 @@ dereference(didUrl, dereferenceOptions) →
 				<li>If the <var>input <a>DID</a></var> does not exist in the VDR, the <a>DID URL dereferencer</a>
 						MUST return the following result:
 						<ol class="algorithm">
-							<li><b>dereferencingMetadata</b>: <code>«[ "error" → "notFound", ... ]»</code></li>
+							<li><b>dereferencingMetadata</b>: <var>error object</var> with type set to <a href="#NOT_FOUND"></a></li>
 							<li><b>contentStream</b>: <code>null</code></li>
 							<li><b>contentMetadata</b>: <code>«[ ]»</code></li>
 						</ol>
@@ -1232,7 +1217,7 @@ dereference(didUrl, dereferenceOptions) →
 						</li>
 						<li>Otherwise, return the following result:
 							<ol class="algorithm">
-								<li><b>dereferencingMetadata</b>: <code>«[ "error" → "representationNotSupported", ... ]»</code></li>
+								<li><b>dereferencingMetadata</b>: <var>error object</var> with type set to <a href="#REPRESENTATION_NOT_SUPPORTED">REPRESENTATION_NOT_SUPPORTED</a></li>
 								<li><b>content</b>: <code>null</code></li>
 								<li><b>contentMetadata</b>: <code>«[ ]»</code></li>
 							</ol>
@@ -1262,7 +1247,7 @@ dereference(didUrl, dereferenceOptions) →
 				<li>If neither this algorithm, nor the applicable <a>DID method</a>, nor an extension, nor the client
 				is able to dereference the <var>input <a>DID URL</a></var>, return the following result:
 				<ol class="algorithm">
-					<li><b>dereferencingMetadata</b>: <code>«[ "error" → "notFound" ]»</code></li>
+					<li><b>dereferencingMetadata</b>: <var>error object</var> with type set to <a href="#NOT_FOUND"></a></li>
 					<li><b>contentStream</b>: <code>null</code></li>
 					<li><b>contentMetadata</b>: <code>«[ ]»</code></li>
 				</ol>
@@ -1344,7 +1329,7 @@ dereference(didUrl, dereferenceOptions) →
 			<p class="note">
 				This behavior of the <a>DID fragment</a> is analogous to the handling of a fragment in an HTTP URL in the
 				case when dereferencing it returns an HTTP <code>3xx</code> (Redirection) response with a
-				<code>Location</code> header (see section 7.1.2 of [[RFC7231]].
+				<code>Location</code> header (see section 7.1.2 of [[RFC7231]]).
 			</p>
 
 		</section>
@@ -2154,7 +2139,7 @@ The `detail` value SHOULD provide a longer human-readable string for the error.
 					<tbody>
 					<tr>
 						<td>
-							<code>invalidDid</code>
+							<code>INVALID_DID</code>
 						</td>
 						<td>
 							<code>400</code>
@@ -2162,7 +2147,7 @@ The `detail` value SHOULD provide a longer human-readable string for the error.
 					</tr>
 					<tr>
 						<td>
-							<code>invalidDidUrl</code>
+							<code>INVALID_DID_URL</code>
 						</td>
 						<td>
 							<code>400</code>
@@ -2170,7 +2155,7 @@ The `detail` value SHOULD provide a longer human-readable string for the error.
 					</tr>
 					<tr>
 						<td>
-							<code>notFound</code>
+							<code>NOT_FOUND</code>
 						</td>
 						<td>
 							<code>404</code>
@@ -2178,7 +2163,7 @@ The `detail` value SHOULD provide a longer human-readable string for the error.
 					</tr>
 					<tr>
 						<td>
-							<code>representationNotSupported</code>
+							<code>REPRESENTATION_NOT_SUPPORTED</code>
 						</td>
 						<td>
 							<code>406</code>
@@ -2186,7 +2171,7 @@ The `detail` value SHOULD provide a longer human-readable string for the error.
 					</tr>
 					<tr>
 						<td>
-							<code>methodNotSupported</code>
+							<code>METHOD_NOT_SUPPORTED</code>
 						</td>
 						<td>
 							<code>501</code>
@@ -2194,7 +2179,7 @@ The `detail` value SHOULD provide a longer human-readable string for the error.
 					</tr>
 					<tr>
 						<td>
-							<code>internalError</code>
+							<code>INTERNAL_ERROR</code>
 						</td>
 						<td>
 							<code>500</code>

--- a/index.html
+++ b/index.html
@@ -761,7 +761,7 @@ string">ASCII string</a>.
 			<li>Determine whether the DID method of the <var>input <a>DID</a></var> is supported by the <a>DID resolver</a>
 			that implements this algorithm. If not, the <a>DID resolver</a> MUST return the following result:
 			<ol class="algorithm">
-				<li><b>didResolutionMetadata</b>: <var>error object</var> with type set to <a href="#METHOD_NOT_SUPPORTED"></a></li>
+				<li><b>didResolutionMetadata</b>: <var>error object</var> with type set to <a href="#METHOD_NOT_SUPPORTED">METHOD_NOT_SUPPORTED</a></li>
 				<li><b>didDocument</b>: <code>null</code></li>
 				<li><b>didDocumentMetadata</b>: <code>«[ ]»</code></li>
 			</ol>
@@ -776,7 +776,7 @@ string">ASCII string</a>.
 				<var>input <a>DID method</a></var>.</li>
 				<li>If the <var>input <a>DID</a></var> does not exist, return the following result:
 				<ol class="algorithm">
-					<li><b>didResolutionMetadata</b>: <var>error object</var> with type set to <a href="#NOT_FOUND"></a></li>
+					<li><b>didResolutionMetadata</b>: <var>error object</var> with type set to <a href="#NOT_FOUND">NOT_FOUND</a></li>
 					<li><b>didDocument</b>: <code>null</code></li>
 					<li><b>didDocumentMetadata</b>: <code>«[ ]»</code></li>
 				</ol>
@@ -1075,10 +1075,7 @@ dereference(didUrl, dereferenceOptions) →
 				error
 			</dt>
 			<dd>
-                An error data structure defined in [[RFC9457]]. This property is REQUIRED when there is an error
-                in the dereferencing process. The errors defined by this specification and can be found in
-                Section <a href="#errors"></a>.
-				The error code from the dereferencing process. This property is REQUIRED when
+                An error data structure defined in [[RFC9457]]. This property is REQUIRED when
 				there is an error in the dereferencing process. The errors defined in this 
                 specification can be found in Section <a href="#errors"></a>. 
                 Additional errors SHOULD be registered in the DID Specification Registries [[?DID-SPEC-REGISTRIES]].
@@ -1114,7 +1111,7 @@ dereference(didUrl, dereferenceOptions) →
 				<li>If the <var>input <a>DID</a></var> does not exist in the VDR, the <a>DID URL dereferencer</a>
 						MUST return the following result:
 						<ol class="algorithm">
-							<li><b>dereferencingMetadata</b>: <var>error object</var> with type set to <a href="#NOT_FOUND"></a></li>
+							<li><b>dereferencingMetadata</b>: <var>error object</var> with type set to <a href="#NOT_FOUND">NOT_FOUND</a></li>
 							<li><b>contentStream</b>: <code>null</code></li>
 							<li><b>contentMetadata</b>: <code>«[ ]»</code></li>
 						</ol>
@@ -1247,7 +1244,7 @@ dereference(didUrl, dereferenceOptions) →
 				<li>If neither this algorithm, nor the applicable <a>DID method</a>, nor an extension, nor the client
 				is able to dereference the <var>input <a>DID URL</a></var>, return the following result:
 				<ol class="algorithm">
-					<li><b>dereferencingMetadata</b>: <var>error object</var> with type set to <a href="#NOT_FOUND"></a></li>
+					<li><b>dereferencingMetadata</b>: <var>error object</var> with type set to <a href="#NOT_FOUND">NOT_FOUND</a></li>
 					<li><b>contentStream</b>: <code>null</code></li>
 					<li><b>contentMetadata</b>: <code>«[ ]»</code></li>
 				</ol>
@@ -1828,7 +1825,7 @@ https://example.com/messages/8377464/some/path?query#frag
 		<p>Examples of DID Resolution Metadata include:</p>
 		<ul>
 		<li>Media type of the returned content (the <b>contentType</b> metadata property).</li>
-		<li>Error code (the <b>error</b> metadata property).</li>
+		<li>Error object (the <b>error</b> metadata property).</li>
 		<li>Duration of the DID resolution process.</li>
 		<li>Caching information about the DID document (see Section <a href="#caching"></a>).</li>
 		<li>Various URLs, IP addresses or other network information that was used during the DID resolution process.</li>

--- a/index.html
+++ b/index.html
@@ -568,6 +568,7 @@ string">ASCII string</a>. The <a>DID resolver</a> implementation SHOULD use this
 				An error data structure defined in [[RFC9457]]. This property is REQUIRED when there is an error
                 in the resolution process. The errors defined by this specification and can be found in
                 Section <a href="#errors"></a>.
+                Additional errors SHOULD be registered in the DID Specification Registries [[?DID-SPEC-REGISTRIES]].
 			</dd>
 		</dl>
 

--- a/index.html
+++ b/index.html
@@ -559,32 +559,18 @@ string">ASCII string</a>. The <a>DID resolver</a> implementation SHOULD use this
 				is an error in the resolution process. The value of this property MUST be a
 				single keyword <a data-lt="ascii string">ASCII string</a>. The possible property
 				values of this field SHOULD be registered in the DID Specification Registries
-				[[?DID-SPEC-REGISTRIES]]. This specification defines the following
-				common error values:
-				<dl>
-					<dt>
-						invalidDid
-					</dt>
-					<dd>
-						The <a>DID</a> supplied to the <a>DID resolution</a> function does not conform
-						to valid syntax. (See <a data-cite="did-core#did-syntax"></a>.)
-					</dd>
-					<dt>
-						notFound
-					</dt>
-					<dd>
-						The <a>DID resolver</a> was unable to find the <a>DID document</a>
-						resulting from this resolution request.
-					</dd>
-					<dt>
-						representationNotSupported
-					</dt>
-					<dd>
-						This error code is returned if the <a>representation</a> requested via the
-						<code>accept</code> input metadata property is not supported by the <a>DID
-						method</a> and/or <a>DID resolver</a> implementation.
-					</dd>
-				</dl>
+				[[?DID-SPEC-REGISTRIES]]. The common error codes defined by this specification can
+				be found in <a href="#errors"></a>.
+			</dd>
+			<dt>
+				problemDetails
+			</dt>
+			<dd>
+				An error data structure defined in [[RFC9457]]. This property is OPTIONAL, when it is 
+				used the error described MUST be equivalent to the error code returned by the <code>error</code>
+				DID Resolution Metadata property. The types for errors defined by this specification and 
+				their mapping to error codes can be found in<a href="#errors"></a>.
+
 			</dd>
 		</dl>
 
@@ -1901,6 +1887,104 @@ https://example.com/messages/8377464/some/path?query#frag
 
 <section id="errors">
 	<h1>Errors</h1>
+	<p>
+		The algorithms described in this specification throw specific types of errors.
+		Implementers might find it useful to convey these errors to other libraries or
+		software systems. This section provides specific URLs and descriptions for the errors,
+		such that an ecosystem implementing technologies described
+		by this specification might interoperate more effectively when errors occur. Additionally,
+		this specification uses some errors defined in <a data-cite="CID#processing-errors">Section 
+		3.5 Processing Errors</a> of the [[CID]] specification.
+	</p>
+		
+	<p>
+		When exposing these errors through an HTTP interface, implementers SHOULD use
+		[[RFC9457]] to encode the error data structure. If [[RFC9457]] is used:
+	</p>
+
+	<ul>
+		<li>
+The `type` value of the error object MUST be a URL that starts with the value
+`https://w3id.org/security#` and ends with the value in the section listed
+below.
+		</li>
+		<li>
+The `title` value SHOULD provide a short but specific human-readable string for
+the error.
+		</li>
+		<li>
+The `detail` value SHOULD provide a longer human-readable string for the error.
+		</li>
+	</ul>
+
+
+	<table class="simple">
+		<thead>
+		<tr>
+			<th>
+				Error Code
+			</th>
+			<th>
+				Type
+			</th>
+			<th>
+				Title
+			</th>
+		</tr>
+		</thead>
+
+		<tbody>
+		</tbody>
+	</table>
+
+	<dl>
+		<dt id="INVALID_DID">INVALID_DID</dt>
+		<dd>
+			An invalid DID was detected during <a>DID Resolution</a>. See <a href="#resolving-algorithm">DID Resolution Algorithm</a>
+		</dd>
+		<dt id="INVALID_DID_DOCUMENT">INVALID_DID_DOCUMENT</dt>
+		<dd>
+The [=DID document=] was malformed. See Section
+[[[#retrieve-verification-method]]].
+		</dd>
+		<dt id="INVALID_VERIFICATION_METHOD">INVALID_VERIFICATION_METHOD</dt>
+		<dd>
+The [=verification method=] in a [=controlled identifier document=] was malformed. See Section
+[[[#retrieve-verification-method]]].
+		</dd>
+		<dt id="INVALID_RELATIONSHIP_FOR_VERIFICATION_METHOD">INVALID_RELATIONSHIP_FOR_VERIFICATION_METHOD</dt>
+		<dd>
+The [=verification method=] in a [=controlled identifier document=] was not
+associated using the expected [=verification relationship=] as expressed in
+the `proofPurpose` property in the [=proof=]. See Section
+[[[#retrieve-verification-method]]].
+		</dd>
+	  </dl>
+	  <dl>
+		<dt>
+			invalidDid
+		</dt>
+		<dd>
+			The <a>DID</a> supplied to the <a>DID resolution</a> function does not conform
+			to valid syntax. (See <a data-cite="did-core#did-syntax"></a>.)
+		</dd>
+		<dt>
+			notFound
+		</dt>
+		<dd>
+			The <a>DID resolver</a> was unable to find the <a>DID document</a>
+			resulting from this resolution request.
+		</dd>
+		<dt>
+			representationNotSupported
+		</dt>
+		<dd>
+			This error code is returned if the <a>representation</a> requested via the
+			<code>accept</code> input metadata property is not supported by the <a>DID
+			method</a> and/or <a>DID resolver</a> implementation.
+		</dd>
+	</dl>
+
     <h2>invalidDid</h2>
 	<p>If an invalid DID is detected during <a>DID Resolution</a>,
 		the value of the DID Resolution Metadata <strong>error</strong> property MUST be <strong>invalidDid</strong>

--- a/index.html
+++ b/index.html
@@ -460,7 +460,9 @@ resolve(did, resolutionOptions) →
 			error in the resolution process, this MUST NOT be empty. This metadata is
 			defined by <a href="#did-resolution-metadata"></a>. If the resolution is
 			not successful, this structure MUST contain an <code>error</code> property
-			describing the error. See Section <a href="#errors"></a>.
+			describing the error. See Section <a href="#errors"></a>. 
+      Additional errors SHOULD be registered in the DID Specification Registries 
+      [[?DID-SPEC-REGISTRIES]].
 		</dd>
 		<dt>
 			<dfn>didDocument</dfn>

--- a/index.html
+++ b/index.html
@@ -759,7 +759,7 @@ string">ASCII string</a>.
 	</section>
 
 	<section id="resolving-algorithm">
-		<h2>Algorithm</h2>
+		<h2>DID Resolution Algorithm</h2>
 		<p>The following <a>DID resolution</a> algorithm MUST be implemented by a conformant <a>DID resolver</a>.</p>
 		<ol class="algorithm">
 			<li>Validate that the <var>input <a>DID</a></var> conforms to the `did` rule of the
@@ -1116,7 +1116,7 @@ dereference(didUrl, dereferenceOptions) →
 
 
 	<section id="dereferencing-algorithm">
-		<h2>Algorithm</h2>
+		<h2>DID URL Dereferencing Algorithm</h2>
 		<p>The following <a>DID URL dereferencing</a> algorithm MUST be implemented by a conformant <a>DID resolver</a>.
 		In accordance with [[RFC3986]], it consists of the following three steps: resolving the DID; dereferencing the
 		resource; and dereferencing the fragment (only if the <var>input <a>DID URL</a></var> contains a <a>DID fragment</a>):</p>
@@ -2032,14 +2032,13 @@ The `detail` value SHOULD provide a longer human-readable string for the error.
 	<dl>
 		<dt id="INVALID_DID">INVALID_DID</dt>
 		<dd>
-			An invalid DID was detected during <a>DID Resolution</a>. See <a href="#resolving-algorithm">
+			An invalid DID was detected during <a>DID Resolution</a>. See Section <a href="#resolving-algorithm"></a>.
 		</dd>
 		<dt id="INVALID_DID_DOCUMENT">INVALID_DID_DOCUMENT</dt>
 		<dd>
-The [=DID document=] was malformed. See Section
-[[[#retrieve-verification-method]]].
+            The [=DID document=] was malformed. See Section <a href="#resolving-algorithm"></a>.
 		</dd>
-		<dt id="INVALID_VERIFICATION_METHOD">INVALID_VERIFICATION_METHOD</dt>
+		<!-- <dt id="INVALID_VERIFICATION_METHOD">INVALID_VERIFICATION_METHOD</dt>
 		<dd>
 The [=verification method=] in a [=controlled identifier document=] was malformed. See Section
 [[[#retrieve-verification-method]]].
@@ -2050,78 +2049,52 @@ The [=verification method=] in a [=controlled identifier document=] was not
 associated using the expected [=verification relationship=] as expressed in
 the `proofPurpose` property in the [=proof=]. See Section
 [[[#retrieve-verification-method]]].
+		</dd> -->
+        <dt id="NOT_FOUND">NOT_FOUND</dt>
+		<dd>
+            The <a>DID resolver</a> was unable to find the <a>DID document</a>
+			resulting from this resolution request. See Section <a href="#resolving-algorithm"></a>.
+		</dd>
+        <dt id="REPRESENTATION_NOT_SUPPORTED">REPRESENTATION_NOT_SUPPORTED</dt>
+		<dd>
+			The <a>representation</a> requested via the <code>accept</code> input metadata property 
+            is not supported by the <a>DID method</a> and/or <a>DID resolver</a> implementation. 
+            See Section <a href="#resolving-algorithm"></a>.
+		</dd>
+        <dt id="INVALID_DID_URL">INVALID_DID_URL</dt>
+		<dd>
+			An invalid <a>DID URL</a> was detected during <a>DID URL dereferencing</a>.
+            See Section <a href="#dereferencing-algorithm"></a>
+		</dd>
+        <dt id="METHOD_NOT_SUPPORTED">METHOD_NOT_SUPPORTED</dt>
+		<dd>
+			The DID method of the DID is not supported by the <a>DID resolver</a>. See Section <a href="#resolving-algorithm"></a>.
+		</dd>
+        <dt id="INTERNAL_ERROR">INTERNAL_ERROR</dt>
+		<dd>
+			An unexpected error occured during <a>DID Resolution</a> or <a>DID URL dereferencing</a>.
+		</dd>
+        <dt id="INVALID_PUBLIC_KEY">INVALID_PUBLIC_KEY</dt>
+		<dd>
+			An invalid public key value is detected during <a>DID Resolution</a> or <a>DID URL dereferencing</a>. 
+		</dd>
+        <dt id="INVALID_PUBLIC_KEY_LENGTH">INVALID_PUBLIC_KEY_LENGTH</dt>
+		<dd>
+			The byte length of <i>rawPublicKeyBytes</i> did not match the expected public key length for the associated multicodecValue 
+            during <a>DID Resolution</a> or <a>DID URL dereferencing</a>.
+		</dd>
+        <dt id="INVALID_PUBLIC_KEY_TYPE">INVALID_PUBLIC_KEY_TYPE</dt>
+		<dd>
+			An invalid public key type was detected during <a>DID Resolution</a> or <a>DID URL dereferencing</a>.
+		</dd>
+        <dt id="INVALID_PUBLIC_KEY_TYPE">UNSUPPORTED_PUBLIC_KEY_TYPE</dt>
+		<dd>
+			An unsupported public key type is detected during <a>DID Resolution</a> or <a>DID URL dereferencing</a>.
 		</dd>
 	  </dl>
 	  <dl>
-		<dt>
-			invalidDid
-		</dt>
-		<dd>
-			The <a>DID</a> supplied to the <a>DID resolution</a> function does not conform
-			to valid syntax. (See <a data-cite="did-core#did-syntax"></a>.)
-		</dd>
-		<dt>
-			notFound
-		</dt>
-		<dd>
-			The <a>DID resolver</a> was unable to find the <a>DID document</a>
-			resulting from this resolution request.
-		</dd>
-		<dt>
-			representationNotSupported
-		</dt>
-		<dd>
-			This error code is returned if the <a>representation</a> requested via the
-			<code>accept</code> input metadata property is not supported by the <a>DID
-			method</a> and/or <a>DID resolver</a> implementation.
-		</dd>
 	</dl>
 
-    <h2>invalidDid</h2>
-	<p>If an invalid DID is detected during <a>DID Resolution</a>,
-		the value of the DID Resolution Metadata <strong>error</strong> property MUST be <strong>invalidDid</strong>
-        as defined in section <a href="#did-resolution-metadata"></a>.
-    </p>
-	<h2>invalidDidUrl</h2>
-	<p>If an invalid DID URL is detected during <a>DID Resolution</a> or <a>DID URL dereferencing</a>,
-		the value of the DID Resolution or DID URL Dereferencing Metadata <strong>error</strong> property MUST be <strong>invalidDidUrl</strong>
-        as defined in section <a href="#did-url-dereferencing-metadata"></a>.
-    </p>
-    <h2>notFound</h2>
-    <p> If during <a>DID Resolution</a> or <a>DID URL dereferencing</a> a DID or DID URL doesn't exist,
-        the value of the DID Resolution or DID URL dereferencing Metadata <strong>error</strong> property MUST be <strong>notFound</strong> as
-        defined in sections <a href="#did-resolution-metadata"></a> and
-        <a href="#did-url-dereferencing-metadata"></a>.
-    </p>
-    <h2>representationNotSupported</h2>
-    <p> If a DID document representation is not supported during <a>DID Resolution</a> or <a>DID URL dereferencing</a>,
-        the value of the DID Resolution Metadata <strong>error</strong> property MUST be <strong>representationNotSupported</strong> as
-        defined in section <a href="#did-resolution-metadata"></a>.
-    </p>
-	<h2>methodNotSupported</h2>
-	<p> If a DID method is not supported during <a>DID Resolution</a> or <a>DID URL dereferencing</a>,
-		the value of the DID Resolution or DID URL Dereferencing Metadata <strong>error</strong> property MUST be <strong>methodNotSupported</strong>.
-	</p>
-	<h2>internalError</h2>
-	<p>When an unexpected error occurs during <a>DID Resolution</a> or <a>DID URL dereferencing</a>,
-		the value of the DID Resolution or DID URL Dereferencing Metadata <strong>error</strong> property MUST be <strong>internalError</strong>.
-    </p>
-	<h2>invalidPublicKey</h2>
-	<p>If an invalid public key value is detected during <a>DID Resolution</a> or <a>DID URL dereferencing</a>,
-		the value of the DID Resolution or DID URL Dereferencing Metadata <strong>error</strong> property MUST be <strong>invalidPublicKey</strong>.
-    </p>
-	<h2>invalidPublicKeyLength</h2>
-	<p>If the byte length of <i>rawPublicKeyBytes</i> does not match the expected public key length for the associated multicodecValue during <a>DID Resolution</a> or <a>DID URL dereferencing</a>,
-		the value of the DID Resolution or DID URL Dereferencing Metadata <strong>error</strong> property MUST be <strong>invalidPublicKeyLength</strong>.
-    </p>
-	<h2>invalidPublicKeyType</h2>
-	<p>If an invalid public key type is detected during <a>DID Resolution</a> or <a>DID URL dereferencing</a>,
-		the value of the DID Resolution or DID URL Dereferencing Metadata <strong>error</strong> property MUST be <strong>invalidPublicKeyType</strong>.
-    </p>
-	<h2>unsupportedPublicKeyType</h2>
-	<p>If an unsupported public key type is detected during <a>DID Resolution</a> or <a>DID URL dereferencing</a>,
-		the value of the DID Resolution or DID URL Dereferencing Metadata <strong>error</strong> property MUST be <strong>unsupportedPublicKeyType</strong>.
-    </p>
 
 </section>
 

--- a/index.html
+++ b/index.html
@@ -565,22 +565,9 @@ string">ASCII string</a>. The <a>DID resolver</a> implementation SHOULD use this
 				error
 			</dt>
 			<dd>
-				The error code from the resolution process. This property is REQUIRED when there
-				is an error in the resolution process. The value of this property MUST be a
-				single keyword <a data-lt="ascii string">ASCII string</a>. The possible property
-				values of this field SHOULD be registered in the DID Specification Registries
-				[[?DID-SPEC-REGISTRIES]]. The common error codes defined by this specification can
-				be found in <a href="#errors"></a>.
-			</dd>
-			<dt>
-				problemDetails
-			</dt>
-			<dd>
-				An error data structure defined in [[RFC9457]]. This property is OPTIONAL, when it is 
-				used the error described MUST be equivalent to the error code returned by the <code>error</code>
-				DID Resolution Metadata property. The types for errors defined by this specification and 
-				their mapping to error codes can be found in<a href="#errors"></a>.
-
+				An error data structure defined in [[RFC9457]]. This property is REQUIRED when there is an error
+                in the resolution process. The errors defined by this specification and can be found in
+                Section <a href="#errors"></a>.
 			</dd>
 		</dl>
 
@@ -2089,7 +2076,7 @@ the `proofPurpose` property in the [=proof=]. See Section
 		</dd>
         <dt id="INVALID_PUBLIC_KEY_TYPE">UNSUPPORTED_PUBLIC_KEY_TYPE</dt>
 		<dd>
-			An unsupported public key type is detected during <a>DID Resolution</a> or <a>DID URL dereferencing</a>.
+			An unsupported public key type was detected during <a>DID Resolution</a> or <a>DID URL dereferencing</a>.
 		</dd>
 	  </dl>
 	  <dl>

--- a/index.html
+++ b/index.html
@@ -1917,30 +1917,10 @@ The `detail` value SHOULD provide a longer human-readable string for the error.
 		</li>
 	</ul>
 
-
-	<table class="simple">
-		<thead>
-		<tr>
-			<th>
-				Error Code
-			</th>
-			<th>
-				Type
-			</th>
-			<th>
-				Title
-			</th>
-		</tr>
-		</thead>
-
-		<tbody>
-		</tbody>
-	</table>
-
 	<dl>
 		<dt id="INVALID_DID">INVALID_DID</dt>
 		<dd>
-			An invalid DID was detected during <a>DID Resolution</a>. See <a href="#resolving-algorithm">DID Resolution Algorithm</a>
+			An invalid DID was detected during <a>DID Resolution</a>. See <a href="#resolving-algorithm">
 		</dd>
 		<dt id="INVALID_DID_DOCUMENT">INVALID_DID_DOCUMENT</dt>
 		<dd>

--- a/index.html
+++ b/index.html
@@ -2074,7 +2074,7 @@ the `proofPurpose` property in the [=proof=]. See Section
 		<dd>
 			An invalid public key type was detected during <a>DID Resolution</a> or <a>DID URL dereferencing</a>.
 		</dd>
-        <dt id="INVALID_PUBLIC_KEY_TYPE">UNSUPPORTED_PUBLIC_KEY_TYPE</dt>
+        <dt id="UNSUPPORTED_PUBLIC_KEY_TYPE">UNSUPPORTED_PUBLIC_KEY_TYPE</dt>
 		<dd>
 			An unsupported public key type was detected during <a>DID Resolution</a> or <a>DID URL dereferencing</a>.
 		</dd>

--- a/index.html
+++ b/index.html
@@ -1979,7 +1979,7 @@ https://example.com/messages/8377464/some/path?query#frag
 	</p>
 		
 	<p>
-		When exposing these errors through an HTTP interface, implementers SHOULD use
+		Implementers SHOULD use
 		[[RFC9457]] to encode the error data structure. If [[RFC9457]] is used:
 	</p>
 

--- a/index.html
+++ b/index.html
@@ -1988,9 +1988,9 @@ https://example.com/messages/8377464/some/path?query#frag
 
 	<ul>
 		<li>
-The `type` value of the error object MUST be a URL that starts with the value
-`https://w3id.org/security#` and ends with the value in the section listed
-below.
+The `type` value of the error object MUST be a URL. Where the values listed
+in the section below do not define a URL, the values MUST be prepended with the
+URL `https://www.w3.org/ns/did#`.
 		</li>
 		<li>
 The `title` value SHOULD provide a short but specific human-readable string for
@@ -2038,20 +2038,20 @@ The `detail` value SHOULD provide a longer human-readable string for the error.
 		<dd>
 			An unexpected error occured during <a>DID Resolution</a> or <a>DID URL dereferencing</a>.
 		</dd>
-        <dt id="INVALID_PUBLIC_KEY">INVALID_PUBLIC_KEY</dt>
+        <dt id="INVALID_PUBLIC_KEY">https://w3id.org/security#INVALID_PUBLIC_KEY</dt>
 		<dd>
 			An invalid public key value is detected during <a>DID Resolution</a> or <a>DID URL dereferencing</a>. 
 		</dd>
-        <dt id="INVALID_PUBLIC_KEY_LENGTH">INVALID_PUBLIC_KEY_LENGTH</dt>
+        <dt id="INVALID_PUBLIC_KEY_LENGTH">https://w3id.org/security#INVALID_PUBLIC_KEY_LENGTH</dt>
 		<dd>
 			The byte length of <i>rawPublicKeyBytes</i> did not match the expected public key length for the associated multicodecValue 
             during <a>DID Resolution</a> or <a>DID URL dereferencing</a>.
 		</dd>
-        <dt id="INVALID_PUBLIC_KEY_TYPE">INVALID_PUBLIC_KEY_TYPE</dt>
+        <dt id="INVALID_PUBLIC_KEY_TYPE">https://w3id.org/security#INVALID_PUBLIC_KEY_TYPE</dt>
 		<dd>
 			An invalid public key type was detected during <a>DID Resolution</a> or <a>DID URL dereferencing</a>.
 		</dd>
-        <dt id="UNSUPPORTED_PUBLIC_KEY_TYPE">UNSUPPORTED_PUBLIC_KEY_TYPE</dt>
+        <dt id="UNSUPPORTED_PUBLIC_KEY_TYPE">https://w3id.org/security#UNSUPPORTED_PUBLIC_KEY_TYPE</dt>
 		<dd>
 			An unsupported public key type was detected during <a>DID Resolution</a> or <a>DID URL dereferencing</a>.
 		</dd>


### PR DESCRIPTION
This issue addresses #87.

It also includes the error from #136. And pending a decision I will add the error in #140.

I also have a few questions about the errors.

1. INVALID_VERIFICATION_METHOD and INVALID_RELATIONSHIP_FOR_VERIFICATION_METHOD are defined in the CID spec. I don't need to list them in this spec again right?
2. All the errors related to public keys feel kind of strange and perhaps an artifact from when we used publicKey instead of verificationMethod and when we had many different types instead of Multikey. It feels like most of those errors are things the client would learn after resolving/dereferencing. Not something the resolution process is going to check.

@peacekeeper be great to get your thoughts.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wip-abramson/did-resolution/pull/146.html" title="Last updated on May 16, 2025, 2:06 PM UTC (497a252)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-resolution/146/1508359...wip-abramson:497a252.html" title="Last updated on May 16, 2025, 2:06 PM UTC (497a252)">Diff</a>