### PR TITLE
fully express error URLs

### DIFF
--- a/index.html
+++ b/index.html
@@ -2256,51 +2256,50 @@ The `detail` value SHOULD provide a longer human-readable string for the error.
 		</dd>
 		<dt id="INVALID_DID_DOCUMENT">INVALID_DID_DOCUMENT</dt>
 		<dd>
-            The [=DID document=] was malformed. See Section <a href="#resolving-algorithm"></a>.
+			The [=DID document=] was malformed. See Section <a href="#resolving-algorithm"></a>.
 			<div><code>https://www.w3.org/ns/did#INVALID_DID_DOCUMENT</code></div>
 		</dd>
-        <dt id="NOT_FOUND">NOT_FOUND</dt>
+		<dt id="NOT_FOUND">NOT_FOUND</dt>
 		<dd>
-            The <a>DID resolver</a> was unable to find the <a>DID document</a>
+			The <a>DID resolver</a> was unable to find the <a>DID document</a>
 			resulting from this resolution request. See Section <a href="#resolving-algorithm"></a>.
 			<div><code>https://www.w3.org/ns/did#NOT_FOUND</code></div>
 		</dd>
-        <dt id="REPRESENTATION_NOT_SUPPORTED">REPRESENTATION_NOT_SUPPORTED</dt>
+		<dt id="REPRESENTATION_NOT_SUPPORTED">REPRESENTATION_NOT_SUPPORTED</dt>
 		<dd>
 			The <a>representation</a> requested via the <code>accept</code> input metadata property
-            is not supported by the <a>DID method</a> and/or <a>DID resolver</a> implementation.
-            See Section <a href="#resolving-algorithm"></a>.
+			is not supported by the <a>DID method</a> and/or <a>DID resolver</a> implementation.
+			See Section <a href="#resolving-algorithm"></a>.
 			<div><code>https://www.w3.org/ns/did#REPRESENTATION_NOT_SUPPORTED</code></div>
 		</dd>
-        <dt id="INVALID_DID_URL">INVALID_DID_URL</dt>
+		<dt id="INVALID_DID_URL">INVALID_DID_URL</dt>
 		<dd>
 			An invalid <a>DID URL</a> was detected during <a>DID URL dereferencing</a>.
-            See Section <a href="#dereferencing-algorithm"></a>
+			See Section <a href="#dereferencing-algorithm"></a>
 			<div><code>https://www.w3.org/ns/did#INVALID_DID_URL</code></div>
 		</dd>
-        <dt id="METHOD_NOT_SUPPORTED">METHOD_NOT_SUPPORTED</dt>
+		<dt id="METHOD_NOT_SUPPORTED">METHOD_NOT_SUPPORTED</dt>
 		<dd>
-			The DID method of the DID is not supported by the <a>DID resolver</a>. See Section <a href="#resolving-algorithm"></a>.
+			The DID method of the DID is not supported by the <a>DID resolver</a>. See Section <a
+				href="#resolving-algorithm"></a>.
 			<div><code>https://www.w3.org/ns/did#METHOD_NOT_SUPPORTED</code></div>
 		</dd>
-        <dt id="INVALID_OPTIONS">INVALID_OPTIONS</dt>
+		<dt id="INVALID_OPTIONS">INVALID_OPTIONS</dt>
 		<dd>
 			One or more of the options provided for <a>DID Resolution</a> or <a>DID URL dereferencing</a> are invalid.
 			<div><code>https://www.w3.org/ns/did#INVALID_OPTIONS</code></div>
 		</dd>
-        <dt id="INTERNAL_ERROR">INTERNAL_ERROR</dt>
+		<dt id="INTERNAL_ERROR">INTERNAL_ERROR</dt>
 		<dd>
 			An unexpected error occured during <a>DID Resolution</a> or <a>DID URL dereferencing</a>.
 			<div><code>https://www.w3.org/ns/did#INTERNAL_ERROR</code></div>
 		</dd>
 		<dt id="FEATURE_NOT_SUPPORTED">FEATURE_NOT_SUPPORTED</dt>
 		<dd>
-		The <a>DID resolver</a> does not support the requested feature. The value of the `detail` field
-		SHOULD provide a longer description of the feature that is not supported by the resolver.
+			The <a>DID resolver</a> does not support the requested feature. The value of the `detail` field
+			SHOULD provide a longer description of the feature that is not supported by the resolver.
 			<div><code>https://www.w3.org/ns/did#FEATURE_NOT_SUPPORTED</code></div>
 		</dd>
-		</dl>
-	  <dl>
 	</dl>
 
 


### PR DESCRIPTION
- **Use full URLs for error values.**
- **Add full URLs to error list.**
- **Cleanup Errors section `<dl>` code.**

Fixes #240.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/BigBlueHat/did-resolution/pull/280.html" title="Last updated on Jan 22, 2026, 7:50 PM UTC (858aebb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-resolution/280/c6ebc22...BigBlueHat:858aebb.html" title="Last updated on Jan 22, 2026, 7:50 PM UTC (858aebb)">Diff</a>