### PR TITLE
Fix quotes in Accept header value

### DIFF
--- a/index.html
+++ b/index.html
@@ -2219,7 +2219,7 @@ The `detail` value SHOULD provide a longer human-readable string for the error.
 				<ol class="algorithm">
 					<li>Append the <var>input <a>DID</a></var> to the <var>request HTTP(S) URL</var>.
 					<pre class="example nohighlight">https://resolver.example/1.0/identifiers/did:example:1234</pre></li>
-					<li>Set the <code>Accept</code> <var>HTTP request header</var> to `application/did-resolution"`
+					<li>Set the <code>Accept</code> <var>HTTP request header</var> to `application/did-resolution`
 						in order to request a complete <a href="#did-resolution-result"></a>, OR</li>
 					<li>set the <code>Accept</code> <var>HTTP request header</var> to the value of the <b>accept</b> <var>resolution option</var>.</li>
 					<li>If any other <var>resolution options</var> are provided:
@@ -2237,7 +2237,7 @@ The `detail` value SHOULD provide a longer human-readable string for the error.
 				<ol class="algorithm">
 					<li>Append the <var>input <a>DID URL</a></var> to the <var>request HTTP(S) URL</var>.
 					<pre class="example nohighlight">https://resolver.example/1.0/identifiers/did:example:1234?service=files&relativeRef=/resume.pdf</pre></li>
-					<li>Set the <code>Accept</code> <var>HTTP request header</var> to `application/did-url-dereferencing"`
+					<li>Set the <code>Accept</code> <var>HTTP request header</var> to `application/did-url-dereferencing`
 						in order to request a complete <a href="#did-url-dereferencing-result"></a>, OR</li>
 					<li>set the <code>Accept</code> <var>HTTP request header</var> to the value of the <b>accept</b> <var>dereferencing option</var>.</li>
 					<li>If any other <var>dereferencing options</var> are provided:
@@ -2385,7 +2385,7 @@ The `detail` value SHOULD provide a longer human-readable string for the error.
 			</li>
 			<li>For the <a>DID resolution</a> function:
 				<ol class="algorithm">
-					<li>If the value of the <code>Content-Type</code> <var>HTTP response header</var> is `application/did-resolution"`:
+					<li>If the value of the <code>Content-Type</code> <var>HTTP response header</var> is `application/did-resolution`:
 						<ol class="algorithm">
 							<li>The <var>HTTP body</var> MUST contain a <a>DID resolution result</a> (see <a href="#did-resolution-result"></a>) that
 								is the result of the <a>DID resolution</a> function.</li>
@@ -2404,7 +2404,7 @@ The `detail` value SHOULD provide a longer human-readable string for the error.
 			</li>
 			<li>For the <a>DID URL dereferencing</a> function:
 				<ol class="algorithm">
-					<li>If the value of the <code>Content-Type</code> <var>HTTP response header</var> is `application/did-url-dereferencing"`:
+					<li>If the value of the <code>Content-Type</code> <var>HTTP response header</var> is `application/did-url-dereferencing`:
 						<ol class="algorithm">
 							<li>The <var>HTTP body</var> MUST contain a <a>DID URL dereferencing result</a> (see <a href="#did-url-dereferencing-result"></a>) that
 								is the result of the <a>DID URL dereferencing</a> function.</li>


### PR DESCRIPTION
Simple editorial fix for quotes in HTTP headers


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-resolution/pull/195.html" title="Last updated on Sep 18, 2025, 12:54 PM UTC (533fd76)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-resolution/195/bc06f2a...533fd76.html" title="Last updated on Sep 18, 2025, 12:54 PM UTC (533fd76)">Diff</a>