### PR TITLE
Make https binding mandatory for network-based did resolvers

### DIFF
--- a/index.html
+++ b/index.html
@@ -1630,8 +1630,8 @@ dereference(didUrl, dereferenceOptions) →
 			<a data-cite="INFRA#lists">list</a>,
 			<a data-cite="INFRA#sets">set</a>,
 		<a data-cite="INFRA#boolean">boolean</a>, or
-s		<a data-cite="INFRA#nulls">null</a>. The values within any complex data
-		structure such as a map or list MUST also be one of these data types.
+		<a data-cite="INFRA#nulls">null</a>.
+
 		The entire metadata structure MUST be serializable according to the <a
 			data-cite="INFRA#serialize-an-infra-value-to-json-bytes">JSON
 		serialization rules</a> in the [[INFRA]] specification. Implementations MAY


### PR DESCRIPTION
This PR addresses https://github.com/w3c/did-resolution/issues/93 

- Network based did resolvers MUST implement the GET version of the https binding and MAY implement the POST version
- All https bindings MUST use TLS

I had to abandon the previous PR https://github.com/w3c/did-resolution/pull/182 because it was too out of synch with the main branch.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ottomorac/did-resolution/pull/272.html" title="Last updated on Feb 7, 2026, 5:02 PM UTC (ee41dbd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-resolution/272/5d29cbe...ottomorac:ee41dbd.html" title="Last updated on Feb 7, 2026, 5:02 PM UTC (ee41dbd)">Diff</a>