### PR TITLE
Require HTTP GET binding and allow HTTP POST

### DIFF
--- a/index.html
+++ b/index.html
@@ -2237,7 +2237,7 @@ The `detail` value SHOULD provide a longer human-readable string for the error.
 
 		<p>All conformant <a>DID resolvers</a> MUST implement an HTTP(S) binding using GET as described in the algorithm below.
 			In addition, <a>DID resolvers</a> MAY support an alternative HTTP(S) binding using POST.
-			Allowing clients to send POST request to the resolver endpoint may be useful in order to avoid URL length limitations,
+			Allowing clients to send POST request to the resolver endpoint might be useful in order to avoid URL length limitations,
 			and it also allows the DID (or DID URL) and resolution options to be kept out of the invoked URL 
 			(protecting them from exposure in logs, proxies, or monitoring).
 			Finally, using POST has the advantage that all data types in 


### PR DESCRIPTION
This PR attempts to address #161 by adding a statement requiring that DID resolvers implement HTTP GET bindings and allowing an alternative HTTP POST binding to be used when desired.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ottomorac/did-resolution/pull/192.html" title="Last updated on Jan 11, 2026, 8:21 PM UTC (b6d4dc7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-resolution/192/907921a...ottomorac:b6d4dc7.html" title="Last updated on Jan 11, 2026, 8:21 PM UTC (b6d4dc7)">Diff</a>