### PR TITLE
Remove or add into algorithms the unthrown errors in specification 

### DIFF
--- a/index.html
+++ b/index.html
@@ -900,6 +900,25 @@ string">ASCII string</a>.
 				<li><b>didDocumentMetadata</b>: <code>«[ ]»</code></li>
 			</ol>
 			</li>
+			<li>
+				Determine whether the <var>input <a href="#did-resolution-options">DID resolution options</a></var>
+				are supported by the <a>DID resolver</a> that implements this algorithm. If not, the <a>DID resolver</a>
+				MUST return the following result:
+				<ol class="algorithm">
+					<li><b>didResolutionMetadata</b>: <var>error object</var> with type set to <a href="#FEATURE_NOT_SUPPORTED">FEATURE_NOT_SUPPORTED</a></li>
+					<li><b>didDocument</b>: <code>null</code></li>
+					<li><b>didDocumentMetadata</b>: <code>«[ ]»</code></li>
+				</ol>
+			</li>
+			<li>
+				Determine whether the <var>input <a href="#did-resolution-options">DID resolution options</a></var>
+				are valid. If not, the <a>DID resolver</a> MUST return the following result:
+				<ol class="algorithm">
+					<li><b>didResolutionMetadata</b>: <var>error object</var> with type set to <a href="#INVALID_OPTIONS">INVALID_OPTIONS</a></li>
+					<li><b>didDocument</b>: <code>null</code></li>
+					<li><b>didDocumentMetadata</b>: <code>«[ ]»</code></li>
+				</ol>
+			</li>
 			<li>Obtain the <a>DID document</a> for the <var>input <a>DID</a></var> by executing the
 			<a href="https://www.w3.org/TR/did-core/#method-operations">Read</a> operation, as defined by the <var>input <a>DID method</a></var>:
 			<ol class="algorithm">
@@ -958,6 +977,16 @@ string">ASCII string</a>.
 				</ol>
 			</li>
 		</ol>
+
+		<p>
+			If the <a>DID resolver</a> encounters any unexpected errors during the execution of the DID Resolution algorithm,
+			it MUST return the following result:
+			<ol class="algorithm">
+				<li><b>didResolutionMetadata</b>: <var>error object</var> with type set to <a href="#INTERNAL_ERROR">INTERNAL_ERROR</a></li>
+				<li><b>didDocument</b>: <code>null</code></li>
+				<li><b>didDocumentMetadata</b>: <code>«[ ]»</code></li>
+			</ol>
+		</p>
 
 	</section>
 
@@ -2433,6 +2462,14 @@ Accept: application/did-url-dereferencing
 					<tr>
 						<td>
 							<code>METHOD_NOT_SUPPORTED</code>
+						</td>
+						<td>
+							<code>501</code>
+						</td>
+					</tr>
+					<tr>
+						<td>
+							<code>FEATURE_NOT_SUPPORTED</code>
 						</td>
 						<td>
 							<code>501</code>


### PR DESCRIPTION
This attempts to address #247.

I have added some steps to the DID Resolution Algorithm to throw the FEATURE_NOT_SUPPORTED and INVALID_OPTIONS errors. Additionally I added a paragraph at the end of the algorithm about throwing INTERNAL_ERROR on unexpected errors.

There may be a better way to handle this, wanted to get something in a PR folks could see and argue over.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wip-abramson/did-resolution/pull/265.html" title="Last updated on Jan 14, 2026, 2:55 PM UTC (a65d403)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-resolution/265/dfc9019...wip-abramson:a65d403.html" title="Last updated on Jan 14, 2026, 2:55 PM UTC (a65d403)">Diff</a>