### PR TITLE
Use "accept" DID URL dereferencing option instead of DID resolution option

### DIFF
--- a/index.html
+++ b/index.html
@@ -1393,7 +1393,7 @@ dereference(didUrl, dereferenceOptions) →
 								</li>
 							</ol>
 						</li>
-						<li>If the <b>accept</b> <var>input <a href="#did-url-dereferencing-options">DID dereferencing option</a></var>
+						<li>If the <b>accept</b> <var>input <a href="#did-url-dereferencing-options">DID URL dereferencing option</a></var>
 							is missing, or if its value is the Media Type of a <a>representation</a> of a <a>DID document</a>:
 							<ol class="algorithm">
 								<li>Update the <a>services</a> in the <var>resolved <a>DID document</a></var> to contain only the
@@ -1407,7 +1407,7 @@ dereference(didUrl, dereferenceOptions) →
 								</li>
 							</ol>
 						</li>
-						<li>If the value of the <b>accept</b> <var>input <a href="#did-resolution-options">DID resolution option</a></var>
+						<li>If the value of the <b>accept</b> <var>input <a href="#did-url-dereferencing-options">DID URL deferencing option</a></var>
 							is <b>text/uri-list</b>:
 							<ol class="algorithm">
 								<li>Return the following result:


### PR DESCRIPTION
This fixes a simple mistake in the spec regarding the "accept" DID URL dereferencing option

Addresses https://github.com/w3c/did-resolution/issues/305

@jandrieu


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-resolution/pull/309.html" title="Last updated on Mar 21, 2026, 10:15 AM UTC (97a3c72)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-resolution/309/35d97e8...97a3c72.html" title="Last updated on Mar 21, 2026, 10:15 AM UTC (97a3c72)">Diff</a>