### PR TITLE
Explain that DID URL dereferencer acts as client of a DID resolver

### DIFF
--- a/index.html
+++ b/index.html
@@ -1003,8 +1003,15 @@ string">ASCII string</a>.
 		The <a>DID URL dereferencing</a> function dereferences a <a>DID URL</a> into a
 		<a>resource</a> with contents depending on the <a>DID URL</a>'s components,
 		including the <a>DID method</a>, method-specific identifier, path, query, and
-		fragment. This process depends on <a>DID resolution</a> of the <a>DID</a>
-		contained in the <a>DID URL</a>. <a>DID URL dereferencing</a> might involve
+		fragment.
+	</p>
+	<p>
+		This process depends on <a>DID resolution</a> of the <a>DID</a>
+		contained in the <a>DID URL</a>. In other words, the <a>DID URL dereferencer</a>
+		acts as a <a>client</a> of a <a>DID resolver</a> during this process.
+	</p>
+	<p>
+		<a>DID URL dereferencing</a> might involve
 		multiple steps (e.g., when the DID URL being dereferenced includes a fragment),
 		and the function is defined to return the final resource after all steps are
 		completed. The following figure depicts the relationship described


### PR DESCRIPTION
This tries to address some confusion about clients, resolvers, and dereferencers, by stating explicitly that a DID URL dereferencer acts as a client of a DID resolver.

This does NOT mean that a DID resolver is a remote service; it can also be an entirely local process.

This does NOT mean that a DID URL deferencer exposes an endpoint; it can also be an entirely local process.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/peacekeeper/did-resolution/pull/319.html" title="Last updated on Apr 9, 2026, 1:58 PM UTC (52f3f3c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-resolution/319/ea94ecc...peacekeeper:52f3f3c.html" title="Last updated on Apr 9, 2026, 1:58 PM UTC (52f3f3c)">Diff</a>