### PR TITLE
Remove auto-publication of pull requests.

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -1,11 +1,8 @@
 # Example: Override respecConfig for W3C deployment and validators.
-name: Echidna Auto-publish
+name: Echidna auto-publish
 on:
-  pull_request:
-    paths: ["**"]
   push:
     branches: [gh-pages]
-    paths: ["**"]
 jobs:
   main:
     name: Echidna Auto-publish WD


### PR DESCRIPTION
We have been publishing every pull request to W3C TR space as a Working Draft. This is not the correct procedure for PRs. This PR fixes our auto-publication to only kick in when something is merged to the gh-pages branch (which is our main branch, which we should also fix to be `main` and not `gh-pages` since we no longer use the legacy gh-pages publication mechanism).