### PR TITLE
Fix broken links in common.js

### DIFF
--- a/common.js
+++ b/common.js
@@ -14,16 +14,6 @@ var ccg = {
       ],
       publisher: "University of California, Irvine."
     },
-    "DID-METHODS": {
-      title: "Decentralized Identifier Methods",
-      href: "https://www.w3.org/TR/did-extensions-methods/",
-      authors: [
-        "Manu Sporny",
-        "Drummond Reed"
-      ],
-      status: "WG-NOTE",
-      publisher: "W3C Decentralized Identifier Working Group"
-    },
     "HASHLINK": {
       title: "Cryptographic Hyperlinks",
       date: "December 2018",


### PR DESCRIPTION
This addresses #214 

I updated the definition for the DID-KEy reference and removed the outdated DID-METHODS reference. 

DID-METHODS wasn't referenced throughout the spec and if we need to reference we should use DID-EXTENSIONS-METHODS.

I also noticed DATA-INTEGRITY is defined in the commonjs, which doesn't seem to be referenced and probably should be cleaned up too as it has been published as a formal standard now. Can add that to this PR is people agree?