### PR TITLE
Add warning about self attested DID document metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -615,7 +615,7 @@ string">ASCII string</a>. The <a>DID resolver</a> implementation SHOULD use this
 		<p>This metadata typically does not change between invocations of the <a>DID Resolution</a> function unless the <a>DID document</a> changes, as it represents data about the <a>DID document</a>.</p>
 		<p>The sources of this metadata are the <a>DID controller</a> and/or the <a>DID method</a>. 
 			DID document metadata attested to by the DID controller comes with no inherent guarantee of accuracy.
-			Clients should proceed with caution when relying on DID document metadata to inform business logic.
+			Clients are advised to proceed with caution when relying on DID document metadata to inform business logic.
 		</p>
 		<p>Examples of DID document metadata include:</p>
 		<ul>


### PR DESCRIPTION
This addresses #163


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wip-abramson/did-resolution/pull/206.html" title="Last updated on Oct 10, 2025, 12:10 PM UTC (28912de)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-resolution/206/6faab3d...wip-abramson:28912de.html" title="Last updated on Oct 10, 2025, 12:10 PM UTC (28912de)">Diff</a>