### PR TITLE
Avoid duplicating terms from DID-Core

### DIFF
--- a/index.html
+++ b/index.html
@@ -385,7 +385,7 @@ did:example:123?service=files&amp;relativeRef=/resume.pdf
 			<td>
 				A relative <a>URI</a> reference according to <a
 					data-cite="RFC3986#section-4.2">RFC3986 Section 4.2</a> that identifies a
-				<a>resource</a> at a [=did service endpoint=], which is selected from a <a>DID
+				<a>resource</a> at a [=DID service endpoint=], which is selected from a <a>DID
 				document</a> by using the <code>service</code> parameter.
 			</td>
 		</tr>
@@ -1362,28 +1362,28 @@ dereference(didUrl, dereferenceOptions) →
 										is a <a data-cite="INFRA#maps">map</a>, skip this <var>selected <a>service</a></var>.</li>
 										<li>If the value of the <code>serviceEndpoint</code> property of the <var>selected <a>service</a></var>
 											is a <a data-cite="INFRA#string">string</a>, add this value to a list of
-											<var>selected [=did service endpoint=] URLs</var>.</li>
+											<var>selected [=DID service endpoint=] URLs</var>.</li>
 										<li>If the value of the <code>serviceEndpoint</code> property of the <var>selected <a>service</a></var>
 											is a <a data-cite="INFRA#sets">set</a>, add all its items that are <a data-cite="INFRA#string">strings</a>
-											to a list of <var>selected [=did service endpoint=] URLs</var>.</li>
+											to a list of <var>selected [=DID service endpoint=] URLs</var>.</li>
 									</ol>
 								</li>
-								<li>For each <var>selected [=did service endpoint=] URL</var>, execute the algorithm specified in
+								<li>For each <var>selected [=DID service endpoint=] URL</var>, execute the algorithm specified in
 									<a data-cite="RFC3986#section-5">RFC3986 Section 5: Reference Resolution</a> as follows:
 									<ol class="algorithm">
-										<li>The <strong>base URI</strong> value is the <var>selected [=did service endpoint=] URL</var>.</li>
+										<li>The <strong>base URI</strong> value is the <var>selected [=DID service endpoint=] URL</var>.</li>
 										<li>The <strong>relative reference</strong> is the value of the
 											<a data-cite="did-core#did-parameters">DID parameter</a> <code>relativeRef</code>.</li>
-										<li>Update the <var>selected [=did service endpoint=] URL</var> to
+										<li>Update the <var>selected [=DID service endpoint=] URL</var> to
 										the result of the "Reference Resolution" algorithm.</li>
 									</ol>
 									<div class="note">
 										<p>
-											Resolving a [=did service endpoint=] — particularly one that is a DID — might
+											Resolving a [=DID service endpoint=] — particularly one that is a DID — might
 											result in a <dfn>resolution cycle</dfn>, which is a set of steps that result in
-											an infinite loop. For example, a [=did service endpoint=] might indirectly point
+											an infinite loop. For example, a [=DID service endpoint=] might indirectly point
 											back through a sequence of resolutions to a previously dereferenced identifier.
-											A <a>DID resolver</a> recursively resolving a [=did service endpoint=] is advised
+											A <a>DID resolver</a> recursively resolving a [=DID service endpoint=] is advised
 											to detect and handle such a cycle to prevent an infinite loop or resolution failure.
 											For further guidance, see Section <a href="#security-cycles-resolution">Resolution Cycles</a>.
 										</p>
@@ -1496,16 +1496,16 @@ dereference(didUrl, dereferenceOptions) →
 					</li>
 				</ol>
 				</li>
-				<li>If the result of <a href="#dereferencing-algorithm-resource"></a> is a <var>selected [=did service endpoint=] URL</var>,
+				<li>If the result of <a href="#dereferencing-algorithm-resource"></a> is a <var>selected [=DID service endpoint=] URL</var>,
 				and the <var>input <a>DID URL</a></var> contains a <a>DID fragment</a>:
 				<pre class="example nohighlight">did:example:1234?service=files&relativeRef=%2Fmyresume%2Fdoc%3Fversion%3Dlatest#intro</pre>
 				<ol class="algorithm">
-					<li>If the <var>selected [=did service endpoint=] URL</var>
+					<li>If the <var>selected [=DID service endpoint=] URL</var>
 					contains a <code>fragment</code> component, raise an error.</li>
-					<li>Append the <a>DID fragment</a> to the <var>select [=did service endpoint=] URL</var>. In other words,
-					the <var>select [=did service endpoint=] URL</var> "inherits" the <a>DID fragment</a> of the
+					<li>Append the <a>DID fragment</a> to the <var>select [=DID service endpoint=] URL</var>. In other words,
+					the <var>select [=DID service endpoint=] URL</var> "inherits" the <a>DID fragment</a> of the
 					<var>input <a>DID URL</a></var>.</li>
-					<li>Return the <var>select [=did service endpoint=] URL</var>.</li>
+					<li>Return the <var>select [=DID service endpoint=] URL</var>.</li>
 				</ol>
 				</li>
 				<li>Otherwise, dereference the DID fragment as defined by the media type ([[RFC2046]]) of the resource.
@@ -1593,7 +1593,7 @@ dereference(didUrl, dereferenceOptions) →
 	did:example:123456789abcdefghi?service=messages&relativeRef=%2Fsome%2Fpath%3Fquery#frag
 	</pre>
 			<p>... and the same <var>resolved <a>DID document</a></var> as in the previous section.<p>
-			<p>... then the result of the <a href="#dereferencing"></a> algorithm is the following <var>selected [=did service endpoint=] URL</var>:</p>
+			<p>... then the result of the <a href="#dereferencing"></a> algorithm is the following <var>selected [=DID service endpoint=] URL</var>:</p>
 			<pre class="example nohighlight">
 	https://example.com/messages/8377464/some/path?query#frag
 	</pre>
@@ -2042,9 +2042,9 @@ dereference(didUrl, dereferenceOptions) →
 		</figure>
 
 		<p>Given the <a>DID URL</a> <code>did:xyz:1234?service=agent&relativeRef=%2Fsome%2Fpath%3Fquery#frag</code>, a <a>DID resolver</a> could be invoked
-			for <a href="#dereferencing-algorithm-resource">Dereferencing the Resource</a> (i.e., a [=did service endpoint=] URL),
+			for <a href="#dereferencing-algorithm-resource">Dereferencing the Resource</a> (i.e., a [=DID service endpoint=] URL),
 			and the <a>client</a> could complete the <a>DID URL dereferencing</a> algorithm by
-			<a href="#dereferencing-algorithm-fragment">Dereferencing the Fragment</a> (i.e., a [=did service endpoint=] URL with a fragment).</p>
+			<a href="#dereferencing-algorithm-fragment">Dereferencing the Fragment</a> (i.e., a [=DID service endpoint=] URL with a fragment).</p>
 
 		<figure id="figure-client-side-dereferencing-2">
 			<img style="margin: auto; display: block; width: 100%; margin-bottom: 20px;" src="diagrams/section-7/client-side-dereferencing-2.svg"
@@ -2525,7 +2525,7 @@ Accept: application/did-url-dereferencing
 						<ol class="algorithm">
 							<li>The HTTP response status code MUST be <code>303</code>.</li>
 							<li>The HTTP response MUST contain an <code>Location</code> header. The value of this header
-								MUST be the <var>selected [=did service endpoint=] URL</var>.</li>
+								MUST be the <var>selected [=DID service endpoint=] URL</var>.</li>
 							<li>the HTTP response body MUST be empty.</li>
 						</ol>
 					</li>
@@ -2754,7 +2754,7 @@ Content-Type: application/did
 			These can occur when a <a>DID document</a> references another DID (or URL) that eventually leads
 			back to a previously dereferenced identifier, forming a loop. A <a>DID resolver</a> can
 			also encounter such a situation when dereferencing a <a>DID URL</a> that references
-			a [=did service endpoint=].</p>
+			a [=DID service endpoint=].</p>
 
 		<div class="example" title="Cycle Through Controllers">
 			<pre><code>did:example:alice

--- a/terms.html
+++ b/terms.html
@@ -59,7 +59,7 @@ included whenever they appear in this specification.
   <dt><dfn data-lt="service">services</dfn></dt>
   <dd>
     Means of communicating or interacting with the <a>DID subject</a> or
-    associated entities via one or more <a data-cite="did-core#dfn-did-service-endpoints">service endpoints</a>.
+    associated entities via one or more [=DID service endpoints=].
     Examples include discovery services, agent services, social networking
     services, file storage services, and verifiable credential repository services.
   </dd>


### PR DESCRIPTION
This PR addresses https://github.com/w3c/did-resolution/issues/232 by removing duplicate term definitions from DID-Core. I have decided to keep the following terms however, since they are not specific to the DID spec (even though they are defined in both the DID Core and DID Resolution spec:

- resource
- representation


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ottomorac/did-resolution/pull/285.html" title="Last updated on Jan 29, 2026, 3:34 PM UTC (3e79d37)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-resolution/285/e0d4da9...ottomorac:3e79d37.html" title="Last updated on Jan 29, 2026, 3:34 PM UTC (3e79d37)">Diff</a>