### PR TITLE
Remove note about did resolution and de-referencing

### DIFF
--- a/index.html
+++ b/index.html
@@ -188,10 +188,6 @@ which describes the underlying DID architecture in full detail.
 	required to communicate with a DID's <a>verifiable data registry</a> are defined by the applicable
 	<a>DID method</a> specification.</p>
 
-	<p class="note">The difference between "resolving" a <a>DID</a> and "dereferencing" a <a>DID URL</a>
-	is being thoroughly discussed by the community. For example, see
-	<a href="https://github.com/w3c/did-spec/issues/166#issuecomment-464502719">this comment</a>.</p>
-
 	<section id="implementer-overview" class="informative">
 		<h2>Implementer Overview</h2>
 		<p>


### PR DESCRIPTION
This PR addresses #227 , it removes the green box note about difference between "resolving" a DID and "dereferencing" a DID URL.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ottomorac/did-resolution/pull/245.html" title="Last updated on Nov 7, 2025, 9:09 PM UTC (247a0b8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-resolution/245/a0da1e3...ottomorac:247a0b8.html" title="Last updated on Nov 7, 2025, 9:09 PM UTC (247a0b8)">Diff</a>