### PR TITLE
Clarify that "DID resolution" is consistent with "URI resolution"

### DIFF
--- a/index.html
+++ b/index.html
@@ -478,10 +478,10 @@ did:example:123?service=files&amp;relativeRef=/resume.pdf
 		<a href="#dereferencing"></a>.
 	</p>
 	<p class="note">
-		In order to be able to dereference a DID URL, one first needs a <a>DID document</a>,
+		To be able to dereference a DID URL, one first needs a <a>DID document</a>,
 		which is the result of the <a>DID resolution</a> process. The <a>DID document</a>
 		is used in various ways during the <a>DID URL dereferencing</a> process.
-		The term <a>DID resolution</a> is therefore consistent with "URI resolution" as defined in
+		The term <a>DID resolution</a> is consistent with "URI resolution" as defined in
 		<a data-cite="RFC3986#section-1.2.2">RFC3986 Section 1.2.2</a>, since it provides
 		"the appropriate parameters necessary to dereference a URI".
 	</p>

--- a/index.html
+++ b/index.html
@@ -473,6 +473,16 @@ did:example:123?service=files&amp;relativeRef=/resume.pdf
 		document</a> by using the "Resolve" operation of the applicable <a>DID method</a>
 		as described in <a data-cite="did-core#method-operations">Method Operations</a>.
 	</p>
+	<p>
+		<a>DID resolution</a> is a part of <a>DID URL dereferencing</a>, as described in
+		<a href="#dereferencing"></a>.
+	</p>
+	<p class="note">
+		The term <a>DID resolution</a> is consistent with "URI resolution" as defined in
+		<a data-cite="RFC3986#section-1.2.2">RFC3986 Section 1.2.2</a>, i.e.
+		"the process of determining an access mechanism and the appropriate parameters
+		necessary to dereference a URI".
+	</p>
 	<p>	All [=conforming DID resolvers=] implement the function below, which has the
 		following abstract form:
 	</p>

--- a/index.html
+++ b/index.html
@@ -478,10 +478,12 @@ did:example:123?service=files&amp;relativeRef=/resume.pdf
 		<a href="#dereferencing"></a>.
 	</p>
 	<p class="note">
-		The term <a>DID resolution</a> is consistent with "URI resolution" as defined in
-		<a data-cite="RFC3986#section-1.2.2">RFC3986 Section 1.2.2</a>, i.e.
-		"the process of determining an access mechanism and the appropriate parameters
-		necessary to dereference a URI".
+		In order to be able to dereference a DID URL, one first needs a <a>DID document</a>,
+		which is the result of the <a>DID resolution</a> process. The <a>DID document</a>
+		is used in various ways during the <a>DID URL dereferencing</a> process.
+		The term <a>DID resolution</a> is therefore consistent with "URI resolution" as defined in
+		<a data-cite="RFC3986#section-1.2.2">RFC3986 Section 1.2.2</a>, since it provides
+		"the appropriate parameters necessary to dereference a URI".
 	</p>
 	<p>	All [=conforming DID resolvers=] implement the function below, which has the
 		following abstract form:


### PR DESCRIPTION
This addresses https://github.com/w3c/did-resolution/issues/226, by clarifying that the term "DID resolution" is consistent with "URI resolution" as defined in RFC3986, and that it is a part of the "DID URL dereferencing" process.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/peacekeeper/did-resolution/pull/318.html" title="Last updated on Apr 17, 2026, 8:42 PM UTC (0463af0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-resolution/318/ea94ecc...peacekeeper:0463af0.html" title="Last updated on Apr 17, 2026, 8:42 PM UTC (0463af0)">Diff</a>