### PR TITLE
Reference RFC9110 which obsoletes RFC7231.

### DIFF
--- a/terms.html
+++ b/terms.html
@@ -184,9 +184,9 @@ included whenever they appear in this specification.
 
   <dt><dfn data-lt="representations">representation</dfn></dt>
   <dd>
-    As defined for HTTP by [[RFC7231]]: "information that is intended to reflect a
+    As defined for HTTP by [[RFC9110]]: "information that is intended to reflect a
     past, current, or desired state of a given resource, in a format that can be
-    readily communicated via the protocol, and that consists of a set of
+    readily communicated via the protocol. A representation consists of a set of
     representation metadata and a potentially unbounded stream of representation
     data." A <a>DID document</a> is a representation of information describing a
     <a>DID subject</a>. See <a data-cite="did-core#representations"></a>.


### PR DESCRIPTION
Fixes https://github.com/w3c/did-resolution/issues/153.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-resolution/pull/176.html" title="Last updated on Aug 7, 2025, 1:40 PM UTC (df1bc60)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-resolution/176/df6f467...df1bc60.html" title="Last updated on Aug 7, 2025, 1:40 PM UTC (df1bc60)">Diff</a>