### PR TITLE
Security Consideration -- DID Resolver Clients should detect resolution cycles

### DIFF
--- a/index.html
+++ b/index.html
@@ -1277,6 +1277,18 @@ dereference(didUrl, dereferenceOptions) →
 										<li>Update the <var>selected <a>service endpoint</a> URL</var> to
 										the result of the "Reference Resolution" algorithm.</li>
 									</ol>
+									<div class="note">
+										<p>
+											Resolving <a>service endpoints</a> — particularly ones that are DIDs — may
+											result in chains that include resolution cycles. For example, a
+											<a>service endpoint</a> might indirectly point back through a sequence of resolutions
+											to a previously dereferenced identifier. <a>DID resolvers</a> recursively resolving
+											<a>service endpoints</a> are advised to detect and handle such cycles to prevent
+											infinite loops or resolution failures. For further guidance, see
+										    <a href="#security-cycles-resolution">Security Considerations: Cycles in
+											Resolution Chains</a>.
+										</p>
+									</div>
 								</li>
 							</ol>
 						</li>
@@ -2681,11 +2693,13 @@ Content-Type: application/did
 	<section id="security-cycles-resolution">
 		<h2>Cycles in Resolution Chains</h2>
 
-		<p>When DID resolver clients dereference identifiers and linked resources in DID documents —
+		<p>When <a>DID resolver</a> clients dereference identifiers and linked resources in DID documents —
 			especially fields like <code>verificationMethod</code>, <code>controller</code>,
 			or <code>alsoKnownAs</code> — they may encounter <strong>cyclic resolution chains</strong>.
-			These can occur when a DID document references another DID (or URL) that eventually leads
-			back to any previously dereferenced identifier, forming a loop.</p>
+			These can occur when a <a>DID document</a> references another DID (or URL) that eventually leads
+			back to a previously dereferenced identifier, forming a loop. <a>DID resolvers</a> can
+			also encounter such situations when dereferencing <a>DID URLs</a> that reference
+			<a>service endpoints</a>.</p>
 
 		<div class="example" title="Cycle Through Controllers">
 			<pre><code>did:example:alice
@@ -2693,9 +2707,8 @@ Content-Type: application/did
 		└── verificationMethod.controller → did:example:alice</code></pre>
 		</div>
 
-		<p>While a conforming DID Resolver resolves only a single DID URL at a time,
-			<strong>DID Resolver Clients</strong> that perform recursive dereferencing
-			across multiple resolutions should expect, detect, and handle such cycles.</p>
+		<p><strong><a>DID resolvers</a> and their clients that perform recursive dereferencing
+			should expect, detect, and handle such cycles</strong>.</p>
 
 		<p><strong>Security and performance risks:</strong> If cycles are not detected and mitigated,
 			recursive dereferencing could lead to:</p>
@@ -2705,9 +2718,9 @@ Content-Type: application/did
 			<li><strong>Denial-of-service (DoS)</strong> vulnerabilities in clients or intermediaries.</li>
 		</ul>
 
-		<p><strong>Mitigation guidance:</strong> Clients that recursively
-			follow external references are encouraged to track identifiers that
-			have already been dereferenced and to detect when a cycle has
+		<p><strong>Mitigation guidance:</strong> Components that recursively
+			follow external <a>DID document</a> references are encouraged to
+			track identifiers that have already been dereferenced and to detect when a cycle has
 			occurred. If a cycle is detected, clients should halt resolution and
 			take appropriate action. In addition, developers may wish to limit
 			recursion depth or breadth to reduce the potential attack surface.</p>

--- a/index.html
+++ b/index.html
@@ -2681,10 +2681,10 @@ Content-Type: application/did
 	<section id="security-cycles-resolution">
 		<h2>Cycles in Resolution Chains</h2>
 
-		<p>When DID resolver clients dereference identifiers and linked resources in DID Documents —
+		<p>When DID resolver clients dereference identifiers and linked resources in DID documents —
 			especially fields like <code>verificationMethod</code>, <code>controller</code>,
 			or <code>alsoKnownAs</code> — they may encounter <strong>cyclic resolution chains</strong>.
-			These can occur when a DID Document references another DID (or URL) that eventually leads
+			These can occur when a DID document references another DID (or URL) that eventually leads
 			back to any previously dereferenced identifier, forming a loop.</p>
 
 		<div class="example" title="Cycle Through Controllers">

--- a/index.html
+++ b/index.html
@@ -1285,7 +1285,7 @@ dereference(didUrl, dereferenceOptions) →
 											back through a sequence of resolutions to a previously dereferenced identifier.
 											<a>DID resolvers</a> recursively resolving <a>service endpoints</a> are advised
 											to detect and handle such cycles to prevent infinite loops or resolution failures.
-											For further guidance, see [[[#resolution-cycles]]].
+											For further guidance, see Section <a href="[#resolution-cycles]">Resolution Cycles</a>.
 										</p>
 									</div>
 								</li>

--- a/index.html
+++ b/index.html
@@ -1279,12 +1279,12 @@ dereference(didUrl, dereferenceOptions) →
 									</ol>
 									<div class="note">
 										<p>
-											Resolving <a>service endpoints</a> — particularly ones that are DIDs — might
+											Resolving a <a>service endpoint</a> — particularly one that is a DID — might
 											result in a <dfn>resolution cycle</dfn>, which is a set of steps that result in
 											an infinite loop. For example, a <a>service endpoint</a> might indirectly point
 											back through a sequence of resolutions to a previously dereferenced identifier.
-											<a>DID resolvers</a> recursively resolving <a>service endpoints</a> are advised
-											to detect and handle such cycles to prevent infinite loops or resolution failures.
+											A <a>DID resolver</a> recursively resolving a <a>service endpoint</a> is advised
+											to detect and handle such a cycle to prevent an infinite loop or resolution failure.
 											For further guidance, see Section <a href="#security-cycles-resolution">Resolution Cycles</a>.
 										</p>
 									</div>
@@ -2692,13 +2692,13 @@ Content-Type: application/did
 	<section id="security-cycles-resolution">
 		<h2>Resolution Cycles</h2>
 
-		<p>When <a>DID resolver</a> clients dereference identifiers and linked resources in DID documents —
+		<p>When a <a>DID resolver</a> client dereferences identifiers and linked resources in a <a>DID document</a> —
 			especially fields like <code>verificationMethod</code>, <code>controller</code>,
-			or <code>alsoKnownAs</code> — they might encounter a <a>resolution cycle</a>.
+			or <code>alsoKnownAs</code> — it might encounter a <a>resolution cycle</a>.
 			These can occur when a <a>DID document</a> references another DID (or URL) that eventually leads
-			back to a previously dereferenced identifier, forming a loop. <a>DID resolvers</a> can
-			also encounter such situations when dereferencing <a>DID URLs</a> that reference
-			<a>service endpoints</a>.</p>
+			back to a previously dereferenced identifier, forming a loop. A <a>DID resolver</a> can
+			also encounter such a situation when dereferencing a <a>DID URL</a> that references
+			a <a>service endpoint</a>.</p>
 
 		<div class="example" title="Cycle Through Controllers">
 			<pre><code>did:example:alice

--- a/index.html
+++ b/index.html
@@ -2707,7 +2707,7 @@ Content-Type: application/did
 		</div>
 
 		<p><strong><a>DID resolvers</a> and their clients that perform recursive dereferencing
-			expect, detect, and handle such cycles</strong>.</p>
+			are expected to expect, detect, and handle such cycles</strong>.</p>
 
 		<p><strong>Security and performance risks:</strong> If cycles are not detected and mitigated,
 			recursive dereferencing could lead to:</p>

--- a/index.html
+++ b/index.html
@@ -1285,7 +1285,7 @@ dereference(didUrl, dereferenceOptions) →
 											back through a sequence of resolutions to a previously dereferenced identifier.
 											<a>DID resolvers</a> recursively resolving <a>service endpoints</a> are advised
 											to detect and handle such cycles to prevent infinite loops or resolution failures.
-											For further guidance, see Section <a href="[#resolution-cycles]">Resolution Cycles</a>.
+											For further guidance, see Section <a href="#security-cycles-resolution">Resolution Cycles</a>.
 										</p>
 									</div>
 								</li>

--- a/index.html
+++ b/index.html
@@ -1279,14 +1279,13 @@ dereference(didUrl, dereferenceOptions) →
 									</ol>
 									<div class="note">
 										<p>
-											Resolving <a>service endpoints</a> — particularly ones that are DIDs — may
-											result in chains that include resolution cycles. For example, a
-											<a>service endpoint</a> might indirectly point back through a sequence of resolutions
-											to a previously dereferenced identifier. <a>DID resolvers</a> recursively resolving
-											<a>service endpoints</a> are advised to detect and handle such cycles to prevent
-											infinite loops or resolution failures. For further guidance, see
-										    <a href="#security-cycles-resolution">Security Considerations: Cycles in
-											Resolution Chains</a>.
+											Resolving <a>service endpoints</a> — particularly ones that are DIDs — might
+											result in a <dfn>resolution cycle</dfn>, which is a set of steps that result in
+											an infinite loop. For example, a <a>service endpoint</a> might indirectly point
+											back through a sequence of resolutions to a previously dereferenced identifier.
+											<a>DID resolvers</a> recursively resolving <a>service endpoints</a> are advised
+											to detect and handle such cycles to prevent infinite loops or resolution failures.
+											For further guidance, see [[[#resolution-cycles]]].
 										</p>
 									</div>
 								</li>
@@ -2691,11 +2690,11 @@ Content-Type: application/did
 	</section>
 
 	<section id="security-cycles-resolution">
-		<h2>Cycles in Resolution Chains</h2>
+		<h2>Resolution Cycles</h2>
 
 		<p>When <a>DID resolver</a> clients dereference identifiers and linked resources in DID documents —
 			especially fields like <code>verificationMethod</code>, <code>controller</code>,
-			or <code>alsoKnownAs</code> — they may encounter <strong>cyclic resolution chains</strong>.
+			or <code>alsoKnownAs</code> — they might encounter a <a>resolution cycle</a>.
 			These can occur when a <a>DID document</a> references another DID (or URL) that eventually leads
 			back to a previously dereferenced identifier, forming a loop. <a>DID resolvers</a> can
 			also encounter such situations when dereferencing <a>DID URLs</a> that reference
@@ -2708,7 +2707,7 @@ Content-Type: application/did
 		</div>
 
 		<p><strong><a>DID resolvers</a> and their clients that perform recursive dereferencing
-			should expect, detect, and handle such cycles</strong>.</p>
+			expect, detect, and handle such cycles</strong>.</p>
 
 		<p><strong>Security and performance risks:</strong> If cycles are not detected and mitigated,
 			recursive dereferencing could lead to:</p>
@@ -2721,8 +2720,7 @@ Content-Type: application/did
 		<p><strong>Mitigation guidance:</strong> Components that recursively
 			follow external <a>DID document</a> references are encouraged to
 			track identifiers that have already been dereferenced and to detect when a cycle has
-			occurred. If a cycle is detected, clients should halt resolution and
-			take appropriate action. In addition, developers may wish to limit
+			occurred and take appropriate action. In addition, developers might wish to limit
 			recursion depth or breadth to reduce the potential attack surface.</p>
 	</section>
 

--- a/index.html
+++ b/index.html
@@ -2678,6 +2678,41 @@ Content-Type: application/did
 	
 	</section>
 
+	<section id="security-cycles-resolution">
+		<h2>Cycles in Resolution Chains</h2>
+
+		<p>When DID resolver clients dereference identifiers and linked resources in DID Documents —
+			especially fields like <code>verificationMethod</code>, <code>controller</code>,
+			or <code>alsoKnownAs</code> — they may encounter <strong>cyclic resolution chains</strong>.
+			These can occur when a DID Document references another DID (or URL) that eventually leads
+			back to any previously dereferenced identifier, forming a loop.</p>
+
+		<div class="example" title="Cycle Through Controllers">
+			<pre><code>did:example:alice
+	└── verificationMethod.controller → did:example:bob
+		└── verificationMethod.controller → did:example:alice</code></pre>
+		</div>
+
+		<p>While a conforming DID Resolver resolves only a single DID URL at a time,
+			<strong>DID Resolver Clients</strong> that perform recursive dereferencing
+			across multiple resolutions should expect, detect, and handle such cycles.</p>
+
+		<p><strong>Security and performance risks:</strong> If cycles are not detected and mitigated,
+			recursive dereferencing could lead to:</p>
+		<ul>
+			<li><strong>Infinite loops</strong> or <strong>stack overflows</strong> in software.</li>
+			<li><strong>Resource exhaustion</strong> (e.g., memory, network, or CPU).</li>
+			<li><strong>Denial-of-service (DoS)</strong> vulnerabilities in clients or intermediaries.</li>
+		</ul>
+
+		<p><strong>Mitigation guidance:</strong> Clients that recursively
+			follow external references are encouraged to track identifiers that
+			have already been dereferenced and to detect when a cycle has
+			occurred. If a cycle is detected, clients should halt resolution and
+			take appropriate action. In addition, developers may wish to limit
+			recursion depth or breadth to reduce the potential attack surface.</p>
+	</section>
+
 </section>
 <section id="privacy-considerations">
 	<h1>Privacy Considerations</h1>


### PR DESCRIPTION
Addresses issue #172 -- that DID resolution cycles can occur across a set of DIDs.

Note that per [my comment](https://github.com/w3c/did-resolution/issues/172#issuecomment-3237527181) I don't think this is a DID Resolver issue per se, because a DID Resolver doesn't recursively resolve identifiers within a DID Doc. This (IMHO) is a DID Resolution Client's concern. As such, I did put this in the Security Considerations section (contrary to @msporny 's advice from the [DID Working Group Meeting on August 28](https://github.com/w3c/did-resolution/issues/172#issuecomment-3234071932)).  Happy to change the location, but I think it is where it belongs.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/swcurran/did-resolution/pull/204.html" title="Last updated on Oct 6, 2025, 7:42 PM UTC (d20d782)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-resolution/204/6faab3d...swcurran:d20d782.html" title="Last updated on Oct 6, 2025, 7:42 PM UTC (d20d782)">Diff</a>