### PR TITLE
Make https binding mandatory

### DIFF
--- a/index.html
+++ b/index.html
@@ -131,8 +131,8 @@
 Decentralized identifier (DID) resolution is the process of obtaining
 a DID document and accompanying metadata for a specific DID. The process
 takes a DID and a set of resolution options as its input and returns a
+DID document and associated metadata about the resolved document and the
 resolution request. A resolved DID document is a set of information which
-enables cryptographically verifiable interactions with the DID subject,
 including mechanisms such as cryptographic public keys. This specification
 covers the algorithms and guidelines to be used for DID resolution and
 relies on the core DID specification,


### PR DESCRIPTION
This PR addresses #93 . It clarifies that conformant implementations must implement at least one did resolver with https binding.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ottomorac/did-resolution/pull/182.html" title="Last updated on Jan 19, 2026, 7:17 PM UTC (41dcd0f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-resolution/182/c550969...ottomorac:41dcd0f.html" title="Last updated on Jan 19, 2026, 7:17 PM UTC (41dcd0f)">Diff</a>