### PR TITLE
Fix DID document media types application/did+ld+json -> application/did

### DIFF
--- a/index.html
+++ b/index.html
@@ -1569,7 +1569,7 @@ dereference(didUrl, dereferenceOptions) →
 	<pre class="example"
 		 title="JSON-encoded DID resolution input metadata example">
 {
-"accept": "application/did+ld+json"
+"accept": "application/did"
 }
   </pre>
 
@@ -1580,7 +1580,7 @@ dereference(didUrl, dereferenceOptions) →
 	<pre class="example"
 		 title="DID resolution input metadata example">
 «[
-"accept" → "application/did+ld+json"
+"accept" → "application/did"
 ]»
   </pre>
 
@@ -2004,7 +2004,7 @@ dereference(didUrl, dereferenceOptions) →
 		}]
 	},
 	"didResolutionMetadata": {
-		"contentType": "application/did+ld+json",
+		"contentType": "application/did",
 		"retrieved": "2024-06-01T19:73:24Z",
 	},
 	"didDocumentMetadata": {
@@ -2084,7 +2084,7 @@ dereference(didUrl, dereferenceOptions) →
 		}]
 	},
 	"didUrlDereferencingMetadata": {
-		"contentType": "application/did+ld+json",
+		"contentType": "application/did",
 		"retrieved": "2024-06-01T19:73:24Z",
 	},
 	"contentMetadata": {


### PR DESCRIPTION
This updates some examples to use the correct DID document media type application/did