### PR TITLE
Prefer UTF-8 for DID Parameters

### DIFF
--- a/index.html
+++ b/index.html
@@ -325,6 +325,13 @@ did:example:123?service=files&amp;relativeRef=/resume.pdf
 	</pre>
 
 	<p>
+		For each DID parameter that is present, its associated value MUST be a 
+		<a data-cite="INFRA#scalar-value-string">scalar value</a>
+		 string serialized into ASCII according to <a data-cite="RFC3987#section-3.1">
+			section 3.1 of RFC3987.</a>
+	</p>
+
+	<p>
 		Some DID parameters are completely independent of any specific <a>DID
 		method</a> and function the same way for all <a>DIDs</a>. Other DID parameters
 		are not supported by all <a>DID methods</a>. Where optional parameters are
@@ -353,8 +360,6 @@ did:example:123?service=files&amp;relativeRef=/resume.pdf
 			</td>
 			<td>
 				Identifies a <a data-cite="did-core#services">service</a> from the <a>DID document</a> by service ID.
-				If present, the associated value MUST be an <a
-					data-lt="ascii string">ASCII string</a>.
 			</td>
 		</tr>
 		<tr>
@@ -363,8 +368,6 @@ did:example:123?service=files&amp;relativeRef=/resume.pdf
 			</td>
 			<td>
 				Identifies a set of one or more <a data-cite="did-core#services">services</a> from the <a>DID document</a> by service type.
-				If present, the associated value MUST be an <a
-					data-lt="ascii string">ASCII string</a>.
 			</td>
 		</tr>
 		<tr>
@@ -376,10 +379,6 @@ did:example:123?service=files&amp;relativeRef=/resume.pdf
 					data-cite="RFC3986#section-4.2">RFC3986 Section 4.2</a> that identifies a
 				<a>resource</a> at a <a>service endpoint</a>, which is selected from a <a>DID
 				document</a> by using the <code>service</code> parameter.
-				If present, the associated value MUST be an <a
-					data-lt="ascii string">ASCII string</a> and MUST use percent-encoding for
-				certain characters as specified in <a data-cite="RFC3986#section-2.1">RFC3986
-				Section 2.1</a>.
 			</td>
 		</tr>
 		<tr>
@@ -389,8 +388,6 @@ did:example:123?service=files&amp;relativeRef=/resume.pdf
 			<td>
 				Identifies a specific version of a <a>DID document</a> to be resolved (the
 				version ID could be sequential, or a <a>UUID</a>, or method-specific).
-				If present, the associated value MUST be an <a
-					data-lt="ascii string">ASCII string</a>.
 			</td>
 		</tr>
 		<tr>
@@ -416,8 +413,6 @@ did:example:123?service=files&amp;relativeRef=/resume.pdf
 			<td>
 				A resource hash of the <a>DID document</a> to add integrity protection, as
 				specified in [[?HASHLINK]]. This parameter is non-normative.
-				If present, the associated value MUST be an
-				<a data-lt="ascii string">ASCII string</a>.
 			</td>
 		</tr>
 


### PR DESCRIPTION
This PR addresses #200 and #201 :
- Includes normative statement about UTF-8 for DID parameters
- Removes ASCII only normative statement from the individual DID parameters (except `versionTime` which should probably remain as ASCII only in my view)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ottomorac/did-resolution/pull/217.html" title="Last updated on Oct 19, 2025, 3:45 AM UTC (349e2b6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-resolution/217/a0da1e3...ottomorac:349e2b6.html" title="Last updated on Oct 19, 2025, 3:45 AM UTC (349e2b6)">Diff</a>