### PR TITLE
Remove unnecessary normative text from DID Resolution Algorithm.

### DIFF
--- a/index.html
+++ b/index.html
@@ -899,8 +899,7 @@ string">ASCII string</a>.
 			</ol>
 			</li>
 			<li>Obtain the <a>DID document</a> for the <var>input <a>DID</a></var> by executing the
-			<a href="https://www.w3.org/TR/did-core/#method-operations">Read</a> operation against the
-			<var>input <a>DID</a>'s</var> <a>verifiable data registry</a>, as defined by the <var>input <a>DID method</a></var>:
+			<a href="https://www.w3.org/TR/did-core/#method-operations">Read</a> operation, as defined by the <var>input <a>DID method</a></var>:
 			<ol class="algorithm">
 				<li>Besides the <var>input <a>DID</a></var>, all additional <var>resolution options</var> of
 				this algorithm MUST be passed to the


### PR DESCRIPTION
This PR is an attempt to address issue #236 by removing unnecessary normative text related to the verifiable data registry from the DID Resolution Algorithm.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/msporny/did-resolution/pull/263.html" title="Last updated on Dec 18, 2025, 3:37 PM UTC (f4e3be7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-resolution/263/602f42b...msporny:f4e3be7.html" title="Last updated on Dec 18, 2025, 3:37 PM UTC (f4e3be7)">Diff</a>