### PR TITLE
Clarify DID document representation in relation to accept header

### DIFF
--- a/index.html
+++ b/index.html
@@ -579,7 +579,7 @@ resolve(did, resolutionOptions) →
 string">ASCII string</a>. The <a>DID resolver</a> implementation SHOULD use this
 				value to determine the <a>representation</a> of the returned
 				<code>didDocument</code> if such a <a>representation</a> is supported and
-				available. Any <a>representation</a> MUST be able to be tranlated into
+				available. Any <a>representation</a> MUST be able to be translated into
 				the representation defined by the <code>application/did</code> mediaType. 
 				This property is OPTIONAL.
 			</dd>


### PR DESCRIPTION
This is an attempt at some language to address #234.

I was unsure if we also wanted to change the didDocument definition - https://www.w3.org/TR/did-resolution/#dfn-diddocument here. Specifically to clarify that there is only one conformant representation `application/did`?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wip-abramson/did-resolution/pull/257.html" title="Last updated on Jan 11, 2026, 8:22 PM UTC (66fb38d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-resolution/257/fea2060...wip-abramson:66fb38d.html" title="Last updated on Jan 11, 2026, 8:22 PM UTC (66fb38d)">Diff</a>