### PR TITLE
Add privacy considerations to address tracking of requests

### DIFF
--- a/index.html
+++ b/index.html
@@ -2808,7 +2808,7 @@ Content-Type: application/did
 	<p>
 	This section details the privacy considerations specific to DID Resolution.
 	Readers are urged to familiarize themselves with the general
-	privacy advice provided in the Privacy Considerations section of the
+	privacy advice provided in the Privacy Considerations sections of the
 	<a href="https://www.w3.org/TR/did-1.1/#privacy-considerations">Decentralized
 	Identifiers specification</a> and
 	<a href="https://w3c.github.io/cid/#privacy-considerations">
@@ -2825,10 +2825,10 @@ Content-Type: application/did
 			infrastructure they control.
 		</p>
 		<p>
-			Clients can also take steps to obfuscate their requests to a service in
-			order to limit the possibilities of correlation and profiling. Techniques
-			for obfuscation include Oblivious HTTP, using a trusted proxy to execute
-			the resolution request, and	using a trusted cache.
+			Clients can also take steps to obfuscate their requests to a service to
+			decrease the possibilities of correlation and profiling. Techniques for
+			obfuscation include Oblivious HTTP, using a trusted proxy to execute the
+			resolution requests, and using a trusted cache.
 		</p>
 
 	</section>
@@ -2838,10 +2838,10 @@ Content-Type: application/did
 			considerations depending on the design decisions and underlying VDR of
 			the method. Implementers are advised to review the privacy considerations
 			of the specific DID methods they intend to support. Designers of DID
-			methods are encouraged to produce a threat model following the
-			<a href="https://www.w3.org/TR/threat-modeling-guide/">W3C
-			Threat Modelling Guide</a> to help implementers understand the
-			privacy implications of the method design.
+			methods are encouraged to follow the
+			<a href="https://www.w3.org/TR/threat-modeling-guide/">W3C Threat
+			Modeling Guide</a> to produce a threat model, to help implementers
+			understand the privacy implications of the method design.
 		</p>
 	</section>
 

--- a/index.html
+++ b/index.html
@@ -2808,10 +2808,11 @@ Content-Type: application/did
 	<p>
 	This section details the privacy considerations specific to DID Resolution.
 	Readers are urged to familiarize themselves with the general
-	privacy advice provided in the
-	<a href="https://www.w3.org/TR/did-1.1/#privacy-considerations">
-	Privacy Considerations section of the Decentralized Identifiers
-	specification</a> before reading this section.
+	privacy advice provided in the Privacy Considerations section of the
+	<a href="https://www.w3.org/TR/did-1.1/#privacy-considerations">Decentralized
+	Identifiers specification</a> and
+	<a href="https://w3c.github.io/cid/#privacy-considerations">
+	Controlled Identifiers specification</a> before reading this section.
 	</p>
 
 	<section id="profiling-requesters">
@@ -2821,10 +2822,27 @@ Content-Type: application/did
 			and profile the clients making requests for these services. To mitigate this privacy risk,
 			clients should make such requests to services they trust, for example,
 			because of an existing business relationship or because the service is running on
-			infrastructure they control. Clients can also take steps to obfuscate their
-			requests to a service in order to limit the possibilities of correlation and profiling.
+			infrastructure they control.
+		</p>
+		<p>
+			Clients can also take steps to obfuscate their requests to a service in
+			order to limit the possibilities of correlation and profiling. Techniques
+			for obfuscation include Oblivious HTTP, using a trusted proxy to execute
+			the resolution request, and	using a trusted cache.
 		</p>
 
+	</section>
+	<section>
+		<h2>Method specific considerations</h2>
+		<p>Different DID methods have different additional privacy implications and
+			considerations depending on the design decisions and underlying VDR of
+			the method. Implementers are advised to review the privacy considerations
+			of the specific DID methods they intend to support. Designers of DID
+			methods are encouraged to produce a threat model following the
+			<a href="https://www.w3.org/TR/threat-modeling-guide/">W3C
+			Threat Modelling Guide</a> to help implementers understand the
+			privacy implications of the method design.
+		</p>
 	</section>
 
 </section>


### PR DESCRIPTION
This text attempts to addresses #293, cc @bvandersloot-mozilla

I have not made the text about obfuscation a should, I could do, but this section is non-normative I believe.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wip-abramson/did-resolution/pull/307.html" title="Last updated on Mar 27, 2026, 2:47 PM UTC (8517ed3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-resolution/307/35d97e8...wip-abramson:8517ed3.html" title="Last updated on Mar 27, 2026, 2:47 PM UTC (8517ed3)">Diff</a>