### PR TITLE
Change section "Resolution Cycles" to "Dereferencing Cycles"

### DIFF
--- a/index.html
+++ b/index.html
@@ -1379,13 +1379,13 @@ dereference(didUrl, dereferenceOptions) →
 									</ol>
 									<div class="note">
 										<p>
-											Resolving a [=DID service endpoint=] — particularly one that is a DID — might
-											result in a <dfn>resolution cycle</dfn>, which is a set of steps that result in
+											Dereferencing a [=DID service endpoint=] — particularly one that is a DID — might
+											result in a <dfn>dereferencing cycle</dfn>, which is a set of steps that result in
 											an infinite loop. For example, a [=DID service endpoint=] might indirectly point
-											back through a sequence of resolutions to a previously dereferenced identifier.
-											A <a>DID resolver</a> recursively resolving a [=DID service endpoint=] is advised
-											to detect and handle such a cycle to prevent an infinite loop or resolution failure.
-											For further guidance, see Section <a href="#security-cycles-resolution">Resolution Cycles</a>.
+											back through a sequence of dereferencing processes to a previously dereferenced identifier.
+											A <a>DID URL dereferencer</a> recursively dereferencing a [=DID service endpoint=] is advised
+											to detect and handle such a cycle to prevent an infinite loop or dereferencing failure.
+											For further guidance, see Section <a href="#security-cycles-dereferencing">Dereferencing Cycles</a>.
 										</p>
 									</div>
 								</li>
@@ -2759,14 +2759,14 @@ Content-Type: application/did
 			the VDR they are using can be disambiguated from such forks.</p>
 	</section>
 
-	<section id="security-cycles-resolution">
-		<h2>Resolution Cycles</h2>
+	<section id="security-cycles-dereferencing">
+		<h2>Dereferencing Cycles</h2>
 
-		<p>When a <a>DID resolver</a> client dereferences identifiers and linked resources in a <a>DID document</a> —
+		<p>When a <a>DID URL dereferencer</a> client dereferences identifiers and linked resources in a <a>DID document</a> —
 			especially fields like <code>verificationMethod</code>, <code>controller</code>,
-			or <code>alsoKnownAs</code> — it might encounter a <a>resolution cycle</a>.
+			or <code>alsoKnownAs</code> — it might encounter a <a>dereferencing cycle</a>.
 			These can occur when a <a>DID document</a> references another DID (or URL) that eventually leads
-			back to a previously dereferenced identifier, forming a loop. A <a>DID resolver</a> can
+			back to a previously dereferenced identifier, forming a loop. A <a>DID URL dereferencer</a> can
 			also encounter such a situation when dereferencing a <a>DID URL</a> that references
 			a [=DID service endpoint=].</p>
 
@@ -2776,7 +2776,7 @@ Content-Type: application/did
 		└── verificationMethod.controller → did:example:alice</code></pre>
 		</div>
 
-		<p><strong><a>DID resolvers</a> and their clients that perform recursive dereferencing
+		<p><strong><a>DID URL dereferencers</a> and their clients that perform recursive dereferencing
 			are expected to expect, detect, and handle such cycles</strong>.</p>
 
 		<p><strong>Security and performance risks:</strong> If cycles are not detected and mitigated,


### PR DESCRIPTION
As mentioned in https://github.com/w3c/did-resolution/issues/304#issue-4039627329 and other discussions, the term "derefencing" should be used instead of "resolving" for anything other than a DID document.