### PR TITLE
Create generic FEATURE_NOT_SUPPORTED error

### DIFF
--- a/index.html
+++ b/index.html
@@ -2701,7 +2701,7 @@ Content-Type: application/did
 		<p>Resolvers that implement noCache might be more vulnerable to denial of service attacks,
 			as malicious clients can bypass caching to force expensive network requests and resource consumption.
 			Clients requesting resolution with <code>noCache</code> expect that some resolvers will reject resolution requests that bypass caching.
-			Resolvers that deny resolution without caching SHOULD respond with a <a href="#FEATURE_NOT_SUPPORTED">FEATURE_NOT_SUPPORTED</a> error that makes it clear that bypassing the cache was not permitted
+			Resolvers that deny resolution without caching MUST respond with a <a href="#FEATURE_NOT_SUPPORTED">FEATURE_NOT_SUPPORTED</a> error that makes it clear that bypassing the cache was not permitted
 			so the client can attempt to resolve without using <code>noCache</code>.</p>
 
 			<p class="issue" data-number="10">See corresponding open issue.</p>


### PR DESCRIPTION
This pr addresses https://github.com/w3c/did-resolution/issues/174 , creates a new FEATURE_NOT_SUPPORTED error and references the error back in the Caching section of the spec.

The previous PR was https://github.com/w3c/did-resolution/pull/183 which had to be reverted due to merge conflicts.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ottomorac/did-resolution/pull/211.html" title="Last updated on Oct 9, 2025, 8:33 PM UTC (1ef9327)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-resolution/211/8876f2b...ottomorac:1ef9327.html" title="Last updated on Oct 9, 2025, 8:33 PM UTC (1ef9327)">Diff</a>