### PR TITLE
Fix section nesting and indentation of result structures

### DIFF
--- a/index.html
+++ b/index.html
@@ -2140,24 +2140,26 @@ dereference(didUrl, dereferenceOptions) →
 		}
 	}
 }
-</pre>
+		</pre>
+
+	</section>
 
 </section>
 
-	<section id="did-url-dereferencing-result">
-		<h1>DID URL Dereferencing Result</h1>
-		<p>This section defines a JSON data structure that represents the result of the algorithm described
-			in <a href="#dereferencing"></a>. A <a>DID URL dereferencing result</a> contains
-			the content as well as
-			<a href="#did-url-dereferencing-metadata">DID URL dereferencing metadata</a> and <a href="#did-url-content-metadata">
-				DID URL content metadata</a>.</p>
+<section id="did-url-dereferencing-result">
+	<h1>DID URL Dereferencing Result</h1>
+	<p>This section defines a JSON data structure that represents the result of the algorithm described
+		in <a href="#dereferencing"></a>. A <a>DID URL dereferencing result</a> contains
+		the content as well as
+		<a href="#did-url-dereferencing-metadata">DID URL dereferencing metadata</a> and <a href="#did-url-content-metadata">
+			DID URL content metadata</a>.</p>
 
-		<p>The media type of this data structure is defined to be `application/did-url-dereferencing`.</p>
+	<p>The media type of this data structure is defined to be `application/did-url-dereferencing`.</p>
 
-		<section>
-			<h2>Example</h2>
+	<section>
+		<h2>Example</h2>
 
-			<pre class="example nohighlight" title="Example DID URL dereferencing result">
+		<pre class="example nohighlight" title="Example DID URL dereferencing result">
 {
 	"content": {
 		"@context": "https://www.w3.org/ns/did/v1",
@@ -2212,10 +2214,8 @@ dereference(didUrl, dereferenceOptions) →
 }
 </pre>
 
-		</section>
-		</section>
-
 	</section>
+</section>
 
 <section id="errors">
 	<h1>Errors</h1>


### PR DESCRIPTION
This is an editorial PR to fix the nesting and indentation of the "DID Resolution Result" and "DID URL Dereferencing Examples" sections.

Currently, the latter is a subsection of the former, but they should really be on the same level.

There is no other change in this PR.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/peacekeeper/did-resolution/pull/320.html" title="Last updated on Apr 9, 2026, 2:04 PM UTC (7024883)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-resolution/320/ea94ecc...peacekeeper:7024883.html" title="Last updated on Apr 9, 2026, 2:04 PM UTC (7024883)">Diff</a>