### PR TITLE
Use Unicode names to denote special characters.

### DIFF
--- a/terms.html
+++ b/terms.html
@@ -64,8 +64,10 @@ included whenever they appear in this specification.
 
   <dt><dfn data-lt="DID fragments">DID fragment</dfn></dt>
   <dd>
-    The portion of a <a>DID URL</a> that follows the first <span class="codepoint" translate="no"><bdi lang="en">&#x23;</bdi> character
-    (<code class="uname">U+0023 NUMBER SIGN</code>)</span>. DID fragment syntax is identical to URI fragment syntax.
+    The portion of a <a>DID URL</a> that follows the first
+    <span class="codepoint" translate="no"><bdi lang="en">&#x23;</bdi> character
+    (<code class="uname">U+0023 NUMBER SIGN</code>)</span>. DID fragment syntax
+    is identical to URI fragment syntax.
   </dd>
 
   <dt><dfn data-lt="DID method's">DID method</dfn></dt>
@@ -80,7 +82,8 @@ included whenever they appear in this specification.
   <dd>
     The portion of a <a>DID URL</a> that begins with and includes the first 
     <span class="codepoint" translate="no"><bdi lang="en">&#x2f;</bdi> character 
-    (<code class="uname">U+002F SOLIDUS</code>)</span> and ends with either a     
+    (<code class="uname">U+002F SOLIDUS</code>)</span> and ends with but does
+    not include either a
     <span class="codepoint" translate="no"><bdi lang="en">&#x3f;</bdi> character
     (<code class="uname">U+003F QUESTION MARK</code>)</span>, a
     <span class="codepoint" translate="no"><bdi lang="en">&#x23;</bdi> character
@@ -91,7 +94,7 @@ included whenever they appear in this specification.
 
   <dt><dfn data-lt="DID queries">DID query</dfn></dt>
   <dd>
-    The portion of a <a>DID URL</a> that follows and includes the
+    The portion of a <a>DID URL</a> that follows and includes the first
     <span class="codepoint" translate="no"><bdi lang="en">&#x3f;</bdi> character
     (<code class="uname">U+003F QUESTION MARK</code>)</span>.
     DID query syntax is identical to URI query


### PR DESCRIPTION
This PR is an attempt to address issue #202 by using Unicode character names to denote special characters.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/msporny/did-resolution/pull/269.html" title="Last updated on Jan 17, 2026, 2:21 PM UTC (d1261e6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-resolution/269/2c695fc...msporny:d1261e6.html" title="Last updated on Jan 17, 2026, 2:21 PM UTC (d1261e6)">Diff</a>