### PR TITLE
Fix example in implementer overview

### DIFF
--- a/index.html
+++ b/index.html
@@ -197,7 +197,7 @@ which describes the underlying DID architecture in full detail.
 			service endpoints, or status.
 		<p>
 			For example, to retrieve the state of the DID `did:example:123`
-             at a past time, a wallet app could resolve the DID with the `versionTime`
+             at a time in the past, a client application could resolve the DID with the `versionTime`
              resolution option, as in the following:<br>
              `resolve("did:example:123", {"versionTime":"2021-05-10T17:00:00Z"})`
 


### PR DESCRIPTION
This PR addresses https://github.com/w3c/did-resolution/issues/228, it clarifies the example usage of how to call the resolve function in the Implementer Overview paragraph.

It also updates the DID Resolution Test Suite link (per request from @wip-abramson ).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ottomorac/did-resolution/pull/266.html" title="Last updated on Feb 3, 2026, 8:58 PM UTC (41e2efd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-resolution/266/b78b770...ottomorac:41e2efd.html" title="Last updated on Feb 3, 2026, 8:58 PM UTC (41e2efd)">Diff</a>