### PR TITLE
Update didDocument definition to remove ambiguous use of match and reference the DID data model section

### DIFF
--- a/index.html
+++ b/index.html
@@ -540,10 +540,10 @@ resolve(did, resolutionOptions) →
 		<dd>
 			If the resolution is successful, this MUST be a <a>DID document</a> that
 			is capable of being represented in one of the conformant
-			<a data-cite="did-core#representations">representations</a> of the [[[DID]]] specification.
-			The value of <code><a data-cite="did-core#dfn-id">id</a></code> in the resolved <a>DID document</a> MUST
-			match the <a>DID</a> that was resolved. If the resolution is unsuccessful, this
-			value MUST be empty.
+			<a data-cite="did#representations">representations</a> of the <a data-cite="did#data-model"></a> 
+			specification. The value of <code><a data-cite="did#dfn-id">id</a></code> 
+			in the resolved <a>DID document</a> MUST be string equivalent to the <a>DID</a> that was resolved. 
+			If the resolution is unsuccessful, this	value MUST be empty.
 		</dd>
 		<dt>
 			<dfn>didDocumentMetadata</dfn>


### PR DESCRIPTION
This addresses #231 and #233.

The only part that is missing is the references are still going to DID 1.0 instead of 1.1. I think this is something to do with ReSpec and the fact that DID 1.1 is not a full standard yet. As soon as it is, I believe these references would update?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wip-abramson/did-resolution/pull/249.html" title="Last updated on Dec 1, 2025, 1:40 AM UTC (4953f62)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-resolution/249/a0da1e3...wip-abramson:4953f62.html" title="Last updated on Dec 1, 2025, 1:40 AM UTC (4953f62)">Diff</a>