### PR TITLE
Define network based conformance classes for resolver and dereferencer

### DIFF
--- a/index.html
+++ b/index.html
@@ -488,9 +488,7 @@ resolve(did, resolutionOptions) →
 	<p>
 		All [=conforming DID resolvers=] MUST implement the <a>DID resolution</a>
 		function for at least one <a>DID method</a> and MUST be able to return a
-		<a>DID document</a> in at least one conformant <a>representation</a>. All 
-		inputs and outputs of the <code>resolve</code> function are MUST be serializable
-		to JSON.
+		<a>DID document</a> in at least one conformant <a>representation</a>.
 
 	</p>
 


### PR DESCRIPTION
This attempts to address #213 

I have addressed this issue a little differently than discussed. Specifically around naming of the conformance class.

I have a conforming resolver (the software bit) then a conforming network-based resolver is a conforming resolver that implements HTTP Binding.

I also added a similar class for DID URL dereferencers.

Then I attempted to clarify the requirement for JSON serialization of inputs and outputs for both resolving and dereferencing. 

Reviews appreciated.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wip-abramson/did-resolution/pull/243.html" title="Last updated on Jan 11, 2026, 8:21 PM UTC (4d40db3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-resolution/243/a0da1e3...wip-abramson:4d40db3.html" title="Last updated on Jan 11, 2026, 8:21 PM UTC (4d40db3)">Diff</a>