### PR TITLE
Andrieu/did parameter guidance

### DIFF
--- a/index.html
+++ b/index.html
@@ -421,34 +421,22 @@ did:example:123?service=files&amp;relativeRef=/resume.pdf
 	</table>
 
 	<p>
-		Implementers as well as <a>DID method</a> specification authors might use
+		[=DID URL authors=] might use
 		additional DID parameters that are not listed here. For maximum
 		interoperability, it is RECOMMENDED that DID parameters use the DID
 		Document Properties Extensions mechanism [[?DID-EXTENSIONS-PROPERTIES]], to avoid collision
 		with other uses of the same DID parameter with different semantics.
 	</p>
 
-	<p>
-		DID parameters might be used if there is a clear use case where the parameter
-		needs to be part of a URL that references a <a>resource</a> with more
-		precision than using the <a>DID</a> alone. It is expected that DID parameters
-		are <em>not</em> used if the same functionality can be expressed by passing
-		input metadata to a <a>DID resolver</a>.
-	</p>
-
 	<p class="note" title="DID parameters and DID resolution">
 		The <a>DID resolution</a> and the <a>DID URL dereferencing</a> functions can
 		be influenced by passing <a href="#did-resolution-options"></a> or
-		<a href="#did-url-dereferencing-options"></a> to a <a>DID resolver</a> that are
+		<a href="#did-url-dereferencing-options"></a> to a <a>DID resolver</a>, or a <a>DID URL dereferencer</a> that are
 		not part of the <a>DID URL</a>. This is comparable to
 		HTTP, where certain parameters could either be included in an HTTP URL, or
-		alternatively passed as HTTP headers during the dereferencing process. The
-		important distinction is that DID parameters that are part of the <a>DID
-		URL</a> should be used to specify <em>what <a>resource</a> is being
-		identified</em>, whereas input metadata that is not part of the <a>DID URL</a>
-		should be used to control <em>how that <a>resource</a> is resolved or
-		dereferenced</em>.
+		alternatively passed as HTTP headers during the dereferencing process. 
 	</p>
+	<p>If [=Resolve=] or [=Dereference=] is called with a resolution option of the same name as a DID parameter in the input DID URL, the resolution option MUST override the DID parameters, when interpreted by the Resolver or Dereferencer, respectively.</p>
 
 	<section id="datetime">
 		<h3>Datetime</h3>

--- a/terms.html
+++ b/terms.html
@@ -11,6 +11,10 @@ included whenever they appear in this specification.
   <dt><dfn>client</dfn></dt>
   <dd>Software and/or hardware that invokes a <a>DID resolver</a> in order to execute the <a>DID resolution</a> and/or <a>DID URL dereferencing</a> algorithms. This invocation is done via a <a>binding</a>. The term <a>client</a> does not imply any specific network topology.</dd>
 
+    <dt><dfn data-lt="">DID URL Author</dfn></dt>
+    <dd>The creator of a DID URL. Like any URL, DID URLs are strings, typically produced in one context and often consumed in another (although constructing a DID URL for a particular use case may immediately use that DID URL in the context it was created). DID URL authors are responsible for properly constructing the DID URL and using any path, query, and fragment parts correctly such that is complies with the <a>DID URL Syntax</a> defined in [[DID-CORE]].</dd>
+
+
   <dt><dfn data-lt="">DID resolution result</dfn></dt>
   <dd>A data structure that represents the result of the <a>DID resolution</a> algorithm.
     May contain a <a>DID document</a>. See Section <a href="#did-resolution-result"></a>.</dd>

--- a/terms.html
+++ b/terms.html
@@ -12,7 +12,7 @@ included whenever they appear in this specification.
   <dd>Software and/or hardware that invokes a <a>DID resolver</a> in order to execute the <a>DID resolution</a> and/or <a>DID URL dereferencing</a> algorithms. This invocation is done via a <a>binding</a>. The term <a>client</a> does not imply any specific network topology.</dd>
 
     <dt><dfn data-lt="">DID URL Author</dfn></dt>
-    <dd>The creator of a DID URL. Like any URL, DID URLs are strings, typically produced in one context and often consumed in another (although constructing a DID URL for a particular use case may immediately use that DID URL in the context it was created). DID URL authors are responsible for properly constructing the DID URL and using any path, query, and fragment parts correctly such that is complies with the <a>DID URL Syntax</a> defined in [[DID-CORE]].</dd>
+    <dd>The creator of a DID URL. Like any URL, DID URLs are strings, typically produced in one context and often consumed in another (although constructing a DID URL for a particular use case might immediately use that DID URL in the context it was created). DID URL authors are responsible for properly constructing the DID URL and using any path, query, and fragment parts correctly such that is complies with the <a>DID URL Syntax</a> defined in [[DID-CORE]].</dd>
 
 
   <dt><dfn data-lt="">DID resolution result</dfn></dt>


### PR DESCRIPTION
Removed overly restricting guidance about when to use options verses parameters, clarifying that options override DID parameters, without erroneously suggesting that DID parameters are used `only where the parameter needs to be part of a URL that references a resource with more precision than using the DID alone.`

Also corrects the incorrect expectation `It is expected that DID parameters are not used if the same functionality can be expressed by passing input metadata to a DID resolver` as the DID URL author cannot be assumed to be the DID URL client. In fact, the DID URL author **only** has DID parameters when sending a DID URL to another party for any purpose, such as in a proof in a VC or on a business card.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/LegReq/did-resolution/pull/325.html" title="Last updated on Apr 15, 2026, 1:54 PM UTC (7f54ec5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-resolution/325/ea94ecc...LegReq:7f54ec5.html" title="Last updated on Apr 15, 2026, 1:54 PM UTC (7f54ec5)">Diff</a>