### PR TITLE
Define generic datetime format for DID resolution and use throughout spec

### DIFF
--- a/index.html
+++ b/index.html
@@ -401,7 +401,7 @@ did:example:123?service=files&amp;relativeRef=/resume.pdf
 				Identifies a certain version timestamp of a <a>DID document</a> to be resolved.
 				That is, the most recent version of the <a>DID document</a> that was valid for a <a>DID</a>
 				before the specified `versionTime`. If present, the associated value
-				MUST be represented in the datetime formate as defined in <a href="#datetime"></a>.
+				MUST be represented in the datetime format as defined in <a href="#datetime"></a>.
 			</td>
 		</tr>
 		<tr>
@@ -453,7 +453,7 @@ did:example:123?service=files&amp;relativeRef=/resume.pdf
 		<h3>Datetime</h3>
 
 		<p>
-			All Datetime values in this specification MUST be an <a	data-lt="ascii string">
+			All datetime values in this specification MUST be an <a	data-lt="ascii string">
 				ASCII string</a> which is a valid XML datetime value defined by the 
 			[[VC-DATA-MODEL]] in <a data-cite="vc-data-model#representing-time"></a>. 
 			Additionally, timestamps used in DID Resolution MUST be adjusted to UTC 


### PR DESCRIPTION
This is a work in progress, I just want to check it is along the right lines.

So far I have added a Datetime section to the spec with a definition of the datetime format that references the VCDM and uses the adjust to UTC language.

I then updated versionTime to reference this section as the format for the datetime.

A review of the Datetime definition would be appreciated. I was unsure about keeping the ASCII string part in, but I didn't see anything about that in the VCDM representing time section - https://w3c.github.io/vc-data-model/#representing-time.
/?

Also, is the way I am referencing the Datetime section from versionTime okay with the normative language? 

Once I have had some reviews and we settle on some language, I will apply the change to all datetime properties throughout the spec.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wip-abramson/did-resolution/pull/248.html" title="Last updated on Jan 11, 2026, 8:22 PM UTC (8cdc289)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-resolution/248/a0da1e3...wip-abramson:8cdc289.html" title="Last updated on Jan 11, 2026, 8:22 PM UTC (8cdc289)">Diff</a>