### PR TITLE
Clarify proof property definition

### DIFF
--- a/index.html
+++ b/index.html
@@ -668,7 +668,7 @@ string">ASCII string</a>. The <a>DID resolver</a> implementation SHOULD use this
                     <a>DID resolution</a> metadata MAY include a <code>proof</code> property.
                     If present, the value MUST be a <a
                         data-cite="INFRA#sets">set</a> where each item is a
-                    <a data-cite="INFRA#maps">map</a> that contains a proof. The use of this property
+                    <a data-cite="INFRA#maps">map</a> that represents a proof. The use of this property
                     and the types of proofs are <a>DID method</a>-independent.
                 </p>
             </dd>
@@ -869,7 +869,7 @@ string">ASCII string</a>.
                     <a>DID document</a> metadata MAY include a <code>proof</code> property.
                     If present, the value MUST be a <a
                         data-cite="INFRA#sets">set</a> where each item is a
-                    <a data-cite="INFRA#maps">map</a> that contains a proof. The use of this property
+                    <a data-cite="INFRA#maps">map</a> that represents a proof. The use of this property
                     and the types of proofs are <a>DID method</a>-specific.
                 </p>
             </dd>
@@ -1225,7 +1225,7 @@ dereference(didUrl, dereferenceOptions) →
                     <a>DID URL dereferencing</a> metadata MAY include a <code>proof</code> property.
                     If present, the value MUST be a <a
                         data-cite="INFRA#sets">set</a> where each item is a
-                    <a data-cite="INFRA#maps">map</a> that contains a proof. The use of this property
+                    <a data-cite="INFRA#maps">map</a> that represents a proof. The use of this property
                     and the types of proofs are <a>DID method</a>-independent.
                 </p>
             </dd>


### PR DESCRIPTION
This addresses #235 per @peacekeeper's suggestion.

However, it does not address the final part of Jeffery's initial comment:

> I also don't see a definition of the proofs these maps are supposed to hold.

There is no definition of what proofs are supposed to hold, this is DID method specific I believe. Are there even any DID methods today that define how to use this property? Are we just reserving the proof field for DID methods to override how they like?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wip-abramson/did-resolution/pull/250.html" title="Last updated on Dec 1, 2025, 5:02 AM UTC (f88e317)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-resolution/250/a0da1e3...wip-abramson:f88e317.html" title="Last updated on Dec 1, 2025, 5:02 AM UTC (f88e317)">Diff</a>