### PR TITLE
Standardize error responses per id (#212)

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -150,21 +150,30 @@ paths:
         "400":
           description: Invalid DID or DID URL.
           content:
-            application/problem+json:
+            application/did-resolution:
               schema:
-                $ref: "#/components/schemas/RFC9457ProblemDetails"
+                $ref: "#/components/schemas/ResolutionResult"
+            application/did-url-dereferencing:
+              schema:
+                $ref: "#/components/schemas/DereferencingResult"
         "404":
           description: DID or DID URL not found.
           content:
-            application/problem+json:
+            application/did-resolution:
               schema:
-                $ref: "#/components/schemas/RFC9457ProblemDetails"
+                $ref: "#/components/schemas/ResolutionResult"
+            application/did-url-dereferencing:
+              schema:
+                $ref: "#/components/schemas/DereferencingResult"
         "406":
           description: Representation not supported.
           content:
-            application/problem+json:
+            application/did-resolution:
               schema:
-                $ref: "#/components/schemas/RFC9457ProblemDetails"
+                $ref: "#/components/schemas/ResolutionResult"
+            application/did-url-dereferencing:
+              schema:
+                $ref: "#/components/schemas/DereferencingResult"
         "410":
           description: Successfully resolved, but DID is deactivated.
           content:
@@ -178,21 +187,24 @@ paths:
             application/did-url-dereferencing:
               schema:
                 $ref: "#/components/schemas/DereferencingResult"
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/RFC9457ProblemDetails"
         "500":
           description: Internal Error.
           content:
-            application/problem+json:
+            application/did-resolution:
               schema:
-                $ref: "#/components/schemas/RFC9457ProblemDetails"
+                $ref: "#/components/schemas/ResolutionResult"
+            application/did-url-dereferencing:
+              schema:
+                $ref: "#/components/schemas/DereferencingResult"
         "501":
           description: DID method not supported.
           content:
-            application/problem+json:
+            application/did-resolution:
               schema:
-                $ref: "#/components/schemas/RFC9457ProblemDetails"
+                $ref: "#/components/schemas/ResolutionResult"
+            application/did-url-dereferencing:
+              schema:
+                $ref: "#/components/schemas/DereferencingResult"
 components:
   schemas:
     ResolutionOptions:


### PR DESCRIPTION
Fixes #212

This pull request updates the OpenAPI specification to provide a consistent error response structure, as discussed in the issue.

It adds a `content` block referencing `RFC9457ProblemDetails` to all `4xx` and `5xx` error responses.