### PR TITLE
EDITORIAL: reformat document to wrap at ~80 chars and avoid stair stepping

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,13 +2,17 @@
 <html lang="en">
   <head>
     <title>Decentralized Identifier Resolution (DID Resolution) v0.3</title>
-    <meta http-equiv='Content-Type' content='text/html;charset=utf-8'/>
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
     <!--
       === NOTA BENE ===
       For the three scripts below, if your spec resides on dev.w3 you can check them
       out in the same tree and use relative links so that they'll work offline.
 	 -->
-	<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer></script>
+    <script
+      src="https://www.w3.org/Tools/respec/respec-w3c"
+      class="remove"
+      defer
+    ></script>
     <script src="./common.js"></script>
     <script type="text/javascript" class="remove">
       var respecConfig = {
@@ -19,7 +23,8 @@
         shortName: "did-resolution",
 
         // subtitle
-        subtitle: "Algorithms and guidelines for resolving DIDs and dereferencing DID URLs",
+        subtitle:
+          "Algorithms and guidelines for resolving DIDs and dereferencing DID URLs",
 
         // if you wish the publication date to be other than today, set this
         // publishDate:  "2009-08-06",
@@ -44,38 +49,52 @@
         // editors, add as many as you like
         // only "name" is required
         editors: [
-          { name: "Markus Sabadello", url: "https://www.linkedin.com/in/markus-sabadello-353a0821",
-            company: "Danube Tech", companyURL: "https://danubetech.com/", w3cid: 46729,
-						extras: [
-							{name: "until 2025-12-10", class: "former"},
-						]
-				 },
-          { name: "Dmitri Zagidulin", url: "https://www.linkedin.com/in/dzagidulin",
-            company: "MIT DCC",  w3cid: 86708 }
+          {
+            name: "Markus Sabadello",
+            url: "https://www.linkedin.com/in/markus-sabadello-353a0821",
+            company: "Danube Tech",
+            companyURL: "https://danubetech.com/",
+            w3cid: 46729,
+            extras: [{ name: "until 2025-12-10", class: "former" }],
+          },
+          {
+            name: "Dmitri Zagidulin",
+            url: "https://www.linkedin.com/in/dzagidulin",
+            company: "MIT DCC",
+            w3cid: 86708,
+          },
         ],
 
         // authors, add as many as you like.
         // This is optional, uncomment if you have authors as well as editors.
         // only "name" is required. Same format as editors.
-        authors:
-        [
-          { name: "Markus Sabadello", url: "https://www.linkedin.com/in/markus-sabadello-353a0821",
-            company: "Danube Tech", companyURL: "https://danubetech.com/", w3cid: 46729 },
-          { name: "Dmitri Zagidulin", url: "https://www.linkedin.com/in/dzagidulin",
-            company: "MIT DCC", w3cid: 86708 }
+        authors: [
+          {
+            name: "Markus Sabadello",
+            url: "https://www.linkedin.com/in/markus-sabadello-353a0821",
+            company: "Danube Tech",
+            companyURL: "https://danubetech.com/",
+            w3cid: 46729,
+          },
+          {
+            name: "Dmitri Zagidulin",
+            url: "https://www.linkedin.com/in/dzagidulin",
+            company: "MIT DCC",
+            w3cid: 86708,
+          },
         ],
 
         // group
-        group:           "did",
+        group: "did",
 
         // name (with the @w3c.org) of the public mailing to which comments are due
         wgPublicList: "public-did-wg",
 
         maxTocLevel: 4,
         inlineCSS: true,
-		lint: {
-     	 "informative-dfn": false
-    	}
+        lint: {
+          "informative-dfn": false,
+        },
       };
     </script>
     <style type="text/css">
@@ -91,1615 +110,1929 @@
         counter-increment: numsection;
         content: counters(numsection, ".") ") ";
       }
-	  .longdesc {
-		  display: none;
-	  }
-	  .longdesc:target {
-		  display: block;
-		  background-color: #ff9;
-	  }
+      .longdesc {
+        display: none;
+      }
+      .longdesc:target {
+        display: block;
+        background-color: #ff9;
+      }
 
-		table.simple {
-			border-collapse: collapse;
-			margin: 25px 0;
-			min-width: 400px;
-			border: 1px solid #dddddd;
-		}
-		table.simple thead tr {
-			background-color: #005a9c;
-			color: #ffffff;
-			text-align: left;
-		}
-		table.simple th,
-		table.simple td {
-			padding: 12px 15px;
-			vertical-align: top;
-			text-align: left;
-		}
-		table.simple tbody tr {
-			border-bottom: 1px solid #dddddd;
-		}
-		table.simple tbody tr:nth-of-type(even) {
-			background-color: #00000008;
-		}
-		table.simple tbody tr:last-of-type {
-			border-bottom: 2px solid #005a9c;
-		}
-
+      table.simple {
+        border-collapse: collapse;
+        margin: 25px 0;
+        min-width: 400px;
+        border: 1px solid #dddddd;
+      }
+      table.simple thead tr {
+        background-color: #005a9c;
+        color: #ffffff;
+        text-align: left;
+      }
+      table.simple th,
+      table.simple td {
+        padding: 12px 15px;
+        vertical-align: top;
+        text-align: left;
+      }
+      table.simple tbody tr {
+        border-bottom: 1px solid #dddddd;
+      }
+      table.simple tbody tr:nth-of-type(even) {
+        background-color: #00000008;
+      }
+      table.simple tbody tr:last-of-type {
+        border-bottom: 2px solid #005a9c;
+      }
     </style>
   </head>
   <body data-cite="infra rfc3986 did">
-    <section id='abstract'>
+    <section id="abstract">
       <p>
-Decentralized identifier (DID) resolution is the process of obtaining
-a DID document and accompanying metadata for a specific DID. The process
-takes a DID and a set of resolution options as its input and returns a
-DID document and associated metadata about the resolved document and the
-resolution request. A resolved DID document is a set of information which
-enables cryptographically verifiable interactions with the DID subject,
-including mechanisms such as cryptographic public keys. This specification
-covers the algorithms and guidelines to be used for DID resolution and
-relies on the core DID specification,
-[[[DID]]],
-which describes the underlying DID architecture in full detail.
+Decentralized identifier (DID) resolution is the process of obtaining a DID
+document and accompanying metadata for a specific DID. The process takes a DID
+and a set of resolution options as its input and returns a DID document and
+associated metadata about the resolved document and the resolution request. A
+resolved DID document is a set of information which enables cryptographically
+verifiable interactions with the DID subject, including mechanisms such as
+cryptographic public keys. This specification covers the algorithms and
+guidelines to be used for DID resolution and relies on the core DID
+specification, [[[DID]]], which describes the underlying DID architecture in
+full detail.
       </p>
     </section>
 
-    <section id='sotd'>
-    <p>
-      Comments regarding this document are welcome. Please file issues
-      directly on <a href="https://github.com/w3c/did-resolution/issues/">GitHub</a>,
-      or send them to
-      <a href="mailto:public-did-wg@w3.org">public-did-wg@w3.org</a>
-      (<a href="mailto:public-did-wg-request@w3.org?subject=subscribe">subscribe</a>,
-      <a href="https://lists.w3.org/Archives/Public/public-did-wg/">archives</a>).
+    <section id="sotd">
+      <p>
+Comments regarding this document are welcome. Please file issues directly on
+<a href="https://github.com/w3c/did-resolution/issues/">GitHub</a>, or send
+them to <a href="mailto:public-did-wg@w3.org">public-did-wg@w3.org</a>
+(<a href="mailto:public-did-wg-request@w3.org?subject=subscribe">subscribe</a>,
+<a href="https://lists.w3.org/Archives/Public/public-did-wg/">archives</a>).
       </p>
 
       <p>
-      Portions of the work on this specification have been funded by the
-      United States Department of Homeland Security's Science and Technology
-      Directorate under contracts HSHQDC-17-C-00019. The content of this
-      specification does not necessarily reflect the position or the policy of
-      the U.S. Government and no official endorsement should be inferred.
+Portions of the work on this specification have been funded by the United States
+Department of Homeland Security's Science and Technology Directorate under
+contracts HSHQDC-17-C-00019. The content of this specification does not
+necessarily reflect the position or the policy of the U.S. Government and no
+official endorsement should be inferred.
       </p>
 
       <p>
-      Work on this specification has also been supported by the Rebooting the
-      Web of Trust community facilitated by Christopher Allen, Shannon
-      Appelcline, Kiara Robles, Brian Weller, Betty Dhamers, Kaliya Young, Kim
-      Hamilton Duffy, Manu Sporny, Drummond Reed, Joe Andrieu, and Heather
-      Vescent.
+Work on this specification has also been supported by the Rebooting the Web of
+Trust community facilitated by Christopher Allen, Shannon Appelcline, Kiara
+Robles, Brian Weller, Betty Dhamers, Kaliya Young, Kim Hamilton Duffy, Manu
+Sporny, Drummond Reed, Joe Andrieu, and Heather Vescent.
       </p>
     </section>
 
-<section id="introduction">
-<h1>Introduction</h1>
+    <section id="introduction">
+      <h1>Introduction</h1>
 
-	<p>[=DID resolution=] is the process of obtaining a <a>DID document</a> for a given <a>DID</a>. This is one
-	of four required operations that can be performed on any DID ("Read"; the other ones being "Create", "Update",
-	and "Deactivate"). The details of these operations differ depending on the <a>DID method</a>.
-	Building on top of [=DID resolution=], <a>DID URL dereferencing</a> is the process of retrieving a representation
-	of a resource for a given <a>DID URL</a>. Software and/or hardware that is able to execute these processes is called
-	a <a>DID resolver</a>.
+      <p>
+[=DID resolution=] is the process of obtaining a <a>DID document</a>
+for a given <a>DID</a>. This is one of four required
+operations that can be performed on any DID ("Read"; the other ones being
+"Create", "Update", and "Deactivate"). The details of these operations differ
+depending on the <a>DID method</a>. Building on top of [=DID
+resolution=], <a>DID URL dereferencing</a> is the process of retrieving a
+representation of a resource for a given <a>DID URL</a>. Software
+and/or hardware that is able to execute these processes is called a
+<a>DID resolver</a>.
+      </p>
 
-	<p>This specification defines a standard interface that clients can use to execute [=DID resolution=] and <a>DID URL dereferencing</a>
-		requests, independent of any specific <a>DID method's</a> "Resolve" operation that a [=DID resolver=] supports. Additionally,
-		this specification defines requirements, algorithms including their inputs and results, architectural options, and various
-		security and privacy considerations relevant to implementing a [=DID resolver=] or <a>DID URL dereferencer</a>.</p>
+      <p>
+This specification defines a standard interface that clients can use to execute
+[=DID resolution=] and <a>DID URL dereferencing</a> requests, independent of
+any specific <a>DID method's</a> "Resolve" operation that a [=DID resolver=]
+supports. Additionally, this specification defines requirements,
+algorithms including their inputs and results, architectural options, and
+various security and privacy considerations relevant to implementing a
+[=DID resolver=] or <a>DID URL dereferencer</a>.
+      </p>
 
-	<p>Note that while this specification defines some base-level functionality for DID resolution, the actual steps
-	required to communicate with a DID's <a>verifiable data registry</a> are defined by the applicable
-	<a>DID method</a> specification.</p>
+      <p>
+Note that while this specification defines some base-level functionality for DID
+resolution, the actual steps required to communicate with a DID's
+<a>verifiable data registry</a> are defined by the applicable
+<a>DID method</a> specification.
+      </p>
 
-	<section id="implementer-overview" class="informative">
-		<h2>Implementer Overview</h2>
-		<p>
-			By invoking a <a>DID resolver</a> using the standard `resolve(did, resolutionOptions)` interface (as defined in
-			the <a href="#resolving">DID Resolution section</a>), one can obtain a <a>DID document</a> and accompanying metadata
-			(e.g., `contentType`, proof, versioning), which an application can use to validate a user's cryptographic keys,
-			service endpoints, or status.
-		<p>
-			For example, to retrieve the state of the DID `did:example:123`
-             at a time in the past, a client application could resolve the DID with the `versionTime`
-             resolution option, as in the following:<br>
-             `resolve("did:example:123", {"versionTime":"2021-05-10T17:00:00Z"})`
+      <section id="implementer-overview" class="informative">
+        <h2>Implementer Overview</h2>
+        <p>
+By invoking a <a>DID resolver</a> using the standard `resolve(did,
+resolutionOptions)` interface (as defined in the
+<a href="#resolving">DID Resolution section</a>), one can obtain a <a>DID document</a>
+and accompanying metadata (e.g., `contentType`, proof, versioning), which an
+application can use to validate a user's cryptographic keys, service endpoints,
+or status.
+        </p>
 
-			Or a client could
-			dereference a DID URL
-			 like <code>did:example:123?service=files&relativeRef=/resume.pdf</code>
-			 (see <a href="#example-dereferencing-to-service-endpoint-url">here for detailed example</a>)
-			 to fetch a user's resume stored via a service declared in the DID document.
-		</p>
-		<p>
-			Further, the specification's <a href="#dereferencing-algorithm">DID URL dereferencing algorithm</a> shows how
-			a client can follow a fragment (e.g., `#key-1`) to extract a particular verification method from
-			the <a>DID document</a> (see <a href="#example-dereferencing-to-verification-method">here for detailed example</a>).
-			In practice, implementers validate their resolver against the
-			<a href="https://github.com/w3c-ccg/did-resolution-mocha-test-suite">DID Resolution Test Suite</a> which exercises
-			normative MUSTs and error conditions (such as invalid DIDs, deactivated DIDs, unsupported methods,
-			relative URL expansion, etc.) to ensure that client applications can reliably depend on correct resolution behavior
-			across different DID methods.
-		</p>
-	</section>
+        <p>
+For example, to retrieve the state of the DID `did:example:123` at a
+time in the past, a client application could resolve the DID with the
+`versionTime` resolution option, as in the
+following:<br> `resolve("did:example:123",
+{"versionTime":"2021-05-10T17:00:00Z"})` Or a client could dereference
+a DID URL like
+<code>did:example:123?service=files&relativeRef=/resume.pdf</code>
+(see <a href="#example-dereferencing-to-service-endpoint-url">here for detailed example</a>)
+to fetch a user's resume stored via a service declared in the DID document.
+        </p>
+        <p>
+Further, the specification's <a href="#dereferencing-algorithm">DID URL dereferencing algorithm</a>
+shows how a client can follow a fragment (e.g., `#key-1`) to extract a
+particular verification method from the <a>DID document</a>
+(see <a href="#example-dereferencing-to-verification-method">here for detailed example</a>).
+In practice, implementers validate their resolver against the
+<a href="https://github.com/w3c-ccg/did-resolution-mocha-test-suite">DID Resolution Test Suite</a>
+which exercises normative MUSTs and error conditions (such as invalid DIDs,
+deactivated DIDs, unsupported methods, relative URL expansion, etc.) to ensure
+that client applications can reliably depend on correct resolution behavior
+across different DID methods.
+        </p>
+      </section>
 
-	<section id="conformance">
+      <section id="conformance">
+        <p>
+A <dfn class="lint-ignore">conforming DID resolver</dfn> is any
+algorithm realized as software and/or hardware that complies with the
+relevant normative statements in <a href="#resolving"></a>.
+        </p>
 
-		<p>
-			A <dfn class="lint-ignore">conforming DID resolver</dfn> is any algorithm
-			realized as software and/or hardware that complies with the relevant normative
-			statements in <a href="#resolving"></a>.
-		</p>
+        <p>
+A
+<dfn class="lint-ignore">conforming network-based DID resolver</dfn>
+is a [=conforming DID resolver=] that additionally complies with the
+normative statements in [[[#bindings-https]]].
+        </p>
 
-		<p>
-			A <dfn class="lint-ignore">conforming network-based DID resolver</dfn> is a
-			[=conforming DID resolver=] that additionally complies with the normative statements
-			in [[[#bindings-https]]].
-		</p>
+        <p>
+A <dfn class="lint-ignore">conforming DID URL dereferencer</dfn> is
+any algorithm realized as software and/or hardware that complies with
+the relevant normative statements in <a href="#dereferencing"></a>.
+        </p>
 
-		<p>
-			A <dfn class="lint-ignore">conforming DID URL dereferencer</dfn> is any
-			algorithm realized as software and/or hardware that complies with the relevant
-			normative statements in <a href="#dereferencing"></a>.
-		</p>
+        <p>
+A
+<dfn class="lint-ignore">conforming network-based DID URL dereferencer</dfn>
+is a [=conforming DID URL dereferencer=] that additionally complies
+with the normative statements in [[[#bindings-https]]].
+        </p>
+      </section>
 
-		<p>
-			A <dfn class="lint-ignore">conforming network-based DID URL dereferencer</dfn> is a
-			[=conforming DID URL dereferencer=] that additionally complies with the normative
-			statements in [[[#bindings-https]]].
-		</p>
+      <section class="informative">
+        <h2>Audience</h2>
+        <p>
+This specification has three primary audiences: implementers of conformant DID
+methods; implementers of conformant DID resolvers; and implementers of systems
+and services that wish to resolve DIDs using DID resolvers. The intended
+audience includes, but is not limited to, software architects, data modelers,
+application developers, service developers, testers, operators, and user
+experience (UX) specialists. Other people involved in a broad range of standards
+efforts related to decentralized identity, verifiable credentials, and secure
+storage might also be interested in reading this specification.
+        </p>
+      </section>
 
-	</section>
+      <section class="informative">
+        <h2>Use Cases</h2>
+        <p>
+The DID resolution specification is intended to support a broad range of use
+cases by defining a standardized interface to resolve DIDs and dereference DID
+URLs independent of the DID method of any particular DID. These usecases
+include:
+        </p>
+        <ul>
+          <li>
+A decentralized address book: By using DIDs as identifiers for people and
+organizations within an address book, the controllers of those DIDs can
+independently update the contents of their DID documents. Through DID
+resolution, these DIDs can be resolved to obtain the current state of the DID
+document for any given contact, enabling persistent stable identifiers with
+updatable services and verification material necessary for continued verifiable
+interactions.
+          </li>
+          <li>
+Verifying a Verifiable Credential: Verifiable Credentials are signed by an
+issuer and given to a holder. The holder can then create a Verifiable
+Presentation that is presented to a verifier. By using DIDs to identify issuers
+and holders within a credential, an issuer enables a verifier to use DID
+resolution to resolve the DID documents of the identified issuers and holders to
+obtain the verification material necessary to verify the signatures on the
+Verifiable Presentation.
+          </li>
+          <li>
+Auditability: DID resolution can be used to obtain the historical state of a DID
+document either at a specific point in time or for a specific version. This can
+be used to audit the historical verifiable actions of a DID controller; for
+example, the issuance of a verifiable receipt or the signing of a contract.
+          </li>
+          <li>
+DID URL based resource retrieval: A DID controller can add service endpoints to
+their DID document that point to resources they control; for example, a profile
+picture. If DID URLs are used to reference these resources, web applications can
+use DID resolution and DID URL dereferencing to retrieve the current version of
+the resource(s). The DID URL can be used as a persistent, dereferenceable
+identifier for these resources, while the DID controller can independently
+change the resource over time.
+          </li>
+        </ul>
+      </section>
+    </section>
 
-	<section class="informative">
-		<h2>
-		  Audience
-		</h2>
-		<p>
-This specification has three primary audiences: implementers of conformant DID methods;
-implementers of conformant DID resolvers; and implementers of systems and services
-that wish to resolve DIDs using DID resolvers. The intended audience includes,
-but is not limited to, software architects, data modelers, application developers,
-service developers, testers, operators, and user experience (UX) specialists.
-Other people involved in a broad range of standards efforts related to decentralized
-identity, verifiable credentials, and secure storage might also be interested in
-reading this specification.
-		</p>
+    <section id="terminology">
+      <h1>Terminology</h1>
 
-	  </section>
+      <div data-include="terms.html"></div>
+    </section>
 
-			<section class="informative">
-		<h2>
-		  Use Cases
-		</h2>
-		<p>
-The DID resolution specification is intended to support a broad range of use cases
-by defining a standardized interface to resolve DIDs and dereference DID URLs
-independent of the DID method of any particular DID. These usecases include:
-		</p>
-		<ul>
-			<li>
-A decentralized address book: By using DIDs as identifiers for people and organizations
-within an address book, the controllers of those DIDs can independently update the contents of
-their DID documents. Through DID resolution, these DIDs can be resolved to obtain the
-current state of the DID document for any given contact, enabling persistent stable identifiers
-with updatable services and verification material necessary for continued verifiable interactions.
-			</li>
-			<li>
-Verifying a Verifiable Credential: Verifiable Credentials are signed by an issuer and given to a
-holder. The holder can then create a Verifiable Presentation that is presented to a verifier.
-By using DIDs to identify issuers and holders within a credential, an issuer enables a verifier to
-use DID resolution to resolve the DID documents of the identified issuers and holders to obtain
-the verification material necessary to verify the signatures on the Verifiable Presentation.
-			</li>
-			<li>
-Auditability: DID resolution can be used to obtain the historical state of a DID document either
-at a specific point in time or for a specific version. This can be used to audit the historical
-verifiable actions of a DID controller; for example, the issuance of a verifiable receipt or the
-signing of a contract.
-			</li>
-			<li>
-DID URL based resource retrieval: A DID controller can add service endpoints to their DID document
-that point to resources they control; for example, a profile picture. If DID URLs are used to reference
-these resources, web applications can use DID resolution and DID URL dereferencing to retrieve the
-current version of the resource(s). The DID URL can be used as a persistent, dereferenceable identifier
-for these resources, while the DID controller can independently change the resource over time.
-			</li>
-		</ul>
+    <section id="did-parameters">
+      <h2>DID Parameters</h2>
 
-	  </section>
+      <p>
+The <a>DID URL</a> syntax supports a simple format for
+parameters (see section <a href="https://www.w3.org/TR/did-core/#query">Query</a> in [[DID-CORE]]). Adding
+a DID parameter to a <a>DID URL</a> means that the parameter
+becomes part of the identifier for a <a>resource</a>.
+      </p>
 
-</section>
-
-<section id="terminology">
-	<h1>Terminology</h1>
-
-	<div data-include="terms.html">
-	</div>
-
-</section>
-
-<section id="did-parameters">
-	<h2>DID Parameters</h2>
-
-	<p>
-		The <a>DID URL</a> syntax supports a simple format for parameters
-		(see section <a href="https://www.w3.org/TR/did-core/#query">Query</a>
-		in [[DID-CORE]]). Adding a DID
-		parameter to a <a>DID URL</a> means that the parameter becomes part of the
-		identifier for a <a>resource</a>.
-	</p>
-
-	<pre class="example nohighlight"
-		 title="A DID URL with a 'versionTime' DID parameter">
+      <pre
+        class="example nohighlight"
+        title="A DID URL with a 'versionTime' DID parameter"
+      >
 did:example:123?versionTime=2021-05-10T17:00:00Z
-	</pre>
+			</pre>
 
-	<pre class="example nohighlight"
-		 title="A DID URL with a 'service' and a 'relativeRef' DID parameter">
+      <pre
+        class="example nohighlight"
+        title="A DID URL with a 'service' and a 'relativeRef' DID parameter"
+      >
 did:example:123?service=files&amp;relativeRef=/resume.pdf
-	</pre>
+			</pre>
 
-	<p>
-		For each DID parameter that is present, its associated value MUST be a
-		<a data-cite="INFRA#scalar-value-string">scalar value</a>
-		 string serialized into ASCII according to <a data-cite="RFC3987#section-3.1">
-			section 3.1 of RFC3987.</a>
-	</p>
+      <p>
+For each DID parameter that is present, its associated value MUST be a
+<a data-cite="INFRA#scalar-value-string">scalar value</a>
+string serialized into ASCII according to
+<a data-cite="RFC3987#section-3.1"> section 3.1 of RFC3987.</a>
+      </p>
 
-	<p>
-		Some DID parameters are completely independent of any specific <a>DID
-		method</a> and function the same way for all <a>DIDs</a>. Other DID parameters
-		are not supported by all <a>DID methods</a>. Where optional parameters are
-		supported, they are expected to operate uniformly across the <a>DID methods</a>
-		that do support them. The following table provides common DID parameters that
-		function the same way across all <a>DID methods</a>. Support for all
-		<a href="#did-parameters">DID Parameters</a> is OPTIONAL.
-	</p>
+      <p>
+Some DID parameters are completely independent of any specific
+<a>DID method</a> and function the same way for all
+<a>DIDs</a>. Other DID parameters are not supported by all
+<a>DID methods</a>. Where optional parameters are supported, they
+are expected to operate uniformly across the <a>DID methods</a> that
+do support them. The following table provides common DID parameters that
+function the same way across all <a>DID methods</a>. Support for all
+<a href="#did-parameters">DID Parameters</a> is OPTIONAL.
+      </p>
 
-	<table class="simple">
-		<thead>
-		<tr>
-			<th>
-				Parameter&nbsp;Name
-			</th>
-			<th>
-				Description
-			</th>
-		</tr>
-		</thead>
+      <table class="simple">
+        <thead>
+          <tr>
+            <th>Parameter&nbsp;Name</th>
+            <th>Description</th>
+          </tr>
+        </thead>
 
-		<tbody>
-		<tr>
-			<td>
-				<code><a>service</a></code>
-			</td>
-			<td>
-				Identifies a <a data-cite="did-core#services">service</a> from the <a>DID document</a> by service ID.
-			</td>
-		</tr>
-		<tr>
-			<td>
-				<code>serviceType</code>
-			</td>
-			<td>
-				Identifies a set of one or more <a data-cite="did-core#services">services</a> from the <a>DID document</a> by service type.
-			</td>
-		</tr>
-		<tr>
-			<td>
-				<code>relativeRef</code>
-			</td>
-			<td>
-				A relative <a>URI</a> reference according to <a
-					data-cite="RFC3986#section-4.2">RFC3986 Section 4.2</a> that identifies a
-				<a>resource</a> at a [=DID service endpoint=], which is selected from a <a>DID
-				document</a> by using the <code>service</code> parameter.
-			</td>
-		</tr>
-		<tr>
-			<td>
-				<code>versionId</code>
-			</td>
-			<td>
-				Identifies a specific version of a <a>DID document</a> to be resolved (the
-				version ID could be sequential, or a <a>UUID</a>, or method-specific).
-			</td>
-		</tr>
-		<tr>
-			<td>
-				<code>versionTime</code>
-			</td>
-			<td>
-				Identifies a certain version timestamp of a <a>DID document</a> to be resolved.
-				That is, the most recent version of the <a>DID document</a> that was valid for a <a>DID</a>
-				before the specified `versionTime`. If present, the associated value
-				MUST be represented in the datetime format as defined in <a href="#datetime"></a>.
-			</td>
-		</tr>
+        <tbody>
+          <tr>
+            <td>
+              <code><a>service</a></code>
+            </td>
+            <td>
+              Identifies a <a data-cite="did-core#services">service</a> from the
+              <a>DID document</a> by service ID.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <code>serviceType</code>
+            </td>
+            <td>
+              Identifies a set of one or more <a data-cite="did-core#services">services</a>
+              from the <a>DID document</a> by service type.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <code>relativeRef</code>
+            </td>
+            <td>
+              A relative <a>URI</a> reference according to
+              <a data-cite="RFC3986#section-4.2">RFC3986 Section 4.2</a> that identifies a
+              <a>resource</a> at a [=DID service endpoint=],
+              which is selected from a <a>DID document</a> by using
+              the <code>service</code> parameter.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <code>versionId</code>
+            </td>
+            <td>
+              Identifies a specific version of a <a>DID document</a>
+              to be resolved (the version ID could be sequential, or a
+              <a>UUID</a>, or method-specific).
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <code>versionTime</code>
+            </td>
+            <td>
+              Identifies a certain version timestamp of a
+              <a>DID document</a> to be resolved. That is, the most
+              recent version of the <a>DID document</a> that was
+              valid for a <a>DID</a> before the specified
+              `versionTime`. If present, the associated value MUST be
+              represented in the datetime format as defined in
+              <a href="#datetime"></a>.
+            </td>
+          </tr>
+        </tbody>
+      </table>
 
-		</tbody>
-	</table>
+      <p>
+Implementers as well as <a>DID method</a> specification authors
+might use additional DID parameters that are not listed here. For maximum
+interoperability, it is RECOMMENDED that DID parameters use the DID Document
+Properties Extensions mechanism [[?DID-EXTENSIONS-PROPERTIES]], to avoid
+collision with other uses of the same DID parameter with different semantics.
+      </p>
 
-	<p>
-		Implementers as well as <a>DID method</a> specification authors might use
-		additional DID parameters that are not listed here. For maximum
-		interoperability, it is RECOMMENDED that DID parameters use the DID
-		Document Properties Extensions mechanism [[?DID-EXTENSIONS-PROPERTIES]], to avoid collision
-		with other uses of the same DID parameter with different semantics.
-	</p>
+      <p>
+DID parameters might be used if there is a clear use case where the
+parameter needs to be part of a <a>DID URL</a> that
+references a <a>resource</a> with more precision than
+using the <a>DID</a> alone. It is expected that DID
+parameters are <em>not</em> used if the same functionality can be
+expressed by passing <a href="#did-resolution-options">DID resolution options</a> or
+<a href="#did-url-dereferencing-options">DID URL dereferencing options</a>.
+      </p>
 
-	<p>
-		DID parameters might be used if there is a clear use case where the parameter
-		needs to be part of a <a>DID URL</a> that references a <a>resource</a> with more
-		precision than using the <a>DID</a> alone. It is expected that DID parameters
-		are <em>not</em> used if the same functionality can be expressed by passing
-		<a href="#did-resolution-options">DID resolution options</a> or
-		<a href="#did-url-dereferencing-options">DID URL dereferencing options</a>.
-	</p>
+      <p class="note" title="DID parameters and DID resolution">
+The <a>DID resolution</a> and the
+<a>DID URL dereferencing</a> functions can be influenced by passing
+<a href="#did-resolution-options">DID resolution options</a> or
+<a href="#did-url-dereferencing-options">DID URL dereferencing options</a> to a
+<a>DID resolver</a> or <a>DID URL dereferencer</a>. Such
+options are not part of the <a>DID</a> or
+<a>DID URL</a>. This is comparable to HTTP, where
+certain parameters could either be included in an HTTP URL, or
+alternatively passed as HTTP headers during the dereferencing process.
+The important distinction is that DID parameters that are part of the
+<a>DID URL</a> should be used to specify
+<em>what is being identified</em>, whereas options that are not part of
+the <a>DID</a> or <a>DID URL</a>
+should be used to control
+<em>how resolution and dereferencing are performed</em>.
+      </p>
 
-	<p class="note" title="DID parameters and DID resolution">
-		The <a>DID resolution</a> and the <a>DID URL dereferencing</a> functions can
-		be influenced by passing <a href="#did-resolution-options">DID resolution options</a> or
-		<a href="#did-url-dereferencing-options">DID URL dereferencing options</a> to a <a>DID resolver</a>
-		or <a>DID URL dereferencer</a>. Such options are
-		not part of the <a>DID</a> or <a>DID URL</a>. This is comparable to
-		HTTP, where certain parameters could either be included in an HTTP URL, or
-		alternatively passed as HTTP headers during the dereferencing process. The
-		important distinction is that DID parameters that are part of the <a>DID
-		URL</a> should be used to specify <em>what is being
-		identified</em>, whereas options that are not part of the <a>DID</a> or <a>DID URL</a>
-		should be used to control <em>how resolution and dereferencing are performed</em>.
-	</p>
+      <section id="datetime">
+        <h3>Datetime</h3>
 
-	<section id="datetime">
-		<h3>Datetime</h3>
+        <p>
+All datetime values in this specification MUST be an
+<a data-lt="ascii string"> ASCII string</a> which is a valid XML datetime value
+defined by the [[VC-DATA-MODEL]] in <a data-cite="vc-data-model#representing-time"></a>.
+Additionally, timestamps used in DID Resolution MUST be adjusted to
+UTC without sub-second decimal precision. For example:
+<code>2020-12-20T19:17:47Z</code>
+        </p>
+      </section>
 
-		<p>
-			All datetime values in this specification MUST be an <a	data-lt="ascii string">
-				ASCII string</a> which is a valid XML datetime value defined by the
-			[[VC-DATA-MODEL]] in <a data-cite="vc-data-model#representing-time"></a>.
-			Additionally, timestamps used in DID Resolution MUST be adjusted to UTC
-			without sub-second decimal precision. For example: <code>2020-12-20T19:17:47Z</code>
-		</p>
+      <section id="query-normalization">
+        <h3>Query Normalization</h3>
 
-	</section>
+        <p>
+<a>DID URL</a> query strings are routinely constructed, parsed,
+logged, cached, and compared by multiple independent components across a
+resolution pipeline — for example, a client, a caching proxy, a downstream
+resolver, and a DID method-specific resolver (see
+<a href="#resolver-architectures"></a>). Inconsistent normalization of
+<a>DID URL</a> query strings across these components can
+silently produce incorrect resolution results, cache poisoning, or broken
+interoperability. This section enumerates edge cases that implementers and DID
+method specification authors are encouraged to address explicitly.
+        </p>
+        <p class="note" title="DID URL query string normalization">
+The guidance in this section concerns how a DID URL query string is normalized
+for the purposes of parsing, comparison, and forwarding. It is distinct from the
+question of which parameters are passed as resolution options as opposed to
+being embedded in the <a>DID URL</a>, which is addressed at the
+end of <a href="#did-parameters"></a> in the note on the distinction between DID
+parameters and resolution options.
+        </p>
 
-	<section id="query-normalization">
-		<h3>Query Normalization</h3>
+        <section id="percent-encoding-normalization" class="informative">
+          <h4>Percent-Encoding Normalization</h4>
 
-		<p>
-			<a>DID URL</a> query strings are routinely constructed, parsed, logged,
-			cached, and compared by multiple independent components across a
-			resolution pipeline — for example, a client, a caching proxy, a
-			downstream resolver, and a DID method-specific resolver (see
-			<a href="#resolver-architectures"></a>). Inconsistent normalization
-			of <a>DID URL</a> query strings across these components can silently
-			produce incorrect resolution results, cache poisoning, or broken
-			interoperability. This section enumerates edge cases that
-			implementers and DID method specification authors are encouraged to
-			address explicitly.
-		</p>
-		<p class="note" title="DID URL query string normalization">
-			The guidance in this section concerns how a DID URL query string is
-			normalized for the purposes of parsing, comparison, and forwarding.
-			It is distinct from the question of which parameters are passed as
-			resolution options as opposed to being embedded in the <a>DID URL</a>, which is
-			addressed at the end of <a href="#did-parameters"></a>
-			in the note on the distinction between DID parameters and resolution
-			options.
-		</p>
+          <p>
+The percent-encoding of a character in a <a>DID URL</a> query
+string does not change the identity of the resource being identified, but
+different encodings of the same logical value could be treated as distinct
+strings by implementations that perform naive string comparison.
+          </p>
+          <p>
+Implementations that compare, cache, or forward DID URLs are encouraged to
+normalize percent-encoding before comparison or storage. The following rules,
+consistent with <a data-cite="RFC3986#section-6.2.2">RFC3986 Section 6.2.2: Syntax-Based Normalization</a>,
+are suggested as a baseline:
+          </p>
+          <ol>
+            <li>
+Percent-encoded octets that correspond to unreserved characters (as defined in
+<a data-cite="RFC3986#section-2.3">RFC3986 Section 2.3: Unreserved Characters</a>)
+can be decoded to their literal character form.
+            </li>
+            <li>
+All remaining percent-encoded octets are best represented using uppercase
+hexadecimal digits (e.g., `%2F` rather than `%2f`).
+            </li>
+            <li>
+Avoid decoding percent-encoded characters that are reserved delimiters within
+the query component (e.g., `%26` for `&`, `%3D` for `=`), as doing so would
+alter the parsed structure of the query string.
+            </li>
+          </ol>
+          <p>
+DID method specifications are encouraged to document which characters in their
+method-specific DID parameters are safe to decode during normalization.
+          </p>
+          <p class="note" title="relativeRef-percent-encoding">
+The `relativeRef` DID parameter value will typically contain percent-encoded
+path separators and query characters (e.g.,
+`relativeRef=%2Fresume.pdf%3Fversion%3D2`). Avoid decoding these as part of
+query-level normalization, as the encoded form is intentional and necessary for
+the value to be correctly interpreted as a relative reference during
+dereferencing (see <a href="#dereferencing-algorithm-resource">Dereferencing the Resource</a>).
+          </p>
+        </section>
 
-		<section id="percent-encoding-normalization" class="informative">
-			<h4>Percent-Encoding Normalization</h4>
+        <section id="duplicate-parameter-handling">
+          <h4>Duplicate Parameter Handling</h4>
 
-			<p>
-				The percent-encoding of a character in a <a>DID URL</a> query string
-				does not change the identity of the resource being identified,
-				but different encodings of the same logical value could be treated
-				as distinct strings by implementations that perform naive string
-				comparison.
-			</p>
-			<p>
-				Implementations that compare, cache, or forward DID URLs are
-				encouraged to normalize percent-encoding before comparison or
-				storage. The following rules, consistent with <a
-				data-cite="RFC3986#section-6.2.2">RFC3986 Section 6.2.2:
-				Syntax-Based Normalization</a>, are suggested as a baseline:
-			</p>
-			<ol>
-				<li>Percent-encoded octets that correspond to unreserved characters
-				(as defined in <a data-cite="RFC3986#section-2.3">RFC3986 Section
-				2.3: Unreserved Characters</a>) can be decoded to their literal
-				character form.</li>
-				<li>All remaining percent-encoded octets are best represented using
-				uppercase hexadecimal digits (e.g., `%2F` rather than `%2f`).</li>
-				<li>Avoid decoding percent-encoded characters that are reserved
-				delimiters within the query component (e.g., `%26` for `&`,
-				`%3D` for `=`), as doing so would alter the parsed structure of
-				the query string.</li>
-			</ol>
-			<p>
-				DID method specifications are encouraged to document which
-				characters in their method-specific DID parameters are safe to
-				decode during normalization.
-			</p>
-			<p class="note" title="relativeRef-percent-encoding">
-				The `relativeRef` DID parameter value will typically contain
-				percent-encoded path separators and query characters (e.g.,
-				`relativeRef=%2Fresume.pdf%3Fversion%3D2`). Avoid decoding these
-				as part of query-level normalization, as the encoded form is
-				intentional and necessary for the value to be correctly
-				interpreted as a relative reference during dereferencing (see
-				<a href="#dereferencing-algorithm-resource">Dereferencing the
-				Resource</a>).
-			</p>
-		</section>
+          <p>
+The <a>DID URL</a> syntax does not prohibit duplicate
+occurrences of the same query parameter name within a single DID URL (e.g.,
+`did:example:123?service=files&service=agent`). The behavior of resolution and
+dereferencing functions when duplicate parameters are present is otherwise
+unspecified by this document.
+          </p>
+          <p>
+Implementers are encouraged to define and document the behavior of their
+implementations when a <a>DID URL</a> contains duplicate query
+parameter names. Because all DID parameters defined in this specification have
+scalar values (see <a href="#did-parameters"></a>), a duplicate occurrence of
+any of these parameters represents an ambiguous input with no well-defined
+resolution behavior. One reasonable approach is to treat such a
+<a>DID URL</a> as invalid and return an `INVALID_DID_URL` error
+(see <a href="#errors"></a>).
+          </p>
+          <p>
+DID method specifications that define method-specific query parameters are
+encouraged to explicitly state whether duplicate occurrences of those parameters
+are permitted, and if so, to define the resolution semantics (e.g., first value
+wins, last value wins, set union).
+          </p>
+        </section>
+        <section id="canonicalization-by-did-method">
+          <h4>Canonicalization by DID Method</h4>
 
-		<section id="duplicate-parameter-handling">
-			<h4>Duplicate Parameter Handling</h4>
+          <p>
+The set of query parameters defined in <a href="#did-parameters"></a> is not
+exhaustive. DID methods can define additional method-specific query parameters,
+and the canonical form of those parameters (including their names, value
+formats, and ordering) can vary by method.
+          </p>
+          <p>
+DID method specifications are encouraged to specify a canonical form for any
+method-specific query parameters they define, covering the following
+considerations:
+          </p>
+          <ol>
+            <li>
+<strong>Value format:</strong> The expected encoding, character
+set, and range of valid values for each parameter.
+            </li>
+            <li>
+<strong>Parameter ordering:</strong> Whether the relative ordering
+of query parameters has semantic significance, and if so, what the
+canonical ordering is. In the absence of explicit guidance, it is
+reasonable to treat parameter ordering as insignificant when
+comparing DID URLs for logical equivalence.
+            </li>
+            <li>
+<strong>Case sensitivity:</strong> Whether parameter names or
+values are case-sensitive. The parameter names defined in this
+specification are case-sensitive ASCII strings. In the absence of
+contrary guidance from a DID method specification, parameter
+values are best treated as case-sensitive.
+            </li>
+          </ol>
+          <p>
+Implementations that need to test two DID URLs for logical equivalence (for
+example, for cache lookup) are encouraged to apply
+parameter-ordering-independent comparison after applying the percent-encoding
+normalization described in <a href="#percent-encoding-normalization"></a>,
+unless the applicable DID method specification defines a canonical parameter
+ordering with semantic significance.
+          </p>
+        </section>
+      </section>
+    </section>
 
-			<p>
-				The <a>DID URL</a> syntax does not prohibit duplicate occurrences of
-				the same query parameter name within a single DID URL (e.g.,
-				`did:example:123?service=files&service=agent`). The behavior of
-				resolution and dereferencing functions when duplicate parameters
-				are present is otherwise unspecified by this document.
-			</p>
-			<p>
-				Implementers are encouraged to define and document the behavior
-				of their implementations when a <a>DID URL</a> contains duplicate query
-				parameter names. Because all DID parameters defined in this
-				specification have scalar values (see <a href="#did-parameters"></a>), a duplicate
-				occurrence of any of these parameters represents an ambiguous
-				input with no well-defined resolution behavior. One reasonable
-				approach is to treat such a <a>DID URL</a> as invalid and return an
-				`INVALID_DID_URL` error (see <a href="#errors"></a>).
-			</p>
-			<p>
-				DID method specifications that define method-specific query
-				parameters are encouraged to explicitly state whether duplicate
-				occurrences of those parameters are permitted, and if so, to
-				define the resolution semantics (e.g., first value wins, last
-				value wins, set union).
-			</p>
+    <section id="resolving">
+      <h1>DID Resolution</h1>
 
-		</section>
-		<section id="canonicalization-by-did-method">
-			<h4>Canonicalization by DID Method</h4>
+      <p>
+The <a>DID resolution</a> function resolves a
+<a>DID</a> into a <a>DID document</a> by using
+the "Resolve" operation of the applicable <a>DID method</a> as
+described in <a data-cite="did-core#method-operations">Method Operations</a>.
+      </p>
+      <p>
+<a>DID resolution</a> is a part of <a>DID URL dereferencing</a>, as
+described in <a href="#dereferencing"></a>.
+      </p>
+      <p class="note">
+To be able to dereference a DID URL, one first needs a
+<a>DID document</a>, which is the result of the
+<a>DID resolution</a> process. The <a>DID document</a> is
+used in various ways during the <a>DID URL dereferencing</a> process. The term
+<a>DID resolution</a> is consistent with "URI resolution" as defined in
+<a data-cite="RFC3986#section-1.2.2">RFC3986 Section 1.2.2</a>, since it provides
+"the appropriate parameters necessary to dereference a URI".
+      </p>
+      <p>
+All [=conforming DID resolvers=] implement the function below, which has the
+following abstract form:
+      </p>
 
-			<p>
-				The set of query parameters defined in <a
-				href="#did-parameters"></a> is not exhaustive. DID methods can
-				define additional method-specific query parameters, and the
-				canonical form of those parameters (including their names,
-				value formats, and ordering) can vary by method.
-			</p>
-			<p>
-				DID method specifications are encouraged to specify a canonical
-				form for any method-specific query parameters they define,
-				covering the following considerations:
-				<ol>
-					<li><strong>Value format:</strong> The expected encoding,
-					character set, and range of valid values for each
-					parameter.</li>
-					<li><strong>Parameter ordering:</strong> Whether the
-					relative ordering of query parameters has semantic
-					significance, and if so, what the canonical ordering is. In
-					the absence of explicit guidance, it is reasonable to treat
-					parameter ordering as insignificant when comparing DID URLs
-					for logical equivalence.</li>
-					<li><strong>Case sensitivity:</strong> Whether parameter
-					names or values are case-sensitive. The parameter names
-					defined in this specification are case-sensitive ASCII
-					strings. In the absence of contrary guidance from a DID
-					method specification, parameter values are best treated as
-					case-sensitive.</li>
-				</ol>
-			</p>
-			<p>
-				Implementations that need to test two DID URLs for logical
-				equivalence (for example, for cache lookup) are encouraged to
-				apply parameter-ordering-independent comparison after applying
-				the percent-encoding normalization described in <a
-				href="#percent-encoding-normalization"></a>, unless the
-				applicable DID method specification defines a canonical
-				parameter ordering with semantic significance.
-			</p>
-		</section>
-	</section>
-
-</section>
-
-<section id="resolving">
-	<h1>DID Resolution</h1>
-
-	<p>
-		The <a>DID resolution</a> function resolves a <a>DID</a> into a <a>DID
-		document</a> by using the "Resolve" operation of the applicable <a>DID method</a>
-		as described in <a data-cite="did-core#method-operations">Method Operations</a>.
-	</p>
-	<p>
-		<a>DID resolution</a> is a part of <a>DID URL dereferencing</a>, as described in
-		<a href="#dereferencing"></a>.
-	</p>
-	<p class="note">
-		To be able to dereference a DID URL, one first needs a <a>DID document</a>,
-		which is the result of the <a>DID resolution</a> process. The <a>DID document</a>
-		is used in various ways during the <a>DID URL dereferencing</a> process.
-		The term <a>DID resolution</a> is consistent with "URI resolution" as defined in
-		<a data-cite="RFC3986#section-1.2.2">RFC3986 Section 1.2.2</a>, since it provides
-		"the appropriate parameters necessary to dereference a URI".
-	</p>
-	<p>	All [=conforming DID resolvers=] implement the function below, which has the
-		following abstract form:
-	</p>
-
-	<pre title="Abstract function for DID Resolution">
+      <pre title="Abstract function for DID Resolution">
 resolve(did, resolutionOptions) →
    « didResolutionMetadata, didDocument, didDocumentMetadata »
       </pre>
 
-	<p>
-		All [=conforming DID resolvers=] MUST implement the <a>DID resolution</a>
-		function for at least one <a>DID method</a> and MUST be able to return a
-		<a>DID document</a>.
-	</p>
+      <p>
+All [=conforming DID resolvers=] MUST implement the
+<a>DID resolution</a> function for at least one
+<a>DID method</a> and MUST be able to return a
+<a>DID document</a>.
+      </p>
 
-	<p>
-		Conforming <a>DID resolver</a> implementations do not alter the signature of
-		this function in any way. <a>DID resolver</a> implementations might map the
-		<code>resolve</code> function to a
-		method-specific internal function to perform the actual <a>DID resolution</a>
-		process. <a>DID resolver</a> implementations might implement and expose
-		additional functions with different signatures in addition to the
-		<code>resolve</code> function specified here.
-	</p>
+      <p>
+Conforming <a>DID resolver</a> implementations do not alter
+the signature of this function in any way.
+<a>DID resolver</a> implementations might map the
+<code>resolve</code> function to a method-specific internal function to
+perform the actual <a>DID resolution</a> process.
+<a>DID resolver</a> implementations might implement and
+expose additional functions with different signatures in addition to the
+<code>resolve</code> function specified here.
+      </p>
 
-	<p>
-		The input variables of the <code>resolve</code> function are as follows:
-	</p>
+      <p>
+The input variables of the <code>resolve</code> function are as follows:
+      </p>
 
-	<dl>
-		<dt>
-			did
-		</dt>
-		<dd>
-			This is the <a>DID</a> to resolve. This input is REQUIRED and the value MUST
-			be a conformant <a>DID</a> as defined in <a data-cite="did-core#did-syntax"></a>.
-		</dd>
-		<dt>
-			resolutionOptions
-		</dt>
-		<dd>
-			A <a href="#metadata-structure">metadata structure</a> consisting of input
-			options to the <code>resolve</code> function in addition to the
-			<code>did</code> itself. This structure is further defined in <a
-				href="#did-resolution-options"></a>. This input is REQUIRED, but the
-			structure MAY be empty.
-		</dd>
-	</dl>
+      <dl>
+        <dt>did</dt>
+        <dd>
+This is the <a>DID</a> to resolve. This input is REQUIRED
+and the value MUST be a conformant <a>DID</a> as defined in
+<a data-cite="did-core#did-syntax"></a>.
+        </dd>
+        <dt>resolutionOptions</dt>
+        <dd>
+A <a href="#metadata-structure">metadata structure</a> consisting of
+input options to the <code>resolve</code> function in addition to the
+<code>did</code> itself. This structure is further defined in
+<a href="#did-resolution-options"></a>. This input is REQUIRED, but the
+structure MAY be empty.
+        </dd>
+      </dl>
 
-	<p>
-		This function returns multiple values, and no limitations
-		are placed on how these values are returned together.
-		The return values of <code>resolve</code> are
-		<a>didResolutionMetadata</a>, <a>didDocument</a>, and
-		<a>didDocumentMetadata</a>. These values are described below:
-	</p>
+      <p>
+This function returns multiple values, and no limitations are placed on
+how these values are returned together. The return values of
+<code>resolve</code> are <a>didResolutionMetadata</a>,
+<a>didDocument</a>, and <a>didDocumentMetadata</a>.
+These values are described below:
+      </p>
 
-	<dl>
-		<dt>
-			<dfn>didResolutionMetadata</dfn>
-		</dt>
-		<dd>
-			A <a href="#metadata-structure">metadata structure</a> consisting of values
-			relating to the results of the <a>DID resolution</a> process. This
-			structure is REQUIRED, and in the case of an
-			error in the resolution process, this MUST NOT be empty. This structure is further
-			defined in <a href="#did-resolution-metadata"></a>. If the resolution is
-			unsuccessful, this structure MUST contain an <code>error</code> property
-			describing the error. See Section <a href="#errors"></a>.
-		</dd>
-		<dt>
-			<dfn>didDocument</dfn>
-		</dt>
-		<dd>
-			If the resolution is successful, this MUST be a <a>DID document</a> that
-			is capable of being represented in one of the conformant
-			<a data-cite="did#representations">representations</a> of the <a data-cite="did#data-model"></a>
-			specification. The value of <code><a data-cite="did#dfn-id">id</a></code>
-			in the resolved <a>DID document</a> MUST be string equal to the <a>DID</a> that was resolved.
-			If the resolution is unsuccessful, this	value MUST be empty.
-		</dd>
-		<dt>
-			<dfn>didDocumentMetadata</dfn>
-		</dt>
-		<dd>
-			If the resolution is successful, this MUST be a <a
-				href="#metadata-structure">metadata structure</a>. This structure contains
-			metadata about the <a>DID document</a> contained in the <code>didDocument</code>
-			property. If the resolution is unsuccessful, this output MUST be an empty <a
-				href="#metadata-structure">metadata structure</a>. This structure is further
-			defined in <a href="#did-document-metadata"></a>.
-		</dd>
-	</dl>
+      <dl>
+        <dt>
+<dfn>didResolutionMetadata</dfn>
+        </dt>
+        <dd>
+A <a href="#metadata-structure">metadata structure</a> consisting of values
+relating to the results of the <a>DID resolution</a> process. This structure
+is REQUIRED, and in the case of an error in the resolution process,
+this MUST NOT be empty. This structure is further defined in
+<a href="#did-resolution-metadata"></a>. If the resolution is unsuccessful,
+this structure MUST contain an <code>error</code> property describing
+the error. See Section <a href="#errors"></a>.
+        </dd>
+        <dt>
+<dfn>didDocument</dfn>
+        </dt>
+        <dd>
+If the resolution is successful, this MUST be a
+<a>DID document</a> that is capable of being represented
+in one of the conformant <a data-cite="did#representations">representations</a> of the
+<a data-cite="did#data-model"></a> specification. The value of
+<code><a data-cite="did#dfn-id">id</a></code>
+in the resolved <a>DID document</a> MUST be string equal
+to the <a>DID</a> that was resolved. If the
+resolution is unsuccessful, this value MUST be empty.
+        </dd>
+        <dt>
+<dfn>didDocumentMetadata</dfn>
+        </dt>
+        <dd>
+If the resolution is successful, this MUST be a
+<a href="#metadata-structure">metadata structure</a>.
+This structure contains metadata about the <a>DID document</a> contained in the
+<code>didDocument</code> property.
+If the resolution is unsuccessful, this output MUST be an
+empty <a href="#metadata-structure">metadata structure</a>.
+This structure is further defined in <a href="#did-document-metadata"></a>.
+        </dd>
+      </dl>
 
-	<section>
-		<h3>DID Resolution Options</h3>
+      <section>
+        <h3>DID Resolution Options</h3>
 
-		<p>This is a <a href="#metadata-structure">metadata structure</a> that contains input options for the <a>DID Resolution</a> process.</p>
+        <p>
+This is a <a href="#metadata-structure">metadata structure</a> that contains
+input options for the <a>DID Resolution</a> process.
+        </p>
 
-		<p>
-			The possible properties within this structure and their possible values SHOULD
-			be registered in the DID Resolution Extensions [[?DID-EXTENSIONS-RESOLUTION]].
-			This specification defines the following common input options:
-		</p>
+        <p>
+The possible properties within this structure and their possible values SHOULD
+be registered in the DID Resolution Extensions [[?DID-EXTENSIONS-RESOLUTION]].
+This specification defines the following common input options:
+        </p>
 
-		<dl>
-			<dt>
-				accept
-			</dt>
-			<dd>
-				The media type of the caller's preferred <a>representation</a> of the
-				<a>DID document</a>. The value MUST be expressed according to the
-				`Accept` header value as defined in [[[RFC9110]]], <a
-				data-cite="RFC9110#section-12.5.1">Section 12.5.1</a>. The <a>DID
-				resolver</a> implementation SHOULD use this value to determine the
-				<a>representation</a> of the returned
-				<code>didDocument</code> if such a <a>representation</a> is supported
-				and available. This property is OPTIONAL.
-			</dd>
-		</dl>
+        <dl>
+          <dt>accept</dt>
+          <dd>
+The media type of the caller's preferred <a>representation</a> of the
+<a>DID document</a>. The value MUST be expressed according to the `Accept`
+header value as defined in [[[RFC9110]]],
+<a data-cite="RFC9110#section-12.5.1">Section 12.5.1</a>. The <a>DID resolver</a>
+implementation SHOULD use this value to determine the <a>representation</a>
+of the returned <code>didDocument</code> if such a <a>representation</a>
+is supported and available. This property is OPTIONAL.
+          </dd>
+        </dl>
 
-		<dl>
-			<dt>
-				expandRelativeUrls
-			</dt>
-			<dd>
-				A boolean flag which instructs a <a>DID resolver</a> to expand
-				<a data-cite="did-core#relative-did-urls">relative DID URLs</a> in
-				the <a>DID document</a> to
-				absolute DID URLs conformant with <a data-cite="did-core#did-url-syntax">
-				DID URL Syntax</a>.
-			</dd>
-		</dl>
+        <dl>
+          <dt>expandRelativeUrls</dt>
+          <dd>
+A boolean flag which instructs a <a>DID resolver</a> to expand
+<a data-cite="did-core#relative-did-urls">relative DID URLs</a>
+in the <a>DID document</a> to absolute DID URLs conformant with
+<a data-cite="did-core#did-url-syntax"> DID URL Syntax</a>.
+          </dd>
+        </dl>
 
-		<dl>
-			<dt>versionId</dt>
-			<dd>
-				See <a href="#did-parameters"></a> for the definition.
-			</dd>
-		</dl>
+        <dl>
+          <dt>versionId</dt>
+          <dd>See <a href="#did-parameters"></a> for the definition.</dd>
+        </dl>
 
-    <dl>
-			<dt>versionTime</dt>
-			<dd>
-				See <a href="#did-parameters"></a> for the definition.
-			</dd>
-		</dl>
-	</section>
+        <dl>
+          <dt>versionTime</dt>
+          <dd>See <a href="#did-parameters"></a> for the definition.</dd>
+        </dl>
+      </section>
 
-	<section>
-		<h3>DID Resolution Metadata</h3>
+      <section>
+        <h3>DID Resolution Metadata</h3>
 
-		<p>This is a <a href="#metadata-structure">metadata structure</a> that contains metadata about the <a>DID Resolution</a> process.</p>
-		<p>This metadata typically changes between invocations of the <a>DID Resolution</a> function as it represents data about the resolution process itself.</p>
-		<p>The source of this metadata is the <a>DID resolver</a>.</p>
-		<p>Examples of DID Resolution Metadata include:</p>
-		<ul>
-			<li>Media type of the returned content (`contentType`).</li>
-			<li>Error object (`error`) (see Section <a href="#errors"></a>).</li>
-            <li>Proofs generated by the <a>DID resolver</a>, e.g., to establish trusted resolution (<b>proof</b>).</li>
-			<li>Duration of the DID resolution process.</li>
-			<li>Caching information (see Section <a href="#caching"></a>).</li>
-			<li>URLs, IP addresses, and/or other networking information about the <a>verifiable data registry</a> that was used during the DID resolution process.</li>
-		</ul>
+        <p>
+This is a <a href="#metadata-structure">metadata structure</a> that contains
+metadata about the <a>DID Resolution</a> process.
+        </p>
+        <p>
+This metadata typically changes between invocations of the
+<a>DID Resolution</a> function as it represents data about the
+resolution process itself.
+        </p>
+        <p>
+The source of this metadata is the <a>DID resolver</a>.
+        </p>
+        <p>Examples of DID Resolution Metadata include:</p>
+        <ul>
+          <li>Media type of the returned content (`contentType`).</li>
+          <li>
+Error object (`error`) (see Section <a href="#errors"></a>).
+          </li>
+          <li>
+Proofs generated by the <a>DID resolver</a>, e.g., to
+establish trusted resolution (<b>proof</b>).
+          </li>
+          <li>Duration of the DID resolution process.</li>
+          <li>
+Caching information (see Section <a href="#caching"></a>).
+          </li>
+          <li>
+URLs, IP addresses, and/or other networking information about the
+<a>verifiable data registry</a> that was used during the DID resolution process.
+          </li>
+        </ul>
 
-		<p>
-			The possible properties within this structure and their possible values SHOULD
-			be registered in the DID Resolution Extensions [[?DID-EXTENSIONS-RESOLUTION]]. This
-			specification defines the following common metadata properties:
-		</p>
+        <p>
+The possible properties within this structure and their possible values SHOULD
+be registered in the DID Resolution Extensions [[?DID-EXTENSIONS-RESOLUTION]].
+This specification defines the following common metadata properties:
+        </p>
 
-		<dl>
-			<dt>
-				contentType
-			</dt>
-			<dd>
-				The Media Type of the returned <code>didDocument</code>. This property is
-				OPTIONAL. If present, the value of this
-				property MUST be an <a data-lt="ascii string">ASCII string</a> that is the Media
-				Type of the conformant <a>representations</a>. In this case, the
-				caller of the <code>resolve</code> function MUST use this value
-				when determining how to parse and process the <code>didDocument</code>.
-			</dd>
-			<dt>
-				error
-			</dt>
-			<dd>
-				An error data structure is defined in [[RFC9457]]. The errors defined by this specification can
-				be found in Section <a href="#errors"></a>.
-                Additional errors SHOULD be registered in the DID Resolution Extensions [[?DID-EXTENSIONS-RESOLUTION]].
-			</dd>
+        <dl>
+          <dt>contentType</dt>
+          <dd>
+The Media Type of the returned <code>didDocument</code>. This
+property is OPTIONAL. If present, the value of this property MUST be
+an <a data-lt="ascii string">ASCII string</a> that is the Media Type of the
+conformant <a>representations</a>. In this case, the caller
+of the <code>resolve</code> function MUST use this value when
+determining how to parse and process the <code>didDocument</code>.
+          </dd>
+          <dt>error</dt>
+          <dd>
+An error data structure is defined in [[RFC9457]]. The errors defined by this
+specification can be found in Section <a href="#errors"></a>.
+Additional errors SHOULD be registered in the DID Resolution Extensions
+[[?DID-EXTENSIONS-RESOLUTION]].
+          </dd>
 
-            <dt>
-                proof
-            </dt>
-            <dd>
-                <p>
-                    Some <a>DID resolvers</a> and <a>DID URL dereferencers</a> use proofs when executing
-                    the <a>DID Resolution</a> or <a>DID URL Dereferencing</a> functions.
-                    See <a href="#resolver-architectures"></a> for details.
-                </p>
-                <p>
-                    <a>DID resolution</a> metadata MAY include a <code>proof</code> property.
-                    If present, the value MUST be a <a
-                        data-cite="INFRA#sets">set</a> where each item is a
-                    <a data-cite="INFRA#maps">map</a> that represents a proof. The use of this property
-                    and the types of proofs are <a>DID method</a>-independent.
-                </p>
-            </dd>
-		</dl>
+          <dt>proof</dt>
+          <dd>
+					<p>
+Some <a>DID resolvers</a> and <a>DID URL dereferencers</a> use proofs when
+executing the <a>DID Resolution</a> or <a>DID URL Dereferencing</a>
+functions. See <a href="#resolver-architectures"></a> for details.
+					</p>
+					<p>
+<a>DID resolution</a> metadata MAY include a <code>proof</code> property.
+If present, the value MUST be a <a data-cite="INFRA#sets">set</a> where each
+item is a <a data-cite="INFRA#maps">map</a> that represents a proof. The use
+of this property and the types of proofs are <a>DID method</a>-independent.
+					</p>
+          </dd>
+        </dl>
+      </section>
 
-	</section>
+      <section>
+        <h3>DID Document Metadata</h3>
 
-	<section>
-		<h3>DID Document Metadata</h3>
+        <p>
+This is a <a href="#metadata-structure">metadata structure</a> that contains
+metadata about the <a>DID Resolution</a> process.
+        </p>
+        <p>
+This metadata typically does not change between invocations of the
+<a>DID Resolution</a> function unless the
+<a>DID document</a> changes, as it represents data about the
+<a>DID document</a>.
+        </p>
+        <p>
+The sources of this metadata are the <a>DID controller</a> and/or the
+<a>DID method</a>. DID document metadata attested to by the DID
+controller comes with no inherent guarantee of accuracy. Clients are advised to
+proceed with caution when relying on DID document metadata to inform business
+logic.
+        </p>
+        <p>Examples of DID document metadata include:</p>
+        <ul>
+          <li>
+Timestamps when the <a>DID</a> and its associated
+<a>DID document</a> were created or updated (e.g., `created`,
+`updated`, `nextUpdate`).
+          </li>
+          <li>
+Versioning information about the DID document (e.g., `versionId`,
+`nextVersionId`).
+          </li>
+          <li>
+Proofs added by the <a>DID controller</a> or generated by the
+<a>DID method's</a> <a>verifiable data registry</a>, which might be
+used to establish control authority or to enable <a>verifiable resolution</a>
+(e.g., `proof`).
+          </li>
+          <li>Metadata about controllers, capabilities, delegations, etc.</li>
+          <li>
+Method-specific metadata, such as block number, index, transaction hash, number
+of confirmations, etc., of a record in the blockchain or other
+<a>verifiable data registry</a>.
+          </li>
+        </ul>
 
-		<p>This is a <a href="#metadata-structure">metadata structure</a> that contains metadata about the <a>DID Resolution</a> process.</p>
-		<p>This metadata typically does not change between invocations of the <a>DID Resolution</a> function unless the <a>DID document</a> changes, as it represents data about the <a>DID document</a>.</p>
-		<p>The sources of this metadata are the <a>DID controller</a> and/or the <a>DID method</a>.
-			DID document metadata attested to by the DID controller comes with no inherent guarantee of accuracy.
-			Clients are advised to proceed with caution when relying on DID document metadata to inform business logic.
-		</p>
-		<p>Examples of DID document metadata include:</p>
-		<ul>
-			<li>Timestamps when the <a>DID</a> and its associated <a>DID document</a> were created or updated (e.g., `created`, `updated`, `nextUpdate`).</li>
-			<li>Versioning information about the DID document (e.g., `versionId`, `nextVersionId`).</li>
-			<li>Proofs added by the <a>DID controller</a> or generated by the <a>DID method's</a> <a>verifiable data registry</a>,
-				which might be used to establish control authority or to enable <a>verifiable resolution</a> (e.g., `proof`).
-			</li>
-			<li>Metadata about controllers, capabilities, delegations, etc.</li>
-			<li>Method-specific metadata, such as block number, index, transaction hash, number of confirmations, etc., of a record in the blockchain or other <a>verifiable data registry</a>.</li>
-		</ul>
+        <p>
+The possible properties within this structure and their possible values SHOULD
+be registered in the DID Document Properties Extensions
+[[?DID-EXTENSIONS-PROPERTIES]]. This specification defines the following common
+metadata properties.
+        </p>
 
-		<p>
-			The possible properties within this structure and their possible values SHOULD
-			be registered in the DID Document Properties Extensions [[?DID-EXTENSIONS-PROPERTIES]].
-			This specification defines the following common metadata properties.
-		</p>
+        <dl>
+          <dt><dfn class="lint-ignore">created</dfn></dt>
+          <dd>
+<a>DID document</a> metadata SHOULD include a <code>created</code> property
+to indicate the timestamp of the
+<a data-cite="did-core#method-operations">Create operation</a>. The value of
+the property MUST be represented in the datetime format as defined in
+<a href="#datetime"></a>.
+          </dd>
 
-		<dl>
-			<dt><dfn class="lint-ignore">created</dfn></dt>
-			<dd>
-				<a>DID document</a> metadata SHOULD include a <code>created</code> property to
-				indicate the timestamp of the <a data-cite="did-core#method-operations">Create operation</a>.
-				The value of the property MUST be represented in the datetime format as
-				defined in <a href="#datetime"></a>.
-			</dd>
+          <dt><dfn class="lint-ignore">updated</dfn></dt>
+          <dd>
+<a>DID document</a> metadata SHOULD include an
+<code>updated</code> property to indicate the timestamp of the last
+<a data-cite="did-core#method-operations">Update operation</a> for the
+document version which was resolved. The value of the property MUST be
+represented in the datetime format as defined in <a href="#datetime"></a>.
+The <code>updated</code> property is omitted if an Update operation has
+never been performed on the <a>DID document</a>. If an
+<code>updated</code> property exists, it can be the same value as
+the <code>created</code> property when the difference between the
+two timestamps is less than one second.
+          </dd>
 
-			<dt><dfn class="lint-ignore">updated</dfn></dt>
-			<dd>
-				<a>DID document</a> metadata SHOULD include an <code>updated</code> property to
-				indicate the timestamp of the last <a data-cite="did-core#method-operations">Update
-				operation</a> for the document version which was resolved. The value of the property
-				MUST be represented in the datetime format as defined in <a href="#datetime"></a>.
-				The <code>updated</code> property is omitted if an Update operation
-				has never been performed on the <a>DID document</a>. If an <code>updated</code>
-				property exists, it can be the same value as the <code>created</code> property
-				when the difference between the two timestamps is less than one second.
-			</dd>
+          <dt><dfn class="lint-ignore">deactivated</dfn></dt>
+          <dd>
+If a DID has been <a data-cite="did-core#method-operations">deactivated</a>,
+<a>DID document</a> metadata MUST include this property
+with the boolean value <code>true</code>. If a DID has not been deactivated,
+this property is OPTIONAL, but if included, MUST have the boolean value
+<code>false</code>.
+          </dd>
 
-			<dt><dfn class="lint-ignore">deactivated</dfn></dt>
-			<dd>
-				If a DID has been <a data-cite="did-core#method-operations">deactivated</a>,
-				<a>DID document</a> metadata MUST include this property with the boolean value
-				<code>true</code>. If a DID has not been deactivated, this property is OPTIONAL,
-				but if included, MUST have the boolean value <code>false</code>.
-			</dd>
+          <dt><dfn class="lint-ignore">nextUpdate</dfn></dt>
+          <dd>
+<a>DID document</a> metadata MAY include a
+<code>nextUpdate</code> property if the resolved document version is
+not the latest version of the document. It indicates the timestamp
+of the next <a data-cite="did-core#method-operations">Update operation</a>.
+The value of the property MUST be represented in the datetime format as defined
+in <a href="#datetime"></a>.
+          </dd>
 
-			<dt><dfn class="lint-ignore">nextUpdate</dfn></dt>
-			<dd>
-				<a>DID document</a> metadata MAY include a <code>nextUpdate</code> property if
-				the resolved document version is not the latest version of the document. It
-				indicates the timestamp of the next <a data-cite="did-core#method-operations">Update
-				operation</a>. The value of the property MUST be represented in the datetime
-				format as defined in <a href="#datetime"></a>.
-			</dd>
+          <dt><dfn class="lint-ignore">versionId</dfn></dt>
+          <dd>
+<a>DID document</a> metadata SHOULD include a
+<code>versionId</code> property to indicate the version of the last
+<a data-cite="did-core#method-operations">Update operation</a> for the document
+version which was resolved. The value of the property MUST be an
+<a data-lt="ascii string">ASCII string</a>.
+          </dd>
 
-			<dt><dfn class="lint-ignore">versionId</dfn></dt>
-			<dd>
-				<a>DID document</a> metadata SHOULD include a <code>versionId</code> property to
-				indicate the version of the last <a data-cite="did-core#method-operations">Update
-				operation</a> for the document version which was resolved. The value of the
-				property MUST be an <a data-lt="ascii string">ASCII string</a>.
-			</dd>
+          <dt><dfn class="lint-ignore">nextVersionId</dfn></dt>
+          <dd>
+<a>DID document</a> metadata MAY include a
+<code>nextVersionId</code> property if the resolved document version
+is not the latest version of the document. It indicates the version
+of the next <a data-cite="did-core#method-operations">Update operation</a>.
+The value of the property MUST be an <a data-lt="ascii string">ASCII string</a>.
+          </dd>
 
-			<dt><dfn class="lint-ignore">nextVersionId</dfn></dt>
-			<dd>
-				<a>DID document</a> metadata MAY include a <code>nextVersionId</code> property
-				if the resolved document version is not the latest version of the document. It
-				indicates the version of the next <a data-cite="did-core#method-operations">Update
-				operation</a>. The value of the property MUST be an <a data-lt="ascii
-string">ASCII string</a>.
-			</dd>
+          <dt><dfn>equivalentId</dfn></dt>
+          <dd>
+					<p>
+A <a>DID method</a> can define different forms of a <a>DID</a> that are
+logically equivalent. An example is when a <a>DID</a> takes one form
+prior to registration in a <a>verifiable data registry</a> and
+another form after such registration. In this case, the
+<a>DID method</a> specification might need to express one or more <a>DIDs</a>
+that are logically equivalent to the resolved <a>DID</a> as a property of the
+<a>DID document</a>. This is the purpose of the
+<code><a>equivalentId</a></code> property.
+					</p>
+					<p>
+<a>DID document</a> metadata MAY include an
+<code>equivalentId</code> property. If present, the value MUST be
+a <a data-cite="INFRA#sets">set</a> where each item is a
+<a data-cite="INFRA#string">string</a> that conforms to the rules in
+Section <a data-cite="did-core#did-syntax"></a>. The relationship is a
+statement that each
+<code><a>equivalentId</a></code> value is logically
+equivalent to the <code>id</code> property value and thus refers
+to the same <a>DID subject</a>. Each
+<code><a>equivalentId</a></code> DID value MUST be
+produced by, and a form of, the same
+<a>DID method</a> as the <code>id</code> property
+value. (e.g., <code>did:example:abc</code> ==
+<code>did:example:ABC</code>)
+					</p>
+					<p>
+A conforming <a>DID method</a> specification MUST
+guarantee that each
+<code><a>equivalentId</a></code> value is logically
+equivalent to the <code>id</code> property value.
+					</p>
+					<p>
+A requesting party is expected to retain the values from the
+<code>id</code> and
+<code><a>equivalentId</a></code> properties to ensure
+any subsequent interactions with any of the values they contain
+are correctly handled as logically equivalent (e.g., retain all
+variants in a database so an interaction with any one maps to the
+same underlying account).
+					</p>
+					<p class="note" title="Stronger equivalence">
+<code><a>equivalentId</a></code> is a much stronger form of equivalence than
+<code><a data-cite="did-core#also-known-as">alsoKnownAs</a></code> because the
+equivalence MUST be guaranteed by the governing <a>DID method</a>. The use of
+<code><a>equivalentId</a></code> means that the same <a>DID document</a>
+describes both the <code><a>equivalentId</a></code> <a>DID</a> and the
+<code>id</code> property <a>DID</a>.
+					</p>
+					<p>
+If a requesting party does not retain the values from the <code>id</code> and
+<code><a>equivalentId</a></code> properties and ensure
+any subsequent interactions with any of the values they contain
+are correctly handled as logically equivalent, there might be
+negative or unexpected issues that arise. Implementers are
+strongly advised to observe the directives related to this
+metadata property.
+					</p>
+          </dd>
 
-			<dt><dfn>equivalentId</dfn></dt>
-			<dd>
-				<p>
-					A <a>DID method</a> can define different forms of a <a>DID</a> that are
-					logically equivalent. An example is when a <a>DID</a> takes one form prior to
-					registration in a <a>verifiable data registry</a> and another form after such
-					registration. In this case, the <a>DID method</a> specification might need to
-					express one or more <a>DIDs</a> that are logically equivalent to the resolved
-					<a>DID</a> as a property of the <a>DID document</a>. This is the purpose of the
-					<code><a>equivalentId</a></code> property.
-				</p>
-				<p>
-					<a>DID document</a> metadata MAY include an <code>equivalentId</code> property.
-					If present, the value MUST be a <a
-						data-cite="INFRA#sets">set</a> where each item is a
-					<a data-cite="INFRA#string">string</a> that conforms to the rules in Section <a
-						data-cite="did-core#did-syntax"></a>. The relationship is a statement that each
-					<code><a>equivalentId</a></code> value is logically equivalent to the
-					<code>id</code> property value and thus refers to the same <a>DID subject</a>.
-					Each <code><a>equivalentId</a></code> DID value MUST be produced by, and a form
-					of, the same <a>DID method</a> as the <code>id</code> property value. (e.g.,
-					<code>did:example:abc</code> == <code>did:example:ABC</code>)
-				</p>
-				<p>
-					A conforming <a>DID method</a> specification MUST guarantee that each
-					<code><a>equivalentId</a></code> value is logically equivalent to the
-					<code>id</code> property value.
-				</p>
-				<p>
-					A requesting party is expected to retain the values from the <code>id</code> and
-					<code><a>equivalentId</a></code> properties to ensure any subsequent
-					interactions with any of the values they contain are correctly handled as
-					logically equivalent (e.g., retain all variants in a database so an interaction
-					with any one maps to the same underlying account).
-				</p>
-				<p class="note" title="Stronger equivalence">
-					<code><a>equivalentId</a></code> is a much stronger form of equivalence than
-					<code><a data-cite="did-core#also-known-as">alsoKnownAs</a></code> because the equivalence MUST be guaranteed by
-					the governing <a>DID method</a>. The use of <code><a>equivalentId</a></code>
-					means that the same <a>DID document</a> describes both the
-					<code><a>equivalentId</a></code> <a>DID</a> and the <code>id</code> property
-					<a>DID</a>.
-				</p>
-				<p>
-					If a requesting party does not retain the values from the <code>id</code> and
-					<code><a>equivalentId</a></code> properties and ensure any subsequent
-					interactions with any of the values they contain are correctly handled as
-					logically equivalent, there might be negative or unexpected issues that
-					arise. Implementers are strongly advised to observe the
-					directives related to this metadata property.
-				</p>
-			</dd>
+          <dt><dfn>canonicalId</dfn></dt>
+          <dd>
+					<p>
+The <code><a>canonicalId</a></code> property is identical to the
+<code><a>equivalentId</a></code> property except: a)
+it is associated with a single value rather than a set, and b) the
+<a>DID</a> is defined to be the canonical ID
+for the <a>DID subject</a> within the scope of the
+containing <a>DID document</a>.
+					</p>
+					<p>
+<a>DID document</a> metadata MAY include a <code>canonicalId</code> property.
+If present, the value MUST be a <a data-cite="INFRA#string">string</a> that
+conforms to the rules in Section <a data-cite="did-core#did-syntax"></a>.
+The relationship is a statement that the <code><a>canonicalId</a></code>
+value is logically equivalent to the <code>id</code> property value and that
+the <code><a>canonicalId</a></code> value is defined by the <a>DID method</a>
+to be the canonical ID for the <a>DID subject</a> in the scope of the
+containing <a>DID document</a>. A <code><a>canonicalId</a></code> value MUST be
+produced by, and a form of, the same <a>DID method</a> as the <code>id</code>
+property value. (e.g., <code>did:example:abc</code> ==
+<code>did:example:ABC</code>).
+					</p>
+					<p>
+A conforming <a>DID method</a> specification MUST guarantee that the
+<code><a>canonicalId</a></code> value is logically equivalent to the
+<code>id</code> property value.
+					</p>
+					<p>
+A requesting party is expected to use the
+<code><a>canonicalId</a></code> value as its primary
+ID value for the <a>DID subject</a> and treat all
+other equivalent values as secondary aliases (e.g., update
+corresponding primary references in their systems to reflect the
+new canonical ID directive).
+					</p>
+					<p class="note" title="Canonical equivalence">
+<code><a>canonicalId</a></code> is the same statement of equivalence as
+<code><a>equivalentId</a></code> except it is constrained to a single value
+that is defined to be canonical for the <a>DID subject</a> in the scope of the
+<a>DID document</a>. Like <code><a>equivalentId</a></code>, the use of
+<code><a>canonicalId</a></code> means that the same <a>DID document</a>
+describes both the <code><a>canonicalId</a></code> DID and the
+<code>id</code> property <a>DID</a>.
+					</p>
+					<p>
+If a resolving party does not use the
+<code><a>canonicalId</a></code> value as its primary
+ID value for the DID subject and treat all other equivalent values
+as secondary aliases, there might be negative or unexpected issues
+that arise related to user experience. Implementers are strongly
+advised to observe the directives related to this metadata
+property.
+					</p>
+          </dd>
 
-			<dt><dfn>canonicalId</dfn></dt>
-			<dd>
-				<p>
-					The <code><a>canonicalId</a></code> property is identical to the
-					<code><a>equivalentId</a></code> property except: a) it is associated with a
-					single value rather than a set, and b) the <a>DID</a> is defined to be
-					the canonical ID for the <a>DID subject</a> within the scope of the containing
-					<a>DID document</a>.
-				</p>
-				<p>
-					<a>DID document</a> metadata MAY include a <code>canonicalId</code> property.
-					If present, the value MUST be a <a
-						data-cite="INFRA#string">string</a> that conforms to the rules in Section <a
-						data-cite="did-core#did-syntax"></a>. The relationship is a statement that the
-					<code><a>canonicalId</a></code> value is logically equivalent to the
-					<code>id</code> property value and that the <code><a>canonicalId</a></code>
-					value is defined by the <a>DID method</a> to be the canonical ID for the <a>DID
-					subject</a> in the scope of the containing <a>DID document</a>. A
-					<code><a>canonicalId</a></code> value MUST be produced by, and a form of, the
-					same <a>DID method</a> as the <code>id</code> property value. (e.g.,
-					<code>did:example:abc</code> == <code>did:example:ABC</code>).
-				</p>
-				<p>
-					A conforming <a>DID method</a> specification MUST guarantee that the
-					<code><a>canonicalId</a></code> value is logically equivalent to the
-					<code>id</code> property value.
-				</p>
-				<p>
-					A requesting party is expected to use the <code><a>canonicalId</a></code> value
-					as its primary ID value for the <a>DID subject</a> and treat all other
-					equivalent values as secondary aliases (e.g., update corresponding primary
-					references in their systems to reflect the new canonical ID directive).
-				</p>
-				<p class="note" title="Canonical equivalence">
-					<code><a>canonicalId</a></code> is the same statement of equivalence as
-					<code><a>equivalentId</a></code> except it is constrained to a single value that
-					is defined to be canonical for the <a>DID subject</a> in the scope of the <a>DID
-					document</a>. Like <code><a>equivalentId</a></code>, the use of
-					<code><a>canonicalId</a></code> means that the same
-					<a>DID document</a> describes both the <code><a>canonicalId</a></code> DID and
-					the <code>id</code> property <a>DID</a>.
-				</p>
-				<p>
-					If a resolving party does not use the <code><a>canonicalId</a></code> value as
-					its primary ID value for the DID subject and treat all other equivalent values
-					as secondary aliases, there might be negative or unexpected issues that arise
-					related to user experience. Implementers are strongly advised to observe the
-					directives related to this metadata property.
-				</p>
-			</dd>
+          <dt>proof</dt>
+          <dd>
+					<p>
+Many <a>DID methods</a> use proofs when executing
+<a data-cite="did-core#method-operations">method operations</a>. See
+<a href="#method-architectures"></a> for details.
+					</p>
+					<p>
+<a>DID document</a> metadata MAY include a
+<code>proof</code> property. If present, the value MUST be a
+<a data-cite="INFRA#sets">set</a> where each item is a
+<a data-cite="INFRA#maps">map</a> that represents a proof. The use
+of this property and the types of proofs are
+<a>DID method</a>-specific.
+					</p>
+          </dd>
+        </dl>
+      </section>
 
-            <dt>proof</dt>
-            <dd>
-                <p>
-                    Many <a>DID methods</a> use proofs when executing
-                    <a data-cite="did-core#method-operations">method operations</a>.
-                    See <a href="#method-architectures"></a> for details.
-                </p>
-                <p>
-                    <a>DID document</a> metadata MAY include a <code>proof</code> property.
-                    If present, the value MUST be a <a
-                        data-cite="INFRA#sets">set</a> where each item is a
-                    <a data-cite="INFRA#maps">map</a> that represents a proof. The use of this property
-                    and the types of proofs are <a>DID method</a>-specific.
-                </p>
-            </dd>
-		</dl>
-
-	</section>
-
-	<section id="resolving-algorithm">
-		<h2>DID Resolution Algorithm</h2>
-		<p>A <a>DID resolver</a> implements the following <a>DID resolution</a> algorithm.</p>
-		<ol class="algorithm">
-			<li>Validate that the <var>input <a>DID</a></var> conforms to the `did` rule of the
-			<a href="https://www.w3.org/TR/did-core/#did-syntax">DID Syntax</a>.
-			If not, the <a>DID resolver</a> MUST return the following result:
-			<ol class="algorithm">
-				<li><b>didResolutionMetadata</b>: <var>error object</var> with type set to <code><a href="#INVALID_DID">https://www.w3.org/ns/did#INVALID_DID</a></code></li>
-				<li><b>didDocument</b>: <code>null</code></li>
-				<li><b>didDocumentMetadata</b>: <code>«[ ]»</code></li>
-			</ol>
-			</li>
-			<li>Determine whether the DID method of the <var>input <a>DID</a></var> is supported by the <a>DID resolver</a>
-			that implements this algorithm. If not, the <a>DID resolver</a> MUST return the following result:
-			<ol class="algorithm">
-				<li><b>didResolutionMetadata</b>: <var>error object</var> with type set to <code><a href="#METHOD_NOT_SUPPORTED">https://www.w3.org/ns/did#METHOD_NOT_SUPPORTED</a></code></li>
-				<li><b>didDocument</b>: <code>null</code></li>
-				<li><b>didDocumentMetadata</b>: <code>«[ ]»</code></li>
-			</ol>
-			</li>
-			<li>
-				Determine whether the <var>input <a href="#did-resolution-options">DID resolution options</a></var>
-				are supported by the <a>DID resolver</a> that implements this algorithm. If not, the <a>DID resolver</a>
-				MUST return the following result:
-				<ol class="algorithm">
-					<li><b>didResolutionMetadata</b>: <var>error object</var> with type set to <code><a href="#FEATURE_NOT_SUPPORTED">https://www.w3.org/ns/did#FEATURE_NOT_SUPPORTED</a></code></li>
-					<li><b>didDocument</b>: <code>null</code></li>
-					<li><b>didDocumentMetadata</b>: <code>«[ ]»</code></li>
-				</ol>
-			</li>
-			<li>
-				Determine whether the <var>input <a href="#did-resolution-options">DID resolution options</a></var>
-				are valid. If not, the <a>DID resolver</a> MUST return the following result:
-				<ol class="algorithm">
-					<li><b>didResolutionMetadata</b>: <var>error object</var> with type set to <code><a href="#INVALID_OPTIONS">https://www.w3.org/ns/did#INVALID_OPTIONS</a></code></li>
-					<li><b>didDocument</b>: <code>null</code></li>
-					<li><b>didDocumentMetadata</b>: <code>«[ ]»</code></li>
-				</ol>
-			</li>
-			<li>Obtain the <a>DID document</a> for the <var>input <a>DID</a></var> by executing the
-			<a href="https://www.w3.org/TR/did-core/#method-operations">Resolve</a> operation, as defined by the <var>input <a>DID method</a></var>:
-			<ol class="algorithm">
-				<li>If the <var>input <a>DID</a></var> does not exist, return the following result:
-				<ol class="algorithm">
-					<li><b>didResolutionMetadata</b>: <var>error object</var> with type set to <code><a href="#NOT_FOUND">https://www.w3.org/ns/did#NOT_FOUND</a></code></li>
-					<li><b>didDocument</b>: <code>null</code></li>
-					<li><b>didDocumentMetadata</b>: <code>«[ ]»</code></li>
-				</ol>
-				</li>
-				<li>If the <var>input <a>DID</a></var> has been deactivated, return the following result:
-				<ol class="algorithm">
-					<li><b>didResolutionMetadata</b>: <code>«[ ... ]»</code></li>
-					<li><b>didDocument</b>: <code>null</code></li>
-					<li><b>didDocumentMetadata</b>: <code>«[ "deactivated" → true, ... ]»</code></li>
-				</ol>
-				</li>
-				<li>Otherwise, the result of the <a href="https://www.w3.org/TR/did-core/#method-operations">Resolve</a> operation
-					is called the <var>output <a>DID document</a></var>. This result MUST be represented in a
-					<a href="https://www.w3.org/TR/did-core/#representations">conformant representation</a>.</li>
-			</ol>
-			<li>If the <var>input <a href="#did-resolution-options">DID resolution options</a></var> contain the <code>expandRelativeUrls</code> option with a value of <code>true</code>:
-				<ol class="algorithm">
-					<li>Iterate over all <a data-cite="did-core#services">services</a>,
-						<a data-cite="did-core#verification-methods">verification methods</a>,
-						<a data-cite="did-core#verification-relationships">verification relationships</a>
-						and any extension-defined properties in the <var>output <a>DID document</a></var>.</li>
-					<li>For each item, if the item is an object and the value of the <code>id</code> property is a
-						<a data-cite="did-core#relative-did-urls">relative DID URL</a>, or if a
-						<a data-cite="did-core#verification-relationships">verification relationship</a> is a
-						<a data-cite="did-core#relative-did-urls">relative DID URL</a>:
+      <section id="resolving-algorithm">
+        <h2>DID Resolution Algorithm</h2>
+        <p>
+A <a>DID resolver</a> implements the following
+<a>DID resolution</a> algorithm.
+        </p>
+        <ol class="algorithm">
+          <li>
+Validate that the <var>input <a>DID</a></var> conforms to the
+`did` rule of the <a href="https://www.w3.org/TR/did-core/#did-syntax">DID Syntax</a>.
+If not, the <a>DID resolver</a> MUST return the following result:
 						<ol class="algorithm">
-							<li>Resolve the <a data-cite="did-core#relative-did-urls">relative DID URL</a> to
-								an absolute <a>DID URL</a> conformant with <a data-cite="did-core#did-url-syntax">DID URL Syntax</a>, according
-								to the rules of section <a data-cite="did-core#relative-did-urls">Relative DID URLs</a> in [[[DID-CORE]]].
+							<li>
+<b>didResolutionMetadata</b>: <var>error object</var> with type
+set to <code><a href="#INVALID_DID">https://www.w3.org/ns/did#INVALID_DID</a></code>
 							</li>
-						</ol>
-					</li>
-					<li>Update the <var>output <a>DID document</a></var> by replacing
-						the <a data-cite="did-core#relative-did-urls">relative DID URLs</a> with the resolved absolute <a>DID URLs</a>.
-					</li>
-				</ol>
-			</li>
-			<li>Return the following result:
-				<ol class="algorithm">
-					<li><b>didResolutionMetadata</b>: <code>«[ ... ]»</code></li>
-					<li><b>didDocument</b>: <var>output DID document</var></li>
-					<li><b>didDocumentMetadata</b>: <code>«[ "contentType" → </code><var>output DID document media type</var><code>, ... ]»</code></li>
-				</ol>
-			</li>
-		</ol>
+							<li><b>didDocument</b>: <code>null</code></li>
+							<li><b>didDocumentMetadata</b>: <code>«[ ]»</code></li>
+            </ol>
+          </li>
+          <li>
+Determine whether the DID method of the
+<var>input <a>DID</a></var> is supported by the
+<a>DID resolver</a> that implements this algorithm. If
+not, the <a>DID resolver</a> MUST return the following
+result:
+						<ol class="algorithm">
+							<li>
+<b>didResolutionMetadata</b>: <var>error object</var> with type
+set to <code><a href="#METHOD_NOT_SUPPORTED">https://www.w3.org/ns/did#METHOD_NOT_SUPPORTED</a></code>
+              </li>
+              <li><b>didDocument</b>: <code>null</code></li>
+              <li><b>didDocumentMetadata</b>: <code>«[ ]»</code></li>
+            </ol>
+          </li>
+          <li>
+Determine whether the
+<var>input <a href="#did-resolution-options">DID resolution options</a></var>
+are supported by the <a>DID resolver</a> that implements
+this algorithm. If not, the <a>DID resolver</a> MUST
+return the following result:
+						<ol class="algorithm">
+							<li>
+<b>didResolutionMetadata</b>: <var>error object</var> with type
+set to <code><a href="#FEATURE_NOT_SUPPORTED">https://www.w3.org/ns/did#FEATURE_NOT_SUPPORTED</a></code>
+              </li>
+              <li><b>didDocument</b>: <code>null</code></li>
+              <li><b>didDocumentMetadata</b>: <code>«[ ]»</code></li>
+            </ol>
+          </li>
+          <li>
+Determine whether the
+<var>input <a href="#did-resolution-options">DID resolution options</a></var>
+are valid. If not, the <a>DID resolver</a> MUST return the following result:
+						<ol class="algorithm">
+							<li>
+<b>didResolutionMetadata</b>: <var>error object</var> with type
+set to <code><a href="#INVALID_OPTIONS">https://www.w3.org/ns/did#INVALID_OPTIONS</a></code>
+              </li>
+              <li><b>didDocument</b>: <code>null</code></li>
+              <li><b>didDocumentMetadata</b>: <code>«[ ]»</code></li>
+            </ol>
+          </li>
+          <li>
+Obtain the <a>DID document</a> for the <var>input <a>DID</a></var> by executing
+the <a href="https://www.w3.org/TR/did-core/#method-operations">Resolve</a>
+operation, as defined by the <var>input <a>DID method</a></var>:
+						<ol class="algorithm">
+							<li>
+If the <var>input <a>DID</a></var> does not exist, return the following result:
+								<ol class="algorithm">
+									<li>
+<b>didResolutionMetadata</b>: <var>error object</var> with
+type set to <code><a href="#NOT_FOUND">https://www.w3.org/ns/did#NOT_FOUND</a></code>
+                  </li>
+                  <li><b>didDocument</b>: <code>null</code></li>
+                  <li><b>didDocumentMetadata</b>: <code>«[ ]»</code></li>
+                </ol>
+              </li>
+              <li>
+If the <var>input <a>DID</a></var> has been
+deactivated, return the following result:
+								<ol class="algorithm">
+									<li><b>didResolutionMetadata</b>: <code>«[ ... ]»</code></li>
+									<li><b>didDocument</b>: <code>null</code></li>
+									<li>
+<b>didDocumentMetadata</b>: <code>«[ "deactivated" → true, ... ]»</code>
+                  </li>
+                </ol>
+              </li>
+              <li>
+Otherwise, the result of the <a href="https://www.w3.org/TR/did-core/#method-operations">Resolve</a>
+operation is called the <var>output <a>DID document</a></var>. This result
+MUST be represented in a <a href="https://www.w3.org/TR/did-core/#representations">conformant representation</a>.
+              </li>
+            </ol>
+          </li>
 
-		<p>
-			If the <a>DID resolver</a> encounters any unexpected errors during the execution of the DID Resolution algorithm,
-			it MUST return the following result:
-		</p>
-		<ol class="algorithm">
-			<li><b>didResolutionMetadata</b>: <var>error object</var> with type set to <code><a href="#INTERNAL_ERROR">https://www.w3.org/ns/did#INTERNAL_ERROR</a></code></li>
-			<li><b>didDocument</b>: <code>null</code></li>
-			<li><b>didDocumentMetadata</b>: <code>«[ ]»</code></li>
-		</ol>
+          <li>
+If the <var>input <a href="#did-resolution-options">DID resolution options</a></var>
+contain the <code>expandRelativeUrls</code> option with a value of
+<code>true</code>:
+						<ol class="algorithm">
+							<li>
+Iterate over all <a data-cite="did-core#services">services</a>,
+<a data-cite="did-core#verification-methods">verification methods</a>,
+<a data-cite="did-core#verification-relationships">verification relationships</a>
+and any extension-defined properties in the
+<var>output <a>DID document</a></var>.
+              </li>
+              <li>
+For each item, if the item is an object and the value of the
+<code>id</code> property is a <a data-cite="did-core#relative-did-urls">relative DID URL</a>,
+or if a <a data-cite="did-core#verification-relationships">verification relationship</a> is a
+<a data-cite="did-core#relative-did-urls">relative DID URL</a>:
+								<ol class="algorithm">
+									<li>
+Resolve the <a data-cite="did-core#relative-did-urls">relative DID URL</a> to an absolute
+<a>DID URL</a> conformant with
+<a data-cite="did-core#did-url-syntax">DID URL Syntax</a>, according to the rules of
+section <a data-cite="did-core#relative-did-urls">Relative DID URLs</a> in [[[DID-CORE]]].
+                  </li>
+                </ol>
+              </li>
+              <li>
+Update the <var>output <a>DID document</a></var> by
+replacing the <a data-cite="did-core#relative-did-urls">relative DID URLs</a> with the resolved
+absolute <a>DID URLs</a>.
+              </li>
+            </ol>
+          </li>
+          <li>
+Return the following result:
+						<ol class="algorithm">
+							<li><b>didResolutionMetadata</b>: <code>«[ ... ]»</code></li>
+							<li><b>didDocument</b>: <var>output DID document</var></li>
+							<li>
+<b>didDocumentMetadata</b>:
+<code>«[ "contentType" → </code><var>output DID document media type</var><code>, ... ]»</code>
+              </li>
+            </ol>
+          </li>
+        </ol>
 
-	</section>
+        <p>
+If the <a>DID resolver</a> encounters any unexpected errors during
+the execution of the DID Resolution algorithm, it MUST return the following
+result:
+        </p>
+        <ol class="algorithm">
+          <li>
+<b>didResolutionMetadata</b>: <var>error object</var> with type set
+to <code><a href="#INTERNAL_ERROR">https://www.w3.org/ns/did#INTERNAL_ERROR</a></code>
+          </li>
+          <li><b>didDocument</b>: <code>null</code></li>
+          <li><b>didDocumentMetadata</b>: <code>«[ ]»</code></li>
+        </ol>
+      </section>
+    </section>
 
-</section>
+    <section id="dereferencing">
+      <h1>DID URL Dereferencing</h1>
 
-<section id="dereferencing">
-	<h1>DID URL Dereferencing</h1>
+      <p>
+The <a>DID URL dereferencing</a> function dereferences a <a>DID URL</a> into a
+<a>resource</a> with contents depending on the <a>DID URL</a>'s components,
+including the <a>DID method</a>, method-specific identifier, path,
+query, and fragment. This process depends on <a>DID resolution</a> of
+the <a>DID</a> contained in the
+<a>DID URL</a>. <a>DID URL dereferencing</a> might involve
+multiple steps (e.g., when the DID URL being dereferenced includes a fragment),
+and the function is defined to return the final resource after all steps are
+completed. The following figure depicts the relationship described above.
+      </p>
 
-	<p>
-		The <a>DID URL dereferencing</a> function dereferences a <a>DID URL</a> into a
-		<a>resource</a> with contents depending on the <a>DID URL</a>'s components,
-		including the <a>DID method</a>, method-specific identifier, path, query, and
-		fragment. This process depends on <a>DID resolution</a> of the <a>DID</a>
-		contained in the <a>DID URL</a>. <a>DID URL dereferencing</a> might involve
-		multiple steps (e.g., when the DID URL being dereferenced includes a fragment),
-		and the function is defined to return the final resource after all steps are
-		completed. The following figure depicts the relationship described
-		above.
-	</p>
-
-	<figure id="did-url-dereference-overview">
-		<img style="margin: auto; display: block; width: 75%;"
-			 src="diagrams/section-5/did-url-dereference-overview.svg" alt="
+      <figure id="did-url-dereference-overview">
+        <img
+          style="margin: auto; display: block; width: 75%"
+          src="diagrams/section-5/did-url-dereference-overview.svg"
+          alt="
 DIDs resolve to DID documents; DID URLs contains a DID; DID URLs dereferenced to DID document fragments or
 external resources.
-        " >
-		<figcaption>
-			Overview of DID URL dereference
-			See also: <a class="longdesc-link"
-						 href="#did-url-dereference-overview-longdesc">narrative description</a>.
-		</figcaption>
-	</figure>
+        "
+        />
+        <figcaption>
+Overview of DID URL dereference See also: <a class="longdesc-link" href="#did-url-dereference-overview-longdesc">narrative description</a>.
+        </figcaption>
+      </figure>
 
-	<div class="longdesc" id="did-url-dereference-overview-longdesc">
-		<p>
-			The top left part of the diagram contains a rectangle with black outline, labeled "DID".
-		</p>
-		<p>
-			The bottom left part of the diagram contains a rectangle with black outline, labeled "DID URL".
-			This rectangle contains four smaller black-outlined rectangles, aligned in a horizontal row adjacent to
-			each other. These smaller rectangles are labeled, in order, "DID", "path", "query", and "fragment.
-		</p>
-		<p>
-			The top right part of the diagram contains a rectangle with black outline, labeled "DID document".
-			This rectangle contains three smaller black-outlined rectangles. These smaller rectangles are
-			labeled "id", "(property X)", and "(property Y)", and are surrounded by multiple series of three
-			dots (ellipses). A curved black arrow, labeled "DID document - relative fragment dereference", extends
-			from the rectangle labeled "(property X)", and points to the rectangle labeled "(property Y)".
-		</p>
-		<p>
-			The bottom right part of the diagram contains an oval shape with black outline, labeled "Resource".
-		</p>
-		<p>
-			A black arrow, labeled "resolves to a DID document", extends from the rectangle in the top left part of
-			the diagram, labeled "DID", and points to the rectangle in the top right part of diagram, labeled
-			"DID document".
-		</p>
-		<p>
-			A black arrow, labeled "refers to", extends from the rectangle in the top right part of the diagram,
-			labeled "DID document", and points to the oval shape in the bottom right part of diagram, labeled
-			"Resource".
-		</p>
-		<p>
-			A black arrow, labeled "contains", extends from the small rectangle labeled "DID" inside the
-			rectangle in the bottom left part of the diagram, labeled "DID URL", and points to the rectangle
-			in the top left part of diagram, labeled "DID".
-		</p>
-		<p>
-			A black arrow, labeled "dereferences to a DID document", extends from the rectangle in the bottom left
-			part of the diagram, labeled "DID URL", and points to the rectangle in the top right part of diagram,
-			labeled "DID document".
-		</p>
-		<p>
-			A black arrow, labeled "dereferences to a resource", extends from the rectangle in the bottom left
-			part of the diagram, labeled "DID URL", and points to the oval shape in the bottom right part of diagram,
-			labeled "Resource".
-		</p>
-	</div>
+      <div class="longdesc" id="did-url-dereference-overview-longdesc">
+        <p>
+The top left part of the diagram contains a rectangle with black outline,
+labeled "DID".
+        </p>
+        <p>
+The bottom left part of the diagram contains a rectangle with black outline,
+labeled "DID URL". This rectangle contains four smaller black-outlined
+rectangles, aligned in a horizontal row adjacent to each other. These smaller
+rectangles are labeled, in order, "DID", "path", "query", and "fragment.
+        </p>
+        <p>
+The top right part of the diagram contains a rectangle with black outline,
+labeled "DID document". This rectangle contains three smaller black-outlined
+rectangles. These smaller rectangles are labeled "id", "(property X)", and
+"(property Y)", and are surrounded by multiple series of three dots (ellipses).
+A curved black arrow, labeled "DID document - relative fragment dereference",
+extends from the rectangle labeled "(property X)", and points to the rectangle
+labeled "(property Y)".
+        </p>
+        <p>
+The bottom right part of the diagram contains an oval shape with black outline,
+labeled "Resource".
+        </p>
+        <p>
+A black arrow, labeled "resolves to a DID document", extends from the rectangle
+in the top left part of the diagram, labeled "DID", and points to the rectangle
+in the top right part of diagram, labeled "DID document".
+        </p>
+        <p>
+A black arrow, labeled "refers to", extends from the rectangle in the top right
+part of the diagram, labeled "DID document", and points to the oval shape in the
+bottom right part of diagram, labeled "Resource".
+        </p>
+        <p>
+A black arrow, labeled "contains", extends from the small rectangle labeled
+"DID" inside the rectangle in the bottom left part of the diagram, labeled "DID
+URL", and points to the rectangle in the top left part of diagram, labeled
+"DID".
+        </p>
+        <p>
+A black arrow, labeled "dereferences to a DID document", extends from the
+rectangle in the bottom left part of the diagram, labeled "DID URL", and points
+to the rectangle in the top right part of diagram, labeled "DID document".
+        </p>
+        <p>
+A black arrow, labeled "dereferences to a resource", extends from the rectangle
+in the bottom left part of the diagram, labeled "DID URL", and points to the
+oval shape in the bottom right part of diagram, labeled "Resource".
+        </p>
+      </div>
 
-	<p>
-		All [=conforming DID URL dereferencers=] implement the
-		function below, which has the following abstract form:
-	</p>
+      <p>
+All [=conforming DID URL dereferencers=] implement the function below, which has
+the following abstract form:
+      </p>
 
-	<pre title="Abstract function for DID URL Dereferencing">
+      <pre title="Abstract function for DID URL Dereferencing">
 dereference(didUrl, dereferenceOptions) →
    « dereferencingMetadata, contentStream, contentMetadata »
       </pre>
 
-	<p>
-		All [=conforming DID URL dereferencers=] MUST implement the [=DID URL dereferencing=]
-		function for at least one [=DID method=]. All inputs and outputs of the <code>dereference</code>
-		function apart from [=contentStream=] MUST be serializable to JSON.
-	</p>
+      <p>
+All [=conforming DID URL dereferencers=] MUST implement the [=DID URL
+dereferencing=] function for at least one [=DID method=]. All inputs and
+outputs of the <code>dereference</code>
+function apart from [=contentStream=] MUST be serializable to JSON.
+      </p>
 
-	<p>
-		The input variables of the <code>dereference</code> function are as follows:
-	</p>
+      <p>
+The input variables of the <code>dereference</code> function are as
+follows:
+      </p>
 
-	<dl>
-		<dt>
-			didUrl
-		</dt>
-		<dd>
-			A conformant <a>DID URL</a> as a single <a data-cite="INFRA#string">string</a>.
-			This is the <a>DID URL</a> to dereference. To dereference a <a>DID fragment</a>,
-			the complete <a>DID URL</a> including the <a>DID fragment</a> MUST be used. This
-			input is REQUIRED.
+      <dl>
+        <dt>didUrl</dt>
+        <dd>
+A conformant <a>DID URL</a> as a single <a data-cite="INFRA#string">string</a>.
+This is the <a>DID URL</a> to dereference. To dereference a <a>DID fragment</a>,
+the complete <a>DID URL</a> including the <a>DID fragment</a> MUST be used.
+This input is REQUIRED.
 
-			<p class="note" title="DID URL dereferencer patterns">
-				While it is valid for any <code>didUrl</code> to be passed to a DID URL
-				dereferencer, implementers are expected to refer to <a href="#dereferencing"></a> to
-				further understand common patterns for how a <a>DID URL</a> is expected
-				to be dereferenced.
-			</p>
-		</dd>
-		<dt>
-			dereferencingOptions
-		</dt>
-		<dd>
-			A <a href="#metadata-structure">metadata structure</a> consisting of input
-			options to the <code>dereference</code> function in addition to the
-			<code>didUrl</code> itself. This structure is further defined in <a
-				href="#did-url-dereferencing-options"></a>. This input is REQUIRED, but the
-			structure MAY be empty.
-		</dd>
-	</dl>
+<p class="note" title="DID URL dereferencer patterns">
+While it is valid for any <code>didUrl</code> to be passed to a DID
+URL dereferencer, implementers are expected to refer to
+<a href="#dereferencing"></a> to further understand common
+patterns for how a <a>DID URL</a> is expected to be
+dereferenced.
+</p>
+        </dd>
+        <dt>dereferencingOptions</dt>
+        <dd>
+A <a href="#metadata-structure">metadata structure</a>
+consisting of input options to the
+<code>dereference</code> function in addition to the
+<code>didUrl</code> itself. This structure is further defined in
+<a href="#did-url-dereferencing-options"></a>. This input is REQUIRED, but the
+structure MAY be empty.
+        </dd>
+      </dl>
 
-	<p>
-		This function returns multiple values, and no limitations
-		are placed on how these values are returned together.
-		The return values of <code>dereference</code> are
-		<a>dereferencingMetadata</a>, <a>contentStream</a>, and
-		<a>contentMetadata</a>. These values are described below:
-	</p>
+      <p>
+This function returns multiple values, and no limitations are placed on
+how these values are returned together. The return values of
+<code>dereference</code> are <a>dereferencingMetadata</a>,
+<a>contentStream</a>, and <a>contentMetadata</a>.
+These values are described below:
+      </p>
 
-	<dl>
-		<dt>
-			<dfn>dereferencingMetadata</dfn>
-		</dt>
-		<dd>
-			A <a href="#metadata-structure">metadata structure</a> consisting of values
-			relating to the results of the <a>DID URL dereferencing</a> process. This
-			structure is REQUIRED, and in the case of an error in the dereferencing process,
-			this MUST NOT be empty. This structure is further defined in <a
-				href="#did-url-dereferencing-metadata"></a>. If the dereferencing is
-			unsuccessful, this structure MUST contain an <code>error</code> property
-			describing the error. See Section <a href="#errors"></a>.
-		</dd>
-		<dt>
-			<dfn>contentStream</dfn>
-		</dt>
-		<dd>
-			If the <code>dereferencing</code> function was called and successful, this MUST
-			contain a <a>resource</a> corresponding to the <a>DID URL</a>. The
-			<code>contentStream</code> MAY be a <a>resource</a> such as a <a>DID
-			document</a> that is serializable in one of the conformant
-			<a>representations</a>, a <a data-cite="did-core#verification-methods">verification
-			method</a>, a <a data-cite="did-core#services">service</a>, or any other resource format that
-			can be identified via a Media Type and obtained through the resolution process.
-			If the dereferencing is unsuccessful, this value MUST be empty.
-		</dd>
-		<dt>
-			<dfn>contentMetadata</dfn>
-		</dt>
-		<dd>
-			If the dereferencing is successful, this MUST be a <a href="#metadata-structure">
-			metadata structure</a>, but the structure MAY be empty. This structure contains
-			metadata about the <code>contentStream</code>. If the <code>contentStream</code>
-			is a <a>DID document</a>, this MUST be a <a>didDocumentMetadata</a> structure as
-			described in <a>DID Resolution</a>. If the dereferencing is unsuccessful, this
-			output MUST be an empty <a href="#metadata-structure">metadata structure</a>.
-			This structure is further defined in <a href="#did-url-content-metadata"></a>.
-		</dd>
-	</dl>
+      <dl>
+        <dt>
+<dfn>dereferencingMetadata</dfn>
+        </dt>
+        <dd>
+A <a href="#metadata-structure">metadata structure</a>
+consisting of values relating to the
+results of the <a>DID URL dereferencing</a> process. This structure
+is REQUIRED, and in the case of an error in the dereferencing process,
+this MUST NOT be empty. This structure is further defined in
+<a href="#did-url-dereferencing-metadata"></a>. If the dereferencing is unsuccessful,
+this structure MUST contain an <code>error</code> property describing
+the error. See Section <a href="#errors"></a>.
+        </dd>
+        <dt>
+<dfn>contentStream</dfn>
+        </dt>
+        <dd>
+If the <code>dereferencing</code> function was called and successful,
+this MUST contain a <a>resource</a> corresponding to
+the <a>DID URL</a>. The
+<code>contentStream</code> MAY be a <a>resource</a>
+such as a <a>DID document</a> that is serializable in one
+of the conformant <a>representations</a>, a
+<a data-cite="did-core#verification-methods">verification method</a>,
+a <a data-cite="did-core#services">service</a>, or
+any other resource format that can be identified via a Media Type and
+obtained through the resolution process. If the dereferencing is
+unsuccessful, this value MUST be empty.
+        </dd>
+        <dt>
+<dfn>contentMetadata</dfn>
+        </dt>
+        <dd>
+If the dereferencing is successful, this MUST be a
+<a href="#metadata-structure"> metadata structure</a>, but the structure MAY be empty. This
+structure contains metadata about the <code>contentStream</code>. If
+the <code>contentStream</code>
+is a <a>DID document</a>, this MUST be a
+<a>didDocumentMetadata</a> structure as described in
+<a>DID Resolution</a>. If the dereferencing is unsuccessful,
+this output MUST be an empty <a href="#metadata-structure">metadata structure</a>. This
+structure is further defined in <a href="#did-url-content-metadata"></a>.
+        </dd>
+      </dl>
 
-	<p>
-		Conforming <a>DID URL dereferencing</a> implementations do not alter the
-		signature of these functions in any way. <a>DID URL dereferencing</a>
-		implementations might map the <code>dereference</code> function to a
-		method-specific internal function to perform the actual <a>DID URL
-		dereferencing</a> process. <a>DID URL dereferencing</a> implementations might
-		implement and expose additional functions with different signatures in addition
-		to the <code>dereference</code> function specified here.
-	</p>
+      <p>
+Conforming <a>DID URL dereferencing</a> implementations do not alter
+the signature of these functions in any way.
+<a>DID URL dereferencing</a> implementations might map the
+<code>dereference</code> function to a method-specific internal function
+to perform the actual <a>DID URL dereferencing</a> process.
+<a>DID URL dereferencing</a> implementations might implement and
+expose additional functions with different signatures in addition to the
+<code>dereference</code> function specified here.
+      </p>
 
-	<section>
-		<h3>DID URL Dereferencing Options</h3>
+      <section>
+        <h3>DID URL Dereferencing Options</h3>
 
-		<p>This is a <a href="#metadata-structure">metadata structure</a> that contains input options for the <a>DID URL Dereferencing</a> process.</p>
+        <p>
+This is a <a href="#metadata-structure">metadata structure</a> that contains input options for the
+<a>DID URL Dereferencing</a> process.
+        </p>
 
-		<p>
-			The possible properties within this structure and their possible values SHOULD
-			be registered in the DID Resolution Extensions [[?DID-EXTENSIONS-RESOLUTION]].
-			This specification defines the following common input options:
-		</p>
+        <p>
+The possible properties within this structure and their possible values SHOULD
+be registered in the DID Resolution Extensions [[?DID-EXTENSIONS-RESOLUTION]].
+This specification defines the following common input options:
+        </p>
 
-		<dl>
-			<dt>
-				accept
-			</dt>
-			<dd>
-				The media type that the caller prefers for <code>contentStream</code>.
-				The value MUST be expressed according to the `Accept` header value as
-				defined in [[[RFC9110]]], <a data-cite="RFC9110#section-12.5.1">Section
-				12.5.1</a>. The <a>DID URL dereferencer</a> implementation SHOULD use
-				this value to determine the <code>contentType</code> of the
-				<a>representation</a> contained in the returned value if such a
-				<a>representation</a> is supported and available.
-			</dd>
-		</dl>
-		<dl>
-			<dt>
-				verificationRelationship
-			</dt>
-			<dd>
-				The verificationRelationship for which the caller expects the verificationMethod
-				dereferenced from the DID URL to be authorized. If present, the
-				associated value MUST be an <a data-lt="ascii string">ASCII string</a>.
-				If the DID URL does not dereference to a verificationMethod, or the
-				DID document does not authorize the verificationMethod for the specified
-				verificationRelationship, then an error MUST be raised.
-			</dd>
-		</dl>
-	</section>
+        <dl>
+          <dt>accept</dt>
+          <dd>
+The media type that the caller prefers for
+<code>contentStream</code>. The value MUST be expressed according to
+the `Accept` header value as defined in [[[RFC9110]]],
+<a data-cite="RFC9110#section-12.5.1">Section 12.5.1</a>. The <a>DID URL dereferencer</a>
+implementation SHOULD use this value to determine the
+<code>contentType</code> of the <a>representation</a>
+contained in the returned value if such a
+<a>representation</a> is supported and available.
+          </dd>
+        </dl>
+        <dl>
+          <dt>verificationRelationship</dt>
+          <dd>
+The verificationRelationship for which the caller expects the verificationMethod
+dereferenced from the DID URL to be authorized. If present, the associated value
+MUST be an <a data-lt="ascii string">ASCII string</a>. If the DID URL does not dereference
+to a verificationMethod, or the DID document does not authorize the
+verificationMethod for the specified verificationRelationship, then an error
+MUST be raised.
+          </dd>
+        </dl>
+      </section>
 
-	<section>
-		<h3>DID URL Dereferencing Metadata</h3>
+      <section>
+        <h3>DID URL Dereferencing Metadata</h3>
 
-		<p>This is a <a href="#metadata-structure">metadata structure</a> that contains metadata about the <a>DID URL Dereferencing</a> process.</p>
-		<p>This metadata typically changes between invocations of the <a>DID URL Dereferencing</a> function as it represents data about the dereferencing process itself.</p>
-		<p>The source of this metadata is the <a>DID URL dereferencer</a>.</p>
+        <p>
+This is a <a href="#metadata-structure">metadata structure</a> that contains
+metadata about the <a>DID URL Dereferencing</a> process.
+        </p>
+        <p>
+This metadata typically changes between invocations of the
+<a>DID URL Dereferencing</a> function as it represents data about the
+dereferencing process itself.
+        </p>
+        <p>
+The source of this metadata is the <a>DID URL dereferencer</a>.
+        </p>
 
-		<p>
-			The possible properties within this structure and their possible values SHOULD
-			be registered in the DID Resolution Extensions [[?DID-EXTENSIONS-RESOLUTION]]. This
-			specification defines the following common metadata properties:
-		</p>
+        <p>
+The possible properties within this structure and their possible values SHOULD
+be registered in the DID Resolution Extensions [[?DID-EXTENSIONS-RESOLUTION]].
+This specification defines the following common metadata properties:
+        </p>
 
-		<dl>
-			<dt>
-				contentType
-			</dt>
-			<dd>
-				The Media Type of the returned <code>contentStream</code> SHOULD be expressed
-				using this property if dereferencing is successful. The Media
-				Type value MUST be expressed as an <a data-lt="ascii string">ASCII string</a>.
-			</dd>
-			<dt>
-				error
-			</dt>
-			<dd>
-                An error data structure defined in [[RFC9457]]. This property is REQUIRED when
-				there is an error in the dereferencing process. The errors defined in this
-                specification can be found in Section <a href="#errors"></a>.
-                Additional errors SHOULD be registered in the DID Resolution Extensions [[?DID-EXTENSIONS-RESOLUTION]].
-			</dd>
+        <dl>
+          <dt>contentType</dt>
+          <dd>
+The Media Type of the returned <code>contentStream</code> SHOULD be
+expressed using this property if dereferencing is successful. The
+Media Type value MUST be expressed as an
+<a data-lt="ascii string">ASCII string</a>.
+          </dd>
+          <dt>error</dt>
+          <dd>
+An error data structure defined in [[RFC9457]]. This property is REQUIRED when
+there is an error in the dereferencing process. The errors defined in this
+specification can be found in Section <a href="#errors"></a>.
+Additional errors SHOULD be registered in the DID Resolution Extensions
+[[?DID-EXTENSIONS-RESOLUTION]].
+          </dd>
 
-            <dt>
-                proof
-            </dt>
-            <dd>
-                <p>
-                    Some <a>DID resolvers</a> and <a>DID URL dereferencers</a> use proofs when executing
-                    the <a>DID Resolution</a> or <a>DID URL Dereferencing</a> functions.
-                    See <a href="#resolver-architectures"></a> for details.
-                </p>
-                <p>
-                    <a>DID URL dereferencing</a> metadata MAY include a <code>proof</code> property.
-                    If present, the value MUST be a <a
-                        data-cite="INFRA#sets">set</a> where each item is a
-                    <a data-cite="INFRA#maps">map</a> that represents a proof. The use of this property
-                    and the types of proofs are <a>DID method</a>-independent.
-                </p>
-            </dd>
-		</dl>
-	</section>
+          <dt>proof</dt>
+          <dd>
+<p>
+Some <a>DID resolvers</a> and
+<a>DID URL dereferencers</a> use proofs when executing the
+<a>DID Resolution</a> or <a>DID URL Dereferencing</a>
+functions. See <a href="#resolver-architectures"></a> for details.
+</p>
+<p>
+<a>DID URL dereferencing</a> metadata MAY include a
+<code>proof</code> property. If present, the value MUST be a
+<a data-cite="INFRA#sets">set</a> where each item is a
+<a data-cite="INFRA#maps">map</a> that represents a proof. The use
+of this property and the types of proofs are
+<a>DID method</a>-independent.
+</p>
+          </dd>
+        </dl>
+      </section>
 
-	<section>
-		<h3>DID URL Content Metadata</h3>
+      <section>
+        <h3>DID URL Content Metadata</h3>
 
-		<p>This is a <a href="#metadata-structure">metadata structure</a> that contains metadata about the <a>DID URL Dereferencing</a> process.</p>
-		<p>This metadata typically does not change between invocations of the <a>DID URL Dereferencing</a> function unless the content changes, as it represents data about the content.</p>
-		<p>The sources of this metadata are the <a>DID controller</a> and/or the <a>DID method</a>.</p>
+        <p>
+This is a <a href="#metadata-structure">metadata structure</a> that contains
+metadata about the <a>DID URL Dereferencing</a> process.
+        </p>
+        <p>
+This metadata typically does not change between invocations of the
+<a>DID URL Dereferencing</a> function unless the content changes, as it
+represents data about the content.
+        </p>
+        <p>
+The sources of this metadata are the <a>DID controller</a> and/or the
+<a>DID method</a>.
+        </p>
 
-		<p>
-			The possible properties within this structure and their possible values SHOULD
-			be registered in the DID Resolution Extensions [[?DID-EXTENSIONS-RESOLUTION]]. This
-			specification defines no common properties.
-		</p>
-	</section>
+        <p>
+The possible properties within this structure and their possible values SHOULD
+be registered in the DID Resolution Extensions [[?DID-EXTENSIONS-RESOLUTION]].
+This specification defines no common properties.
+        </p>
+      </section>
 
-	<section id="dereferencing-algorithm">
-		<h2>DID URL Dereferencing Algorithm</h2>
-		<p>A <a>DID URL dereferencer</a> implements the following <a>DID URL dereferencing</a> algorithm.
-		In accordance with [[RFC3986]], it consists of the following three steps: resolving the DID; dereferencing the
-		resource; and dereferencing the fragment (only if the <var>input <a>DID URL</a></var> contains a <a>DID fragment</a>):</p>
+      <section id="dereferencing-algorithm">
+        <h2>DID URL Dereferencing Algorithm</h2>
+        <p>
+A <a>DID URL dereferencer</a> implements the following
+<a>DID URL dereferencing</a> algorithm. In accordance with
+[[RFC3986]], it consists of the following three steps: resolving the
+DID; dereferencing the resource; and dereferencing the fragment (only
+if the <var>input <a>DID URL</a></var> contains a
+<a>DID fragment</a>):
+        </p>
 
-		<section id="dereferencing-algorithm-resource">
-			<h2>Dereferencing the Resource</h2>
-			<ol class="algorithm">
-				<li>Validate that the <var>input <a>DID URL</a></var> conforms to the `did-url` rule of the
-					<a href="https://www.w3.org/TR/did-core/#did-url-syntax">DID URL Syntax</a>.
-					If not, the <a>DID URL dereferencer</a> MUST return the following result:
-					<ol class="algorithm">
-						<li><b>dereferencingMetadata</b>: <var>error object</var> with type set to <code><a href="#INVALID_DID_URL">https://www.w3.org/ns/did#INVALID_DID_URL</a></code></li>
-						<li><b>contentStream</b>: <code>null</code></li>
-						<li><b>contentMetadata</b>: <code>«[ ]»</code></li>
-					</ol>
-				</li>
-				<li>Obtain the <a>DID document</a> for the <var>input <a>DID</a></var> by executing the
-					<a>DID resolution</a> algorithm as defined in <a href="#resolving"></a>. All
-					<var>dereferencing options</var> and all
-					<a href="#did-parameters">
-						DID parameters</a> of the <var>input <a>DID URL</a></var> MUST be passed as <var>resolution options</var> to the
-						<a>DID Resolution</a> algorithm.</li>
-				<li>If the <var>input <a>DID</a></var> does not exist in the VDR, the <a>DID URL dereferencer</a>
-						MUST return the following result:
-						<ol class="algorithm">
-							<li><b>dereferencingMetadata</b>: <var>error object</var> with type set to <code><a href="#NOT_FOUND">https://www.w3.org/ns/did#NOT_FOUND</a></code></li>
-							<li><b>contentStream</b>: <code>null</code></li>
-							<li><b>contentMetadata</b>: <code>«[ ]»</code></li>
-						</ol>
-				</li>
-				<li>Otherwise, the <b>didDocument</b> result of the <a>DID resolution</a> algorithm is called the <var>resolved <a>DID document</a></var>.</li>
-				<li>If present, separate the <a>DID fragment</a> from the <var>input <a>DID URL</a></var> and continue
-					with the adjusted <var>input <a>DID URL</a></var>.</li>
-				<li>If the <var>input <a>DID URL</a></var> contains no <a>DID path</a> and no <a>DID query</a>:
-					<pre class="example nohighlight">did:example:1234</pre>
-					The <a>DID URL dereferencer</a> MUST return the <var>resolved <a>DID document</a></var> and
-					<var>resolved <a href="#did-document-metadata"></a></var> as follows:
-					<ol class="algorithm">
-						<li><b>dereferencingMetadata</b>: <code>«[ ... ]»</code></li>
-						<li><b>contentStream</b>: <code>resolved DID document</code></li>
-						<li><b>contentMetadata</b>: <code>«[ <code>resolved DID document metadata</code> ]»</code></li>
-					</ol>
-				</li>
-				<li>If the <var>input <a>DID URL</a></var> contains the
-				<a href="#did-parameters">
-					DID parameter</a> <code>service</code> and/or the <a href="#did-parameters">
-					DID parameter</a> <code>serviceType</code>, and optionally the
-					<a href="#did-parameters">DID parameter</a> <code>relativeRef</code>:
-					<pre class="example nohighlight">did:example:1234?service=files&relativeRef=%2Fmyresume%2Fdoc%3Fversion%3Dlatest</pre>
-					<ol class="algorithm">
-						<li>From the <var>resolved <a>DID document</a></var>, select all
-							<a data-cite="did-core#services">services</a> which fulfill the following conditions:
+        <section id="dereferencing-algorithm-resource">
+          <h2>Dereferencing the Resource</h2>
+          <ol class="algorithm">
+            <li>
+Validate that the <var>input <a>DID URL</a></var> conforms to the `did-url`
+rule of the <a href="https://www.w3.org/TR/did-core/#did-url-syntax">DID URL Syntax</a>.
+If not, the <a>DID URL dereferencer</a> MUST return the following result:
 							<ol class="algorithm">
-								<li>If the <var>input <a>DID URL</a></var> contains the
-									<a href="#did-parameters">DID parameter</a> <code>service</code>:
-									Select the <a data-cite="did-core#services">service</a> if its <code>id</code>
-									property matches the value of the <code>service</code> DID parameter. If the <code>id</code>
-									property or the <code>service</code> DID parameter or both contain relative
-									references, the corresponding absolute URIs MUST be resolved and used for determining
-									the match, using the rules specified in <a data-cite="RFC3986#section-5">RFC3986 Section 5: Reference Resolution</a>
-									and in section <a data-cite="did-core#relative-did-urls">Relative DID URLs</a> in [[[DID-CORE]]].</li>
-								<li>If the <var>input <a>DID URL</a></var> contains the
-									<a href="#did-parameters">DID parameter</a> <code>serviceType</code>:
-									Select the <a data-cite="did-core#services">service</a> if its <code>type</code>
-									property matches the value of the <code>serviceType</code> DID parameter.</li>
-							</ol>
-							The selected <a data-cite="did-core#services">services</a> are a list called the <var>selected <a>services</a></var>.
-						</li>
-						<li>If the <var>input <a>DID URL</a></var> contains the
-							<a href="#did-parameters">DID parameter</a> <code>relativeRef</code>:
+								li>
+<b>dereferencingMetadata</b>: <var>error object</var> with
+type set to <code><a href="#INVALID_DID_URL">https://www.w3.org/ns/did#INVALID_DID_URL</a></code>
+                </li>
+                <li><b>contentStream</b>: <code>null</code></li>
+                <li><b>contentMetadata</b>: <code>«[ ]»</code></li>
+              </ol>
+            </li>
+            <li>
+Obtain the <a>DID document</a> for the <var>input <a>DID</a></var> by executing
+the <a>DID resolution</a> algorithm as defined in <a href="#resolving"></a>.
+All <var>dereferencing options</var> and all <a href="#did-parameters">DID parameters</a>
+of the <var>input <a>DID URL</a></var> MUST be passed as
+<var>resolution options</var> to the <a>DID Resolution</a> algorithm.
+            </li>
+            <li>
+If the <var>input <a>DID</a></var> does not
+exist in the VDR, the <a>DID URL dereferencer</a> MUST return
+the following result:
+<ol class="algorithm">
+<li>
+<b>dereferencingMetadata</b>: <var>error object</var> with
+type set to <code><a href="#NOT_FOUND">https://www.w3.org/ns/did#NOT_FOUND</a></code>
+                </li>
+                <li><b>contentStream</b>: <code>null</code></li>
+                <li><b>contentMetadata</b>: <code>«[ ]»</code></li>
+              </ol>
+            </li>
+            <li>
+Otherwise, the <b>didDocument</b> result of the
+<a>DID resolution</a> algorithm is called the
+<var>resolved <a>DID document</a></var>.
+            </li>
+            <li>
+If present, separate the <a>DID fragment</a> from the
+<var>input <a>DID URL</a></var> and continue with
+the adjusted <var>input <a>DID URL</a></var>.
+            </li>
+            <li>
+If the <var>input <a>DID URL</a></var> contains
+no <a>DID path</a> and no
+<a>DID query</a>:
+<pre class="example nohighlight">did:example:1234</pre>
+The <a>DID URL dereferencer</a> MUST return the
+<var>resolved <a>DID document</a></var> and
+<var>resolved <a href="#did-document-metadata"></a></var> as follows:
+<ol class="algorithm">
+<li><b>dereferencingMetadata</b>: <code>«[ ... ]»</code></li>
+<li>
+<b>contentStream</b>: <code>resolved DID document</code>
+                </li>
+                <li>
+<b>contentMetadata</b>:
+<code>«[ <code>resolved DID document metadata</code> ]»</code>
+                </li>
+              </ol>
+            </li>
+            <li>
+If the <var>input <a>DID URL</a></var> contains
+the <a href="#did-parameters"> DID parameter</a> <code>service</code> and/or
+the <a href="#did-parameters"> DID parameter</a> <code>serviceType</code>, and
+optionally the <a href="#did-parameters">DID parameter</a>
+<code>relativeRef</code>:
+<pre class="example nohighlight">
+did:example:1234?service=files&relativeRef=%2Fmyresume%2Fdoc%3Fversion%3Dlatest
+</pre>
 							<ol class="algorithm">
-								<li>For each <var>selected <a>service</a></var>:
+								<li>
+From the <var>resolved <a>DID document</a></var>,
+select all <a data-cite="did-core#services">services</a> which fulfill the
+following conditions:
 									<ol class="algorithm">
-										<li>If the value of the <code>serviceEndpoint</code> property of the <var>selected <a>service</a></var>
-										is a <a data-cite="INFRA#maps">map</a>, skip this <var>selected <a>service</a></var>.</li>
-										<li>If the value of the <code>serviceEndpoint</code> property of the <var>selected <a>service</a></var>
-											is a <a data-cite="INFRA#string">string</a>, add this value to a list of
-											<var>selected [=DID service endpoint=] URLs</var>.</li>
-										<li>If the value of the <code>serviceEndpoint</code> property of the <var>selected <a>service</a></var>
-											is a <a data-cite="INFRA#sets">set</a>, add all its items that are <a data-cite="INFRA#string">strings</a>
-											to a list of <var>selected [=DID service endpoint=] URLs</var>.</li>
-									</ol>
-								</li>
-								<li>For each <var>selected [=DID service endpoint=] URL</var>, execute the algorithm specified in
-									<a data-cite="RFC3986#section-5">RFC3986 Section 5: Reference Resolution</a> as follows:
+										<li>
+If the <var>input <a>DID URL</a></var> contains
+the <a href="#did-parameters">DID parameter</a> <code>service</code>:
+Select the <a data-cite="did-core#services">service</a> if its
+<code>id</code> property matches the value of the
+<code>service</code> DID parameter. If the
+<code>id</code> property or the <code>service</code> DID
+parameter or both contain relative references, the
+corresponding absolute URIs MUST be resolved and used for
+determining the match, using the rules specified in
+<a data-cite="RFC3986#section-5">RFC3986 Section 5: Reference Resolution</a> and in section
+<a data-cite="did-core#relative-did-urls">Relative DID URLs</a> in [[[DID-CORE]]].
+                    </li>
+                    <li>
+If the <var>input <a>DID URL</a></var> contains
+the <a href="#did-parameters">DID parameter</a>
+<code>serviceType</code>: Select the
+<a data-cite="did-core#services">service</a> if its
+<code>type</code> property matches the value of the
+<code>serviceType</code> DID parameter.
+                    </li>
+                  </ol>
+                  The selected <a data-cite="did-core#services">services</a> are a list called
+                  the <var>selected <a>services</a></var>.
+                </li>
+                <li>
+If the <var>input <a>DID URL</a></var> contains the
+<a href="#did-parameters">DID parameter</a> <code>relativeRef</code>:
 									<ol class="algorithm">
-										<li>The <strong>base URI</strong> value is the <var>selected [=DID service endpoint=] URL</var>.</li>
-										<li>The <strong>relative reference</strong> is the value of the
-											<a href="#did-parameters">DID parameter</a> <code>relativeRef</code>.</li>
-										<li>Update the <var>selected [=DID service endpoint=] URL</var> to
-										the result of the "Reference Resolution" algorithm.</li>
-									</ol>
-									<div class="note">
-										<p>
-											Dereferencing a [=DID service endpoint=] — particularly one that is a DID — might
-											result in a <dfn>dereferencing cycle</dfn>, which is a set of steps that result in
-											an infinite loop. For example, a [=DID service endpoint=] might indirectly point
-											back through a sequence of dereferencing processes to a previously dereferenced identifier.
-											A <a>DID URL dereferencer</a> recursively dereferencing a [=DID service endpoint=] is advised
-											to detect and handle such a cycle to prevent an infinite loop or dereferencing failure.
-											For further guidance, see Section <a href="#security-cycles-dereferencing">Dereferencing Cycles</a>.
-										</p>
-									</div>
-								</li>
-							</ol>
-						</li>
-						<li>If the <b>accept</b> <var>input <a href="#did-url-dereferencing-options">DID URL dereferencing option</a></var>
-							is missing, or if its value is the Media Type of a <a>representation</a> of a <a>DID document</a>:
-							<ol class="algorithm">
-								<li>Update the <a>services</a> in the <var>resolved <a>DID document</a></var> to contain only the
-									<var>selected <a>services</a></var>.</li>
-								<li>Return the following result:
+										<li>
+For each <var>selected <a>service</a></var>:
+											<ol class="algorithm">
+												<li>
+If the value of the <code>serviceEndpoint</code> property of the
+<var>selected <a>service</a></var> is
+a <a data-cite="INFRA#maps">map</a>, skip this
+<var>selected <a>service</a></var>.
+                        </li>
+                        <li>
+If the value of the <code>serviceEndpoint</code> property of the
+<var>selected <a>service</a></var>
+is a <a data-cite="INFRA#string">string</a>, add this value
+to a list of
+<var>selected [=DID service endpoint=] URLs</var>.
+                        </li>
+                        <li>
+If the value of the <code>serviceEndpoint</code> property of the
+<var>selected <a>service</a></var> is
+a <a data-cite="INFRA#sets">set</a>, add all its items
+that are <a data-cite="INFRA#string">strings</a> to a list of
+<var>selected [=DID service endpoint=] URLs</var>.
+                        </li>
+                      </ol>
+                    </li>
+                    <li>
+For each <var>selected [=DID service endpoint=] URL</var>,
+execute the algorithm specified in
+<a data-cite="RFC3986#section-5">RFC3986 Section 5: Reference Resolution</a> as follows:
+											<ol class="algorithm">
+												<li>
+The <strong>base URI</strong> value is the
+<var>selected [=DID service endpoint=] URL</var>.
+                        </li>
+                        <li>
+The <strong>relative reference</strong> is the value
+of the <a href="#did-parameters">DID parameter</a>
+<code>relativeRef</code>.
+                        </li>
+                        <li>
+Update the
+<var>selected [=DID service endpoint=] URL</var> to
+the result of the "Reference Resolution" algorithm.
+                        </li>
+                      </ol>
+                      <div class="note">
+                        <p>
+Dereferencing a [=DID service endpoint=] —
+particularly one that is a DID — might result in a
+<dfn>dereferencing cycle</dfn>, which is a set of
+steps that result in an infinite loop. For example, a
+[=DID service endpoint=] might indirectly point back
+through a sequence of dereferencing processes to a
+previously dereferenced identifier. A
+<a>DID URL dereferencer</a> recursively
+dereferencing a [=DID service endpoint=] is advised to
+detect and handle such a cycle to prevent an infinite
+loop or dereferencing failure. For further guidance,
+see Section <a href="#security-cycles-dereferencing">Dereferencing Cycles</a>.
+                        </p>
+                      </div>
+                    </li>
+                  </ol>
+                </li>
+                <li>
+If the <b>accept</b>
+<var>input <a href="#did-url-dereferencing-options">DID URL dereferencing option</a></var>
+is missing, or if its value is the Media Type of a
+<a>representation</a> of a
+<a>DID document</a>:
+<ol class="algorithm">
+<li>
+Update the <a>services</a> in the <var>resolved <a>DID document</a></var> to
+contain only the <var>selected <a>services</a></var>.
+                    </li>
+                    <li>
+Return the following result:
+											<ol class="algorithm">
+												<li>
+<b>dereferencingMetadata</b>: <code>«[ ... ]»</code>
+                        </li>
+                        <li>
+<b>content</b>:
+<code>resolved DID document with selected services</code>
+                        </li>
+                        <li>
+<b>contentMetadata</b>:
+<code>«[ <code>resolved DID document metadata</code> ]»</code>
+                        </li>
+                      </ol>
+                    </li>
+                  </ol>
+                </li>
+                <li>
+If the value of the <b>accept</b>
+<var>input <a href="#did-url-dereferencing-options">DID URL deferencing option</a></var> is
+<b>text/uri-list</b>:
+<ol class="algorithm">
+<li>
+Return the following result:
+<ol class="algorithm">
+<li>
+<b>dereferencingMetadata</b>: <code>«[ ... ]»</code>
+                        </li>
+                        <li>
+<b>content</b>:
+<code>« selected service endpoint URLs »</code>
+                        </li>
+                        <li>
+<b>contentMetadata</b>:
+<code>«[ "contentType" → "text/uri-list", ... ]»</code>
+                        </li>
+                      </ol>
+                    </li>
+                  </ol>
+                </li>
+                <li>
+Otherwise, return the following result:
 									<ol class="algorithm">
-										<li><b>dereferencingMetadata</b>: <code>«[ ... ]»</code></li>
-										<li><b>content</b>: <code>resolved DID document with selected services</code></li>
-										<li><b>contentMetadata</b>: <code>«[ <code>resolved DID document metadata</code> ]»</code></li>
-									</ol>
-								</li>
-							</ol>
-						</li>
-						<li>If the value of the <b>accept</b> <var>input <a href="#did-url-dereferencing-options">DID URL deferencing option</a></var>
-							is <b>text/uri-list</b>:
+										<li>
+<b>dereferencingMetadata</b>: <var>error object</var> with
+type set to <code><a href="#REPRESENTATION_NOT_SUPPORTED">https://www.w3.org/ns/did#REPRESENTATION_NOT_SUPPORTED</a></code>
+                    </li>
+                    <li><b>content</b>: <code>null</code></li>
+                    <li><b>contentMetadata</b>: <code>«[ ]»</code></li>
+                  </ol>
+                </li>
+              </ol>
+            </li>
+
+            <li>
+Otherwise, if the
+<var>input <a>DID URL</a></var> contains a
+<a>DID path</a> and/or
+<a>DID query</a>:
+<pre class="example nohighlight">
+did:example:1234/custom/path?customquery
+</pre>
 							<ol class="algorithm">
-								<li>Return the following result:
-									<ol class="algorithm">
-										<li><b>dereferencingMetadata</b>: <code>«[ ... ]»</code></li>
-										<li><b>content</b>: <code>« selected service endpoint URLs »</code></li>
-										<li><b>contentMetadata</b>: <code>«[ "contentType" → "text/uri-list", ... ]»</code></li>
-									</ol>
-								</li>
-							</ol>
-						</li>
-						<li>Otherwise, return the following result:
+								<li>
+The applicable <a>DID method</a> MAY specify how
+to dereference the <a>DID path</a> and/or <a>DID query</a> of the
+<var>input <a>DID URL</a></var>.
+<pre class="example nohighlight">
+did:example:1234/resources/1234
+</pre>
+                </li>
+                <li>
+An extension specification MAY specify how to dereference the
+<a>DID path</a> of the
+<var>input <a>DID URL</a></var>.
+<pre class="example nohighlight">did:example:1234/whois</pre>
+                </li>
+                <li>
+An extension specification MAY specify how to dereference the
+<a>DID query</a> of the
+<var>input <a>DID URL</a></var>.
+<pre class="example nohighlight">
+did:example:1234?transformKey=JsonWebKey</pre>
+                </li>
+                <li>
+The client MAY be able to dereference the
+<var>input <a>DID URL</a></var> in an
+application-specific way.
+                </li>
+              </ol>
+            </li>
+            <li>
+If neither this algorithm, nor the applicable
+<a>DID method</a>, nor an extension, nor the client
+is able to dereference the
+<var>input <a>DID URL</a></var>, return the
+following result:
 							<ol class="algorithm">
-								<li><b>dereferencingMetadata</b>: <var>error object</var> with type set to <code><a href="#REPRESENTATION_NOT_SUPPORTED">https://www.w3.org/ns/did#REPRESENTATION_NOT_SUPPORTED</a></code></li>
-								<li><b>content</b>: <code>null</code></li>
-								<li><b>contentMetadata</b>: <code>«[ ]»</code></li>
-							</ol>
-						</li>
-					</ol>
-				</li>
+								<li>
+<b>dereferencingMetadata</b>: <var>error object</var> with
+type set to <code><a href="#NOT_FOUND">https://www.w3.org/ns/did#NOT_FOUND</a></code>
+                </li>
+                <li><b>contentStream</b>: <code>null</code></li>
+                <li><b>contentMetadata</b>: <code>«[ ]»</code></li>
+              </ol>
+            </li>
+          </ol>
+        </section>
 
-				<li>Otherwise, if the <var>input <a>DID URL</a></var> contains a <a>DID path</a> and/or <a>DID query</a>:
-				<pre class="example nohighlight">did:example:1234/custom/path?customquery</pre>
-				<ol class="algorithm">
-					<li>The applicable <a>DID method</a> MAY specify how to dereference
-						the <a>DID path</a> and/or <a>DID query</a> of the <var>input <a>DID URL</a></var>.
-						<pre class="example nohighlight">did:example:1234/resources/1234</pre>
-					</li>
-					<li>An extension specification MAY specify how to dereference
-						the <a>DID path</a> of the <var>input <a>DID URL</a></var>.
-						<pre class="example nohighlight">did:example:1234/whois</pre>
-					</li>
-					<li>An extension specification MAY specify how to dereference
-						the <a>DID query</a> of the <var>input <a>DID URL</a></var>.
-						<pre class="example nohighlight">did:example:1234?transformKey=JsonWebKey</pre>
-					</li>
-					<li>The client MAY be able to dereference the <var>input <a>DID URL</a></var>
-						in an application-specific way.</li>
-				</ol>
-				</li>
-				<li>If neither this algorithm, nor the applicable <a>DID method</a>, nor an extension, nor the client
-				is able to dereference the <var>input <a>DID URL</a></var>, return the following result:
-				<ol class="algorithm">
-					<li><b>dereferencingMetadata</b>: <var>error object</var> with type set to <code><a href="#NOT_FOUND">https://www.w3.org/ns/did#NOT_FOUND</a></code></li>
-					<li><b>contentStream</b>: <code>null</code></li>
-					<li><b>contentMetadata</b>: <code>«[ ]»</code></li>
-				</ol>
-				</li>
-			</ol>
+        <section id="dereferencing-algorithm-fragment">
+          <h2>Dereferencing the Fragment</h2>
+          <p>
+If the <var>input <a>DID URL</a></var> contains a
+<a>DID fragment</a>, then dereferencing of the fragment
+is dependent on the media type ([[RFC2046]]) of the resource, i.e.,
+on the result of <a href="#dereferencing-algorithm-resource"></a>.
+          </p>
+          <ol class="algorithm">
+            <li>
+If the result of <a href="#dereferencing-algorithm-resource"></a> is an
+<var>output <a>DID document</a></var>, and the
+<var>input <a href="#did-url-dereferencing-options">DID URL dereferencing options</a></var>
+contain the <code>verificationRelationship</code> option:
+							<ol class="algorithm">
+								<li>
+Let <var>verificationRelationship</var> be the value of the
+<code>verificationRelationship</code>
+option.
+                </li>
+                <li>
+Let <var>verificationMethod</var> be the result of
+dereferencing the <a>DID fragment</a> from the
+<var>output <a>DID document</a></var> according to
+the rules of the media type of the <var>DID document</var>.
+                </li>
+                <li>
+If <var>verificationMethod</var> is not a
+<a data-cite="cid#dfn-conforming-verification-method">conforming verification method</a>,
+an error MUST be raised and SHOULD convey an error type of
+<a data-cite="cid#INVALID_VERIFICATION_METHOD">INVALID_VERIFICATION_METHOD</a>.
+                </li>
+                <li>
+If <var>verificationMethod</var> is not associated, either by
+reference (URL) or by value (object), with the
+<a data-cite="cid#dfn-verification-relationship">verification relationship</a> array in the
+<var>output <a>DID document</a></var> identified
+by <var>verificationRelationship</var>, an error MUST be
+raised and SHOULD convey an error type of
+<a data-cite="cid#INVALID_RELATIONSHIP_FOR_VERIFICATION_METHOD">INVALID_RELATIONSHIP_FOR_VERIFICATION_METHOD</a>.
+                </li>
+                <li>Return the <var>verificationMethod</var>.</li>
+              </ol>
+            </li>
+            <li>
+If the result of <a href="#dereferencing-algorithm-resource"></a> is a
+<var>selected [=DID service endpoint=] URL</var>, and the
+<var>input <a>DID URL</a></var> contains a <a>DID fragment</a>:
+<pre class="example nohighlight">
+did:example:1234?service=files&relativeRef=%2Fmyresume%2Fdoc%3Fversion%3Dlatest#intro
+</pre>
+							<ol class="algorithm">
+								<li>
+If the <var>selected [=DID service endpoint=] URL</var> contains a
+<code>fragment</code> component, raise an error.
+                </li>
+                <li>
+Append the <a>DID fragment</a> to the
+<var>select [=DID service endpoint=] URL</var>. In other
+words, the <var>select [=DID service endpoint=] URL</var> "inherits" the
+<a>DID fragment</a> of the <var>input <a>DID URL</a></var>.
+                </li>
+                <li>
+Return the <var>select [=DID service endpoint=] URL</var>.
+                </li>
+              </ol>
+            </li>
+            <li>
+Otherwise, dereference the DID fragment as defined by the media
+type ([[RFC2046]]) of the resource. For example, if the resource
+is a representation of a DID document with media type
+<code>application/did</code>, then the fragment is treated
+according to the rules associated with the
+<a href="https://www.w3.org/TR/json-ld11/#iana-considerations">JSON-LD 1.1: application/ld+json media type</a> [JSON-LD11].
+            </li>
+          </ol>
 
-		</section>
+          <p class="note">
+This use of the <a>DID fragment</a> is consistent with
+the definition of the fragment identifier in [[RFC3986]]. It
+identifies a <em>secondary resource</em> which is a subset of the
+<em>primary resource</em> (the <a>DID document</a>).
+          </p>
 
-		<section id="dereferencing-algorithm-fragment">
-			<h2>Dereferencing the Fragment</h2>
-			<p>If the <var>input <a>DID URL</a></var> contains a <a>DID fragment</a>,
-			then dereferencing of the fragment is dependent
-			on the media type ([[RFC2046]]) of the resource, i.e., on the result of
-			<a href="#dereferencing-algorithm-resource"></a>.</p>
-			<ol class="algorithm">
-				<li>If the result of <a href="#dereferencing-algorithm-resource"></a> is an <var>output <a>DID document</a></var>,
-				and the <var>input <a href="#did-url-dereferencing-options">DID URL dereferencing options</a></var> contain the
-				<code>verificationRelationship</code> option:
-				<ol class="algorithm">
-					<li>
-					Let <var>verificationRelationship</var> be the value of the <code>verificationRelationship</code>
-					option.
-					</li>
-					<li>
-					Let <var>verificationMethod</var> be the result of dereferencing the
-					<a>DID fragment</a> from the <var>output <a>DID document</a></var> according to the
-					rules of the media type of the <var>DID document</var>.
-					</li>
-					<li>
-					If <var>verificationMethod</var> is not a <a data-cite="cid#dfn-conforming-verification-method">conforming verification method</a>,
-					an error MUST be raised and SHOULD convey an error type of
-					<a data-cite="cid#INVALID_VERIFICATION_METHOD">INVALID_VERIFICATION_METHOD</a>.
-					</li>
-					<li>
-					If <var>verificationMethod</var> is not associated, either by reference
-					(URL) or by value (object), with the <a data-cite="cid#dfn-verification-relationship">verification relationship</a> array in the
-					<var>output <a>DID document</a></var> identified by <var>verificationRelationship</var>,
-					an error MUST be raised and SHOULD convey an error type of
-					<a data-cite="cid#INVALID_RELATIONSHIP_FOR_VERIFICATION_METHOD">
-					INVALID_RELATIONSHIP_FOR_VERIFICATION_METHOD</a>.
-					</li>
-					<li>
-					Return the <var>verificationMethod</var>.
-					</li>
-				</ol>
-				</li>
-				<li>If the result of <a href="#dereferencing-algorithm-resource"></a> is a <var>selected [=DID service endpoint=] URL</var>,
-				and the <var>input <a>DID URL</a></var> contains a <a>DID fragment</a>:
-				<pre class="example nohighlight">did:example:1234?service=files&relativeRef=%2Fmyresume%2Fdoc%3Fversion%3Dlatest#intro</pre>
-				<ol class="algorithm">
-					<li>If the <var>selected [=DID service endpoint=] URL</var>
-					contains a <code>fragment</code> component, raise an error.</li>
-					<li>Append the <a>DID fragment</a> to the <var>select [=DID service endpoint=] URL</var>. In other words,
-					the <var>select [=DID service endpoint=] URL</var> "inherits" the <a>DID fragment</a> of the
-					<var>input <a>DID URL</a></var>.</li>
-					<li>Return the <var>select [=DID service endpoint=] URL</var>.</li>
-				</ol>
-				</li>
-				<li>Otherwise, dereference the DID fragment as defined by the media type ([[RFC2046]]) of the resource.
-				For example, if the resource is a representation of a DID document with media type <code>application/did</code>, then
-				the fragment is treated according to the rules associated with the
-				<a href="https://www.w3.org/TR/json-ld11/#iana-considerations">JSON-LD 1.1: application/ld+json media type</a>
-				[JSON-LD11].
-				</li>
-			</ol>
+          <p class="note">
+This behavior of the <a>DID fragment</a> is analogous to
+the handling of a fragment in an HTTP URL in the case when
+dereferencing it returns an HTTP <code>3xx</code> (Redirection)
+response with a <code>Location</code> header (see section 7.1.2 of
+[[RFC7231]]).
+          </p>
+        </section>
+      </section>
 
-			<p class="note">
-				This use of the <a>DID fragment</a> is consistent with the definition of the fragment identifier in
-				[[RFC3986]]. It identifies a <em>secondary resource</em> which is a subset of the <em>primary resource</em>
-				(the <a>DID document</a>).
-			</p>
+      <section>
+        <h2>Examples</h2>
 
-			<p class="note">
-				This behavior of the <a>DID fragment</a> is analogous to the handling of a fragment in an HTTP URL in the
-				case when dereferencing it returns an HTTP <code>3xx</code> (Redirection) response with a
-				<code>Location</code> header (see section 7.1.2 of [[RFC7231]]).
-			</p>
-
-		</section>
-
-	</section>
-
-	<section>
-		<h2>Examples</h2>
-
-		<section>
-			<h3>Example: Dereferencing to verification method</h3>
-			<p>Given the following <var>input <a>DID URL</a></var>:</p>
-			<pre class="example nohighlight">
+        <section>
+          <h3>Example: Dereferencing to verification method</h3>
+          <p>
+Given the following
+<var>input <a>DID URL</a></var>:
+          </p>
+          <pre class="example nohighlight">
 	did:example:123456789abcdefghi#keys-1
-	</pre>
-			<p>... and the following <var>resolved <a>DID document</a></var>:<p>
-			<pre class="example nohighlight">
+</pre>
+          <p>
+... and the following <var>resolved <a>DID document</a></var>:
+          </p>
+<pre class="example nohighlight">
 	{
 		"@context":[
 			"https://www.w3.org/ns/did/v1.1",
@@ -1723,9 +2056,12 @@ dereference(didUrl, dereferenceOptions) →
 			"serviceEndpoint": "https://example.com/verifiable-presentation.jsonld"
 		}]
 	}
-	</pre>
-			<p>... then the result of the <a href="#dereferencing"></a> algorithm is the following <var>output resource</var>:</p>
-			<pre class="example nohighlight">
+</pre>
+          <p>
+... then the result of the <a href="#dereferencing"></a> algorithm
+is the following <var>output resource</var>:
+          </p>
+<pre class="example nohighlight">
 	{
 		"@context": "https://www.w3.org/ns/did/v1.1",
 		"id": "did:example:123456789abcdefghi#keys-1",
@@ -1733,518 +2069,731 @@ dereference(didUrl, dereferenceOptions) →
 		"controller": "did:example:123456789abcdefghi",
 		"publicKeyMultibase": "z6MkmM42vxfqZQsv4ehtTjFFxQ4sQKS2w6WR7emozFAn5cxu"
 	}
-	</pre>
-			<figure id="figure-dereference-to-verification-method">
-				<img style="margin: auto; display: block; width: 100%;" src="diagrams/section-5/example-dereference-to-verification-method.svg"
-					 alt="Diagram showing how a DID URL can be dereferenced to a verification method">
-				<figcaption style="text-align: center;">
-					Dereferencing a DID URL to a verification method.
-				</figcaption>
-			</figure>
-		</section>
+</pre>
+          <figure id="figure-dereference-to-verification-method">
+            <img
+              style="margin: auto; display: block; width: 100%"
+              src="diagrams/section-5/example-dereference-to-verification-method.svg"
+              alt="Diagram showing how a DID URL can be dereferenced to a verification method"
+            />
+            <figcaption style="text-align: center;">
+Dereferencing a DID URL to a verification method.
+            </figcaption>
+          </figure>
+        </section>
 
-		<section>
-			<h3>Example: Dereferencing to service endpoint URL</h3>
-			<p>Given the following <var>input <a>DID URL</a></var>:</p>
-			<pre class="example nohighlight">
+        <section>
+          <h3>Example: Dereferencing to service endpoint URL</h3>
+          <p>
+Given the following
+<var>input <a>DID URL</a></var>:
+          </p>
+<pre class="example nohighlight">
 	did:example:123456789abcdefghi?service=messages&relativeRef=%2Fsome%2Fpath%3Fquery#frag
-	</pre>
-			<p>... and the same <var>resolved <a>DID document</a></var> as in the previous section.<p>
-			<p>... then the result of the <a href="#dereferencing"></a> algorithm is the following <var>selected [=DID service endpoint=] URL</var>:</p>
-			<pre class="example nohighlight">
-	https://example.com/messages/8377464/some/path?query#frag
-	</pre>
-			<figure id="figure-dereference-to-service-endpoint-url">
-				<img style="margin: auto; display: block; width: 100%;" src="diagrams/section-5/example-dereference-to-service-endpoint-url.svg"
-				alt="Diagram showing how a DID URL can be dereferenced to a service endpoint URL">
-				<figcaption style="text-align: center;">
-					Dereferencing a DID URL to a service endpoint URL.
-				</figcaption>
-			</figure>
-		</section>
+</pre>
+          <p>
+... and the same
+<var>resolved <a>DID document</a></var> as in the
+previous section.
+          </p>
+          <p></p>
+          <p>
+... then the result of the <a href="#dereferencing"></a> algorithm
+is the following <var>selected [=DID service endpoint=] URL</var>:
+          </p>
+<pre class="example nohighlight">
+https://example.com/messages/8377464/some/path?query#frag
+</pre>
+          <figure id="figure-dereference-to-service-endpoint-url">
+            <img
+              style="margin: auto; display: block; width: 100%"
+              src="diagrams/section-5/example-dereference-to-service-endpoint-url.svg"
+              alt="Diagram showing how a DID URL can be dereferenced to a service endpoint URL"
+            />
+            <figcaption style="text-align: center">
+Dereferencing a DID URL to a service endpoint URL.
+            </figcaption>
+          </figure>
+        </section>
+      </section>
+    </section>
 
-	</section>
+    <section>
+      <h2>Metadata Structure</h2>
 
-</section>
+      <p>
+Input and output metadata is often involved during the
+<a>DID Resolution</a>, <a>DID URL dereferencing</a>, and other
+DID-related processes. The structure used to communicate this metadata MUST be a
+<a data-cite="INFRA#maps">map</a> of properties. Each property name MUST be a
+<a data-cite="INFRA#string">string</a>. Each property value, and each value within any
+complex data structure such as a map or list, MUST be a
+<a data-cite="INFRA#string">string</a>, <a data-cite="INFRA#numbers">number</a>,
+<a data-cite="INFRA#maps">map</a>, <a data-cite="INFRA#lists">list</a>,
+<a data-cite="INFRA#sets">set</a>, <a data-cite="INFRA#boolean">boolean</a>, or
+<a data-cite="INFRA#nulls">null</a>. The entire metadata structure MUST be
+serializable according to the <a data-cite="INFRA#serialize-an-infra-value-to-json-bytes">JSON serialization rules</a>
+in the [[INFRA]] specification. Implementations MAY serialize the metadata
+structure to other data formats.
+      </p>
 
-<section>
-	<h2>Metadata Structure</h2>
+      <aside class="note">
+        <p>
+Numeric representations vary across platforms and serializations (for example,
+IEEE-754 floating-point vs. fixed-width integers vs. “bigint”/bignum types). The
+<a data-cite="INFRA#numbers">Infra</a> standard does not yet provide comprehensive
+guidance for numbers. Implementers are advised to avoid metadata numbers that
+are likely to be represented differently on different platforms — notably the
+following:
+        </p>
+        <ul>
+          <li>
+non-integer values such as floating-point numbers or fractions
+          </li>
+          <li>
+integers outside common fixed-width ranges, such as those larger
+than a 32-bit unsigned integer (maximum
+<code>2<sup>32</sup> - 1</code> or <code>4,294,967,295</code>)
+          </li>
+        </ul>
+        <p>
+Where such values are needed for interoperability, a good practice for
+property is definitions to use a canonical
+<strong>string</strong> serialization (for example, a string formatted
+as a floating-point number using a clearly defined precision and
+rounding strategy) and to document any expected range or format.
+        </p>
+      </aside>
 
-	<p>
-		Input and output metadata is often involved during the <a>DID Resolution</a>,
-		<a>DID URL dereferencing</a>, and other DID-related processes. The structure
-		used to communicate this metadata MUST be a <a data-cite="INFRA#maps">map</a>
-		of properties. Each property name MUST be a <a
-			data-cite="INFRA#string">string</a>. Each property value, and each
-		value within any complex data structure such as a map or list,
-		MUST be a <a data-cite="INFRA#string">string</a>,
-			<a data-cite="INFRA#numbers">number</a>,
-			<a data-cite="INFRA#maps">map</a>,
-			<a data-cite="INFRA#lists">list</a>,
-			<a data-cite="INFRA#sets">set</a>,
-		<a data-cite="INFRA#boolean">boolean</a>, or
-		<a data-cite="INFRA#nulls">null</a>.
+      <p>
+All implementations of functions that use metadata structures as either input or
+output are able to fully represent all data types described here in a
+deterministic fashion. As inputs and outputs using metadata structures are
+defined in terms of data types and not their serialization, the method for
+<a>representation</a> is internal to the implementation of the
+function and is out of scope of this specification.
+      </p>
 
-		The entire metadata structure MUST be serializable according to the <a
-			data-cite="INFRA#serialize-an-infra-value-to-json-bytes">JSON
-		serialization rules</a> in the [[INFRA]] specification. Implementations MAY
-		serialize the metadata structure to other data formats.
-	</p>
+      <p>
+The following example demonstrates a JSON-encoded metadata structure that might
+be used as <a href="#did-resolution-options">DID resolution options</a>.
+      </p>
 
-	<aside class="note">
-		<p>
-			Numeric representations vary across platforms and serializations
-			(for example, IEEE-754 floating-point vs. fixed-width integers vs.
-			“bigint”/bignum types). The
-			<a data-cite="INFRA#numbers">Infra</a> standard does not yet provide
-			comprehensive guidance for numbers. Implementers are advised to avoid
-			metadata numbers that are likely to be represented differently on
-			different platforms — notably the following:
-		</p>
-		<ul>
-			<li>non-integer values such as floating-point numbers or fractions</li>
-			<li>integers outside common fixed-width ranges, such as those larger
-			than a 32-bit unsigned integer (maximum <code>2<sup>32</sup> - 1</code>
-			or <code>4,294,967,295</code>)</li>
-		</ul>
-		<p>
-			Where such values are needed for interoperability,
-			a good practice for property is definitions to use
-			a canonical <strong>string</strong> serialization (for example, a
-			string formatted as a floating-point number using a clearly defined
-			precision and rounding strategy) and to document any expected
-			range or format.
-		</p>
-		</aside>
-
-	<p>
-		All implementations of functions that use metadata structures as either input or
-		output are able to fully represent all data types described here in a
-		deterministic fashion. As inputs and outputs using metadata structures are
-		defined in terms of data types and not their serialization, the method for
-		<a>representation</a> is internal to the implementation of the function and is
-		out of scope of this specification.
-	</p>
-
-	<p>
-		The following example demonstrates a JSON-encoded metadata structure that
-		might be used as <a href="#did-resolution-options">DID
-		resolution options</a>.
-	</p>
-
-	<pre class="example"
-		 title="JSON-encoded DID resolution options example">
+<pre class="example" title="JSON-encoded DID resolution options example">
 {
 "accept": "application/did"
 }
-  </pre>
+</pre>
 
-	<p>
-		This example corresponds to a metadata structure of the following format:
-	</p>
+      <p>
+This example corresponds to a metadata structure of the following format:
+      </p>
 
-	<pre class="example"
-		 title="DID resolution options example">
+<pre class="example" title="DID resolution options example">
 «[
 "accept" → "application/did"
 ]»
-  </pre>
+</pre>
 
-	<p>
-		The next example demonstrates a JSON-encoded metadata structure that might be
-		used as <a href="#did-resolution-metadata">DID resolution
-		metadata</a> if a <a>DID</a> was not found.
-	</p>
+      <p>
+The next example demonstrates a JSON-encoded metadata structure that might be
+used as <a href="#did-resolution-metadata">DID resolution metadata</a> if a
+<a>DID</a> was not found.
+      </p>
 
-	<pre class="example"
-		 title="JSON-encoded DID resolution metadata example">
+<pre class="example" title="JSON-encoded DID resolution metadata example">
 {
 "error": "notFound"
 }
-  </pre>
+</pre>
 
-	<p>
-		This example corresponds to a metadata structure of the following format:
-	</p>
+      <p>
+This example corresponds to a metadata structure of the following format:
+      </p>
 
-	<pre class="example"
-		 title="DID resolution metadata example">
+<pre class="example" title="DID resolution metadata example">
 «[
 "error" → "notFound"
 ]»
-  </pre>
+</pre>
 
-	<p>
-		The next example demonstrates a JSON-encoded metadata structure that might be
-		used as <a href="#did-document-metadata">DID document metadata</a>
-		to describe timestamps associated with the <a>DID document</a>.
-	</p>
+      <p>
+The next example demonstrates a JSON-encoded metadata structure that might be
+used as <a href="#did-document-metadata">DID document metadata</a> to describe
+timestamps associated with the <a>DID document</a>.
+      </p>
 
-	<pre class="example" title="JSON-encoded DID document metadata example">
+<pre class="example" title="JSON-encoded DID document metadata example">
 {
 "created": "2019-03-23T06:35:22Z",
 "updated": "2023-08-10T13:40:06Z"
 }
-  </pre>
+</pre>
 
-	<p>
-		This example corresponds to a metadata structure of the following format:
-	</p>
+      <p>
+This example corresponds to a metadata structure of the following format:
+      </p>
 
-	<pre class="example"
-		 title="DID document metadata example">
+<pre class="example" title="DID document metadata example">
 «[
 "created" → "2019-03-23T06:35:22Z",
 "updated" → "2023-08-10T13:40:06Z"
 ]»
-  </pre>
+</pre>
+    </section>
 
-</section>
+    <section id="architectures">
+      <h1>DID Resolution Architectures</h1>
 
-<section id="architectures">
-	<h1>DID Resolution Architectures</h1>
-
-	<section id="method-architectures">
-		<h2>Method Architectures</h2>
-		<p>The <a>DID resolution</a> algorithm involves executing the <a data-cite="did-core#method-operations">Resolve</a>
-		operation on a <a>DID</a> according to its <a>DID method</a> (see <a href="#resolving"></a>).</p>
-
-		<p>Every DID method defines this method operation, i.e.,
-            how a <a>DID resolver</a> can obtain a DID document from a DID. The underlying
-            data formats, protocols, technical infrastructures, and processes can vary considerably among
-		    <a>DID methods</a>.</p>
-
-        <p>Examples of DID method considerations include the following:</p>
-		<ul>
-          <li>A DID method might use an immutable blockchain, distributed ledger, distributed file system,
-            peer-to-peer network, or other decentralized infrastructure as (part of) its
-            <a>verifiable data registry</a>.
-          </li>
-          <li>A DID method might use DNS, HTTP, or web servers as (part of) its <a>verifiable data registry</a>.
-          </li>
-          <li>A DID method might use any combination of the above technical infrastructures.
-          </li>
-          <li>A DID method might store an actual <a>DID document</a> in plain-text form in a
-            <a>verifiable data registry</a> and might simply retrieve that document during the "Resolve" operation.
-          </li>
-          <li>A DID method might define its "Resolve" operation in a more complex way that could involve
-            intermediate, partial, or temporary <a>DID documents</a>, and use multi-step processes
-            that construct the <a>DID document</a> "on-the-fly".
-          </li>
-          <li>A DID method might require interaction with remote servers or networks during execution
-            of the "Resolve" operation.
-          </li>
-          <li>A DID method might execute the "Resolve" operation in an entirely local way that does not require any
-            interaction with remote servers or networks. For example, in the [[?DID-KEY]] method,
-            the DID itself wraps a public key, and the "Resolve" operation is simply a trivial, local transformation
-            process.
-          </li>
-		</ul>
-
-		<p>Based on the above considerations combined with the nature of a <a>DID method's</a> "Resolve" operation, the interaction between a
-		<a>DID resolver</a> and the <a>verifiable data registry</a> could be considered either a <a>verifiable resolution</a>
-		or an <a>unverifiable resolution</a>:</p>
-
-		<figure id="figure-architecture-method-verifiable">
-			<img style="margin: auto; display: block; width: 100%; margin-bottom: 20px;" src="diagrams/section-7/architecture-method-verifiable.svg"
-			alt="Diagram showing a 'verifiable resolution' implementation of a DID method.">
-			<figcaption style="text-align: center;">
-				A <a>verifiable resolution</a> implementation of a <a>DID method</a>.
-			</figcaption>
-		</figure>
-		<figure id="figure-architecture-method-unverifiable">
-			<img style="margin: auto; display: block; width: 100%; margin-bottom: 20px;" src="diagrams/section-7/architecture-method-unverifiable.svg"
-			alt="Diagram showing an 'unverifiable resolution' implementation of a DID method.">
-			<figcaption style="text-align: center;">
-				An <a>unverifiable resolution</a> implementation of a <a>DID method</a>.
-			</figcaption>
-		</figure>
-
-		<p>
-			A <a>verifiable resolution</a> maximizes confidence in the integrity and correctness of the result of the "Resolve" operation, to the extent
-			possible under the applicable <a>DID method</a>. This can be accomplished in a number of ways, such as the following:
-		</p>
-
-		<ul>
-		<li>A <a>verifiable resolution</a> can be accomplished if access to the <a>verifiable data registry</a> is
-			possible in a local, trusted network environment.
-            <ul>
-                <li>For example, in blockchain-based <a>DID methods</a>, a
-                <a>verifiable resolution</a> might be accomplished if a blockchain full node is deployed on a local server.</li>
-            </ul></li>
-        <li>If access to the <a>verifiable data registry</a> happens via a remote server, a <a>verifiable resolution</a> might
-            still be accomplished if the remote server is trusted, and if it can be accessed via
-            a secure channel.</li>
-        <li>If access to the <a>verifiable data registry</a> happens via a remote server, a <a>verifiable resolution</a> might
-            be accomplished if the <a>DID resolver</a> has some way of verifying the <a>DID document</a> and
-            <a href="#did-document-metadata">DID document metadata</a> returned by the DID method.
-            <ul>
-            <li>For example, in blockchain-based <a>DID methods</a>, even if direct access to a blockchain
-                full node is not available, a <a>verifiable resolution</a> may still be possible by using a light client that
-                processes metadata to verify the data.</li>
-            </ul></li>
-		</ul>
-
-		<p>
-			An <a>unverifiable resolution</a> does not have such guarantees and is therefore less desirable, for example:
-		</p>
-
-		<ul>
-        <li>An <a>unverifiable resolution</a> takes place if access to the <a>verifiable data registry</a> happens
-			via a remote, untrusted intermediary.
-            <ul>
-            <li>For example, in the case of blockchain-based <a>DID methods</a>, a remote blockchain explorer API
-			    operated by an third party may be used to look up data from the blockchain.</li>
-            </ul></li>
-		</ul>
-
-		<p class="note" title="Implementation Details">
-			Whether or not a <a>verifiable resolution</a> is possible depends not only on a <a>DID method</a> itself, but also on the way
-			a <a>DID resolver</a> implements that <a>DID method</a>. <a>DID methods</a> MAY allow multiple ways of implementing their "Resolve"
-			operation, and SHOULD offer guidance regarding at least one way to implement a <a>verifiable resolution</a>.
-		</p>
-
-		<p class="note" title="Limitations of Verifiable Data Registries">
-			The guarantees associated with a <a>verifiable resolution</a> are always limited by the architecture(s), protocol(s), cryptographic element(s),
-            and other aspects of the <a>DID method's</a> underlying <a>verifiable data registry</a>. The forms of <a>verifiable resolution</a> implementation
-            that are considered strongest are those that require no interaction with any remote network (for example, see
-            [[?DID-KEY]]), and those that minimize dependencies on specific network infrastructure, reducing the "root of trust"
-            to proven entropy and cryptography (for example, see [[KERI]]).
-		</p>
-
+      <section id="method-architectures">
+        <h2>Method Architectures</h2>
         <p>
-            To enable <a>verifiable resolutions</a>, many DID methods use digital signatures, state proofs, proofs of
-            inclusion in Merkle trees, cryptographic event logs, or other types of proof. If a <a>DID method</a>
-            uses such proofs, it MUST specify in its DID method specification how they are used for
-            verification of the correctness of the result of a "Resolve" operation.
+The <a>DID resolution</a> algorithm involves executing the
+<a data-cite="did-core#method-operations">Resolve</a> operation on a <a>DID</a>
+according to its <a>DID method</a> (see
+<a href="#resolving"></a>).
         </p>
 
         <p>
-            A <a>DID method</a> MAY also include such proofs in the <a>DID document</a> itself, or
-            in a <code>proof</code> property of the
-            <a href="#did-document-metadata">DID document metadata</a>.
-            This can potentially enable a <a>client</a> to independently verify the results of a
-            <a>DID Resolution</a> process, even if it does not trust the <a>DID resolver</a>.
-		</p>
+Every DID method defines this method operation, i.e., how a
+<a>DID resolver</a> can obtain a DID document from a DID. The
+underlying data formats, protocols, technical infrastructures, and processes can
+vary considerably among <a>DID methods</a>.
+        </p>
 
-		<p class="advisement">
-			Note that proofs originating from the <a>DID method</a> are <a>DID method</a>-specific
-			and must be understood within the technology of the applicable <a>DID method</a>.
-			A simple signature on a
-            <a>DID document</a> or <a href="#did-document-metadata">DID document metadata</a> does not
-            necessarily prove control of a DID, nor guarantee that the <a>DID document</a> is the correct
-            one for the <a>DID</a>.
-			These proofs help to verify the integrity and authenticity of the results of a
-			<a>DID Resolution</a> process as far as the <a>DID method</a> itself is concerned.
-			However, they do not guarantee that the <a>binding</a> between a <a>client</a> and the
-			<a>DID resolver</a> is secure. See also <a href="#resolver-architectures"></a>.
-		</p>
-
-	</section>
-
-	<section id="resolver-architectures">
-		<h2>Resolver Architectures</h2>
-		<p>The algorithms for <a>DID resolution</a> and <a>DID URL dereferencing</a> are defined as abstract functions
-		(see <a href="#resolving"></a> and <a href="#dereferencing"></a>).</p>
+        <p>Examples of DID method considerations include the following:</p>
+        <ul>
+          <li>
+A DID method might use an immutable blockchain, distributed ledger, distributed
+file system, peer-to-peer network, or other decentralized infrastructure as
+(part of) its <a>verifiable data registry</a>.
+          </li>
+          <li>
+A DID method might use DNS, HTTP, or web servers as (part of) its
+<a>verifiable data registry</a>.
+          </li>
+          <li>
+A DID method might use any combination of the above technical infrastructures.
+          </li>
+          <li>
+A DID method might store an actual <a>DID document</a> in plain-text
+form in a <a>verifiable data registry</a> and might simply retrieve that
+document during the "Resolve" operation.
+          </li>
+          <li>
+A DID method might define its "Resolve" operation in a more complex way that
+could involve intermediate, partial, or temporary
+<a>DID documents</a>, and use multi-step processes that construct the
+<a>DID document</a> "on-the-fly".
+          </li>
+          <li>
+A DID method might require interaction with remote servers or networks during
+execution of the "Resolve" operation.
+          </li>
+          <li>
+A DID method might execute the "Resolve" operation in an entirely local way that
+does not require any interaction with remote servers or networks. For example,
+in the [[?DID-KEY]] method, the DID itself wraps a public key, and the "Resolve"
+operation is simply a trivial, local transformation process.
+          </li>
+        </ul>
 
         <p>
-            Those algorithms are implemented by <a>DID resolvers</a> and <a>DID URL dereferencers</a>,
-            which are invoked by a <a>client</a> via a <a>binding</a>. Bindings define how the abstract functions are
-            accessed using concrete programming or communication interfaces.
+Based on the above considerations combined with the nature of a
+<a>DID method's</a> "Resolve" operation, the interaction between a
+<a>DID resolver</a> and the <a>verifiable data registry</a> could be
+considered either a <a>verifiable resolution</a> or an
+<a>unverifiable resolution</a>:
+        </p>
+
+        <figure id="figure-architecture-method-verifiable">
+          <img
+            style="
+              margin: auto;
+              display: block;
+              width: 100%;
+              margin-bottom: 20px;
+            "
+            src="diagrams/section-7/architecture-method-verifiable.svg"
+            alt="Diagram showing a 'verifiable resolution' implementation of a DID method."
+          />
+          <figcaption style="text-align: center;">
+A <a>verifiable resolution</a> implementation of a
+<a>DID method</a>.
+          </figcaption>
+        </figure>
+        <figure id="figure-architecture-method-unverifiable">
+          <img
+            style="
+              margin: auto;
+              display: block;
+              width: 100%;
+              margin-bottom: 20px;
+            "
+            src="diagrams/section-7/architecture-method-unverifiable.svg"
+            alt="Diagram showing an 'unverifiable resolution' implementation of a DID method."
+          />
+          <figcaption style="text-align: center;">
+An <a>unverifiable resolution</a> implementation of a
+<a>DID method</a>.
+          </figcaption>
+        </figure>
+
+        <p>
+A <a>verifiable resolution</a> maximizes confidence in the integrity and
+correctness of the result of the "Resolve" operation, to the extent possible
+under the applicable <a>DID method</a>. This can be accomplished
+in a number of ways, such as the following:
+        </p>
+
+        <ul>
+          <li>
+A <a>verifiable resolution</a> can be accomplished if access to
+the <a>verifiable data registry</a> is possible in a local, trusted
+network environment.
+<ul>
+<li>
+For example, in blockchain-based <a>DID methods</a>, a
+<a>verifiable resolution</a> might be accomplished if a
+blockchain full node is deployed on a local server.
+              </li>
+            </ul>
+          </li>
+          <li>
+If access to the <a>verifiable data registry</a> happens via a remote server, a
+<a>verifiable resolution</a> might still be accomplished if the remote server
+is trusted, and if it can be accessed via a secure channel.
+          </li>
+          <li>
+If access to the <a>verifiable data registry</a> happens via a
+remote server, a <a>verifiable resolution</a> might be
+accomplished if the <a>DID resolver</a> has some way of
+verifying the <a>DID document</a> and
+<a href="#did-document-metadata">DID document metadata</a> returned by the DID method.
+<ul>
+<li>
+For example, in blockchain-based
+<a>DID methods</a>, even if direct access to a
+blockchain full node is not available, a
+<a>verifiable resolution</a> may still be possible by using a
+light client that processes metadata to verify the data.
+              </li>
+            </ul>
+          </li>
+        </ul>
+
+        <p>
+An <a>unverifiable resolution</a> does not have such guarantees and is
+therefore less desirable, for example:
+        </p>
+
+        <ul>
+          <li>
+An <a>unverifiable resolution</a> takes place if access to the
+<a>verifiable data registry</a> happens via a remote, untrusted
+intermediary.
+<ul>
+<li>
+For example, in the case of blockchain-based
+<a>DID methods</a>, a remote blockchain explorer
+API operated by an third party may be used to look up data from
+the blockchain.
+              </li>
+            </ul>
+          </li>
+        </ul>
+
+        <p class="note" title="Implementation Details">
+Whether or not a <a>verifiable resolution</a> is possible depends not only on
+a <a>DID method</a> itself, but also on the way a
+<a>DID resolver</a> implements that <a>DID method</a>.
+<a>DID methods</a> MAY allow multiple ways of implementing their
+"Resolve" operation, and SHOULD offer guidance regarding at least one way to
+implement a <a>verifiable resolution</a>.
+        </p>
+
+        <p class="note" title="Limitations of Verifiable Data Registries">
+The guarantees associated with a <a>verifiable resolution</a> are always
+limited by the architecture(s), protocol(s), cryptographic element(s), and other
+aspects of the <a>DID method's</a> underlying
+<a>verifiable data registry</a>. The forms of <a>verifiable resolution</a>
+implementation that are considered strongest are those that require no
+interaction with any remote network (for example, see [[?DID-KEY]]), and those
+that minimize dependencies on specific network infrastructure, reducing the
+"root of trust" to proven entropy and cryptography (for example, see [[KERI]]).
+        </p>
+
+        <p>
+To enable <a>verifiable resolutions</a>, many DID methods use digital
+signatures, state proofs, proofs of inclusion in Merkle trees, cryptographic
+event logs, or other types of proof. If a <a>DID method</a> uses
+such proofs, it MUST specify in its DID method specification how they are used
+for verification of the correctness of the result of a "Resolve" operation.
+        </p>
+
+        <p>
+A <a>DID method</a> MAY also include such proofs in the
+<a>DID document</a> itself, or in a <code>proof</code> property of the
+<a href="#did-document-metadata">DID document metadata</a>.
+This can potentially enable a <a>client</a> to
+independently verify the results of a <a>DID Resolution</a>
+process, even if it does not trust the
+<a>DID resolver</a>.
+        </p>
+
+        <p class="advisement">
+Note that proofs originating from the <a>DID method</a> are
+<a>DID method</a>-specific and must be understood within the
+technology of the applicable <a>DID method</a>. A simple signature
+on a <a>DID document</a> or <a href="#did-document-metadata">DID document metadata</a>
+does not necessarily prove control of a DID, nor guarantee that the
+<a>DID document</a> is the correct one for the
+<a>DID</a>. These proofs help to verify the integrity and
+authenticity of the results of a <a>DID Resolution</a> process as far
+as the <a>DID method</a> itself is concerned. However, they do not
+guarantee that the <a>binding</a> between a
+<a>client</a> and the <a>DID resolver</a> is
+secure. See also <a href="#resolver-architectures"></a>.
+        </p>
+      </section>
+
+      <section id="resolver-architectures">
+        <h2>Resolver Architectures</h2>
+        <p>
+The algorithms for <a>DID resolution</a> and
+<a>DID URL dereferencing</a> are defined as abstract functions (see
+<a href="#resolving"></a> and <a href="#dereferencing"></a>).
+        </p>
+
+        <p>
+Those algorithms are implemented by <a>DID resolvers</a> and
+<a>DID URL dereferencers</a>, which are invoked by a
+<a>client</a> via a <a>binding</a>. Bindings
+define how the abstract functions are accessed using concrete programming or
+communication interfaces.
         </p>
 
         <p>Examples of bindings include the following:</p>
         <ul>
-            <li>A <a>DID resolver</a> might be invoked within an application by calling a software library or SDK.</li>
-            <li>A <a>DID resolver</a> might be invoked as a command line tool.</li>
-            <li>A <a>DID resolver</a> might be invoked over an HTTP(S) API or other network protocol, e.g., see <a href="#bindings-https"></a>.</li>
+          <li>
+A <a>DID resolver</a> might be invoked within an application by
+calling a software library or SDK.
+          </li>
+          <li>
+A <a>DID resolver</a> might be invoked as a command line tool.
+          </li>
+          <li>
+A <a>DID resolver</a> might be invoked over an HTTP(S) API or other
+network protocol, e.g., see <a href="#bindings-https"></a>.
+          </li>
         </ul>
 
-        <p>Based on the above considerations combined with the nature of the binding, the interaction between a
-            <a>client</a> and the <a>DID resolver</a> or <a>DID URL dereferencer</a> could be considered either a <a>local binding</a>
-            or a <a>remote binding</a>:</p>
+        <p>
+Based on the above considerations combined with the nature of the binding, the
+interaction between a <a>client</a> and the
+<a>DID resolver</a> or <a>DID URL dereferencer</a> could be
+considered either a <a>local binding</a> or a
+<a>remote binding</a>:
+        </p>
 
-		<figure id="figure-architecture-binding-local">
-			<img style="margin: auto; display: block; width: 100%; margin-bottom: 20px;" src="diagrams/section-7/architecture-binding-local.svg"
-			alt="Diagram showing a DID resolver with a 'local binding'.">
-			<figcaption style="text-align: center;">
-				A <a>local binding</a> for a <a>DID resolver</a>.
-			</figcaption>
-		</figure>
-		<figure id="figure-architecture-binding-remote">
-			<img style="margin: auto; display: block; width: 100%; margin-bottom: 20px;" src="diagrams/section-7/architecture-binding-remote.svg"
-			alt="Diagram showing a DID resolver with a 'remote binding'.">
-			<figcaption style="text-align: center;">
-				A <a>remote binding</a> for a <a>DID resolver</a>.
-			</figcaption>
-		</figure>
+        <figure id="figure-architecture-binding-local">
+          <img
+            style="
+              margin: auto;
+              display: block;
+              width: 100%;
+              margin-bottom: 20px;
+            "
+            src="diagrams/section-7/architecture-binding-local.svg"
+            alt="Diagram showing a DID resolver with a 'local binding'."
+          />
+          <figcaption style="text-align: center">
+A <a>local binding</a> for a <a>DID resolver</a>.
+          </figcaption>
+        </figure>
+        <figure id="figure-architecture-binding-remote">
+          <img
+            style="
+              margin: auto;
+              display: block;
+              width: 100%;
+              margin-bottom: 20px;
+            "
+            src="diagrams/section-7/architecture-binding-remote.svg"
+            alt="Diagram showing a DID resolver with a 'remote binding'."
+          />
+          <figcaption style="text-align: center;">
+A <a>remote binding</a> for a <a>DID resolver</a>.
+          </figcaption>
+        </figure>
 
         <p>
-            Whenever possible, <a>local bindings</a> are preferred, as they minimize dependencies on third parties
-            and intermediaries, reduce security risks, and maximize confidence in the integrity and correctness of the
-            results of the <a>DID resolution</a> and <a>DID URL dereferencing</a> functions.
+Whenever possible, <a>local bindings</a> are preferred, as they
+minimize dependencies on third parties and intermediaries, reduce security
+risks, and maximize confidence in the integrity and correctness of the results
+of the <a>DID resolution</a> and <a>DID URL dereferencing</a>
+functions.
         </p>
 
         <p>
-            In some cases, it might not be possible to use a <a>local binding</a>; for example, in constrained IoT (Internet of Things)
-            environments, or when a <a>DID method</a> requires complex infrastructure, or when many different <a>DID
-            methods</a> should be supported.
+In some cases, it might not be possible to use a
+<a>local binding</a>; for example, in constrained IoT (Internet of
+Things) environments, or when a <a>DID method</a> requires complex
+infrastructure, or when many different <a>DID methods</a> should be
+supported.
         </p>
 
         <p>
-            If a <a>client</a> uses a <a>remote binding</a>, the following considerations apply:
+If a <a>client</a> uses a <a>remote binding</a>, the
+following considerations apply:
         </p>
-            <ul>
-                <li>The <a>remote binding</a> SHOULD use a trusted instance of a <a>DID resolver</a>, ideally
-                    under the control of the <a>client</a> itself (e.g., self-hosted).</li>
-                <li>The <a>remote binding</a> SHOULD use a secure channel such as VPN and/or TLS with mutual authentication.</li>
-                <li>The <a>client</a> could query multiple <a>DID resolvers</a> over a <a>remote binding</a> and compare results.</li>
-            </ul>
+        <ul>
+          <li>
+The <a>remote binding</a> SHOULD use a trusted instance of a
+<a>DID resolver</a>, ideally under the control of the
+<a>client</a> itself (e.g., self-hosted).
+          </li>
+          <li>
+The <a>remote binding</a> SHOULD use a secure channel such as VPN
+and/or TLS with mutual authentication.
+          </li>
+          <li>
+The <a>client</a> could query multiple
+<a>DID resolvers</a> over a <a>remote binding</a> and
+compare results.
+          </li>
+        </ul>
 
         <p>
-            A <a>DID resolver</a> MAY also include proofs
-            in a <code>proof</code> property of the
-            <a href="#did-resolution-metadata">DID resolution metadata</a>.
+A <a>DID resolver</a> MAY also include proofs in a
+<code>proof</code> property of the <a href="#did-resolution-metadata">DID resolution metadata</a>.
         </p>
 
         <p class="advisement">
-            Note that proofs originating from a <a>DID resolver</a> are
-            <a>DID method</a>-independent and can be universally applied by a <a>DID resolver</a>,
-            across all DID methods. These proofs help to
-            verify the integrity and authenticity of the results of a <a>DID Resolution</a> process
-            as far as the <a>DID resolver</a> itself is concerned. However, they do not guarantee that the result
-            from the "Resolve" operation of the applicable <a>DID method</a> is itself correct.
-            See also <a href="#method-architectures"></a>.
+Note that proofs originating from a <a>DID resolver</a> are
+<a>DID method</a>-independent and can be universally applied by a
+<a>DID resolver</a>, across all DID methods. These proofs help to
+verify the integrity and authenticity of the results of a
+<a>DID Resolution</a> process as far as the
+<a>DID resolver</a> itself is concerned. However, they do not
+guarantee that the result from the "Resolve" operation of the applicable
+<a>DID method</a> is itself correct. See also
+<a href="#method-architectures"></a>.
         </p>
 
-		<section id="resolver-architectures-multiple">
-			<h2>Multiple Methods</h2>
+        <section id="resolver-architectures-multiple">
+          <h2>Multiple Methods</h2>
 
-			<p>A <a>DID resolver</a> might support the <a>DID resolution</a> algorithm for multiple <a>DID methods</a>:</p>
-			<figure id="figure-resolver-multiple">
-				<img style="margin: auto; display: block; width: 100%; margin-bottom: 20px;" src="diagrams/section-7/resolver-multiple.svg"
-					 alt="Diagram showing a DID resolver that supports multiple DID methods.">
-				<figcaption style="text-align: center;">
-					A <a>DID resolver</a> that supports multiple <a>DID methods</a>.
-				</figcaption>
-			</figure>
+          <p>
+A <a>DID resolver</a> might support the
+<a>DID resolution</a> algorithm for multiple
+<a>DID methods</a>:
+          </p>
+          <figure id="figure-resolver-multiple">
+            <img
+              style="
+                margin: auto;
+                display: block;
+                width: 100%;
+                margin-bottom: 20px;
+              "
+              src="diagrams/section-7/resolver-multiple.svg"
+              alt="Diagram showing a DID resolver that supports multiple DID methods."
+            />
+            <figcaption style="text-align: center">
+A <a>DID resolver</a> that supports multiple <a>DID methods</a>.
+            </figcaption>
+          </figure>
 
-			<p>In this case, the above considerations in <a href="#method-architectures"></a> about <a>verifiable resolution</a> and <a>unverifiable resolution</a>
-				implementations apply to each supported <a>DID method</a> individually.</p>
+          <p>
+In this case, the above considerations in <a href="#method-architectures"></a> about
+<a>verifiable resolution</a> and <a>unverifiable resolution</a>
+implementations apply to each supported <a>DID method</a>
+individually.
+          </p>
+        </section>
 
-	</section>
+        <section id="resolver-architectures-proxied">
+          <h2>Proxied Resolution</h2>
 
-	<section id="resolver-architectures-proxied">
-		<h2>Proxied Resolution</h2>
+          <p>
+A <a>DID resolver</a> MAY invoke another
+<a>DID resolver</a>, which serves as a proxy that executes the
+<a>DID resolution</a> algorithm as defined in <a href="#resolving"></a>.
+          </p>
 
-		<p>A <a>DID resolver</a> MAY invoke another <a>DID resolver</a>, which serves as a proxy that executes
-		the <a>DID resolution</a> algorithm as defined in <a href="#resolving"></a>.</p>
+          <p>
+The first <a>DID resolver</a> then acts as a
+<a>client</a> and chooses a suitable
+<a>binding</a> for invoking the second
+<a>DID resolver</a>. For example, a <a>DID resolver</a>
+may be invoked via a <a>local binding</a> (such as a command line
+tool), which in turn invokes another <a>DID resolver</a> via a
+<a>remote binding</a> (such as the <a href="#bindings-https">HTTP(S) binding</a>).
+          </p>
 
-		<p>The first <a>DID resolver</a> then acts
-		as a <a>client</a> and chooses a suitable <a>binding</a> for invoking the second <a>DID resolver</a>. For example, a <a>DID resolver</a> may be
-		invoked via a <a>local binding</a> (such as a command line tool), which in turn invokes another <a>DID resolver</a>
-		via a <a>remote binding</a> (such as the <a href="#bindings-https">HTTP(S) binding</a>).</p>
+          <p>
+When using proxied resolution, a "downstream" resolver SHOULD preserve all
+<a href="#did-resolution-metadata">DID resolution metadata</a> and
+<a href="#did-document-metadata">DID document metadata</a> from an
+"upstream" resolver in a transparent manner, including any proofs that may be
+present. In this process, the "downstream" resolver MAY add its own
+<a href="#did-resolution-metadata">DID resolution metadata</a>,
+including any metadata about the proxied resolution process itself.
+          </p>
 
-        <p>When using proxied resolution, a "downstream" resolver SHOULD preserve all
-          <a href="#did-resolution-metadata">DID resolution metadata</a> and
-          <a href="#did-document-metadata">DID document metadata</a> from an
-          "upstream" resolver in a transparent manner, including any proofs that may be
-          present. In this process, the "downstream" resolver MAY add its own
-          <a href="#did-resolution-metadata">DID resolution metadata</a>, including
-          any metadata about the proxied resolution process itself.</p>
+          <figure id="figure-resolver-proxied">
+            <img
+              style="
+                margin: auto;
+                display: block;
+                width: 100%;
+                margin-bottom: 20px;
+              "
+              src="diagrams/section-7/resolver-proxied.svg"
+              alt="Diagram showing two DID resolvers, one invoked via 'local binding', the other invoked via 'remote binding'."
+            />
+            <figcaption style="text-align: center">
+A <a>client</a> invokes a <a>DID resolver</a> via
+<a>local binding</a>, which invokes another
+<a>DID resolver</a> via <a>remote binding</a>, which in
+turn executes the resolution operation of the <a>DID method</a>.
+            </figcaption>
+          </figure>
 
-		<figure id="figure-resolver-proxied">
-			<img style="margin: auto; display: block; width: 100%; margin-bottom: 20px;" src="diagrams/section-7/resolver-proxied.svg"
-			alt="Diagram showing two DID resolvers, one invoked via 'local binding', the other invoked via 'remote binding'.">
-			<figcaption style="text-align: center;">
-				A <a>client</a> invokes a <a>DID resolver</a> via <a>local binding</a>, which invokes another <a>DID resolver</a> via
-				<a>remote binding</a>, which in turn executes the resolution operation of the <a>DID method</a>.
-			</figcaption>
-		</figure>
+          <p class="note" title="Comparison to DNS">
+This is similar to a "stub resolver" invoking a "recursive resolver" in DNS
+architecture, although the concepts are not entirely comparable (DNS Resolution
+uses a single concrete protocol, whereas DID resolution is an abstract function
+realized by different <a>DID methods</a> and different
+<a>bindings</a>).
+          </p>
+        </section>
 
-		<p class="note" title="Comparison to DNS">This is similar to a "stub resolver" invoking a "recursive resolver" in DNS architecture, although
-		the concepts are not entirely comparable (DNS Resolution uses a single concrete protocol, whereas DID resolution
-		is an abstract function realized by different <a>DID methods</a> and different <a>bindings</a>).</p>
+        <section id="resolver-architectures-client-side">
+          <h2>Client-Side Dereferencing</h2>
 
-	</section>
+          <p>
+Different parts of the <a href="#dereferencing">DID URL dereferencing</a>
+algorithm may be performed by different components of a
+<a href="#resolver-architectures">Resolver Architecture</a>.
+          </p>
 
-	<section id="resolver-architectures-client-side">
-		<h2>Client-Side Dereferencing</h2>
+          <p>
+Specifically, when a <a>DID URL</a> with a
+<a>DID fragment</a> is dereferenced, then
+<a href="#dereferencing-algorithm-resource">Dereferencing the Resource</a>
+is done by the <a>DID resolver</a>, and
+<a href="#dereferencing-algorithm-fragment">Dereferencing the Fragment</a>
+is done by the <a>client</a>.
+          </p>
+        </section>
+      </section>
 
-		<p>Different parts of the <a href="#dereferencing">DID URL dereferencing</a>
-		algorithm may be performed by different components of a <a href="#resolver-architectures">Resolver Architecture</a>.</p>
+      <section>
+        <h2>Examples</h2>
 
-		<p>Specifically, when a <a>DID URL</a> with a <a>DID fragment</a> is dereferenced, then
-		<a href="#dereferencing-algorithm-resource">Dereferencing the Resource</a> is done by
-		the <a>DID resolver</a>, and
-		<a href="#dereferencing-algorithm-fragment">Dereferencing the Fragment</a> is done by the <a>client</a>.</p>
-	</section>
+        <p>
+Given the <a>DID URL</a>
+<code>did:xyz:1234#keys-1</code>, a <a>DID resolver</a>
+could be invoked via <a>local binding</a> for
+<a href="#dereferencing-algorithm-resource">Dereferencing the Resource</a>
+(i.e., the <a>DID document</a>), and the <a>client</a> could complete the
+<a>DID URL dereferencing</a> algorithm by
+<a href="#dereferencing-algorithm-fragment">Dereferencing the Fragment</a>
+(i.e., a part of the <a>DID document</a>).
+        </p>
 
-	</section>
+        <figure id="figure-client-side-dereferencing-1">
+          <img
+            style="display: block; width: 100%; margin-bottom: 20px"
+            src="diagrams/section-7/client-side-dereferencing-1.svg"
+            alt="Diagram showing client-side dereferencing of a DID URL by a DID resolver and a client"
+          />
+          <figcaption style="text-align: center">
+Client-side dereferencing of a <a>DID URL</a> by a
+<a>DID resolver</a> and a <a>client</a>.
+          </figcaption>
+        </figure>
 
-	<section>
-		<h2>Examples</h2>
+        <p>
+Given the <a>DID URL</a>
+<code>did:xyz:1234?service=agent&relativeRef=%2Fsome%2Fpath%3Fquery#frag</code>,
+a <a>DID resolver</a> could be invoked for
+<a href="#dereferencing-algorithm-resource">Dereferencing the Resource</a>
+(i.e., a [=DID service endpoint=] URL), and the <a>client</a> could complete the
+<a>DID URL dereferencing</a> algorithm by
+<a href="#dereferencing-algorithm-fragment">Dereferencing the Fragment</a>
+(i.e., a [=DID service endpoint=] URL with a fragment).
+        </p>
 
-		<p>Given the <a>DID URL</a> <code>did:xyz:1234#keys-1</code>, a <a>DID resolver</a> could be invoked
-		via <a>local binding</a>
-		for <a href="#dereferencing-algorithm-resource">Dereferencing the Resource</a> (i.e., the <a>DID document</a>),
-		and the <a>client</a> could complete the <a>DID URL dereferencing</a> algorithm by
-		<a href="#dereferencing-algorithm-fragment">Dereferencing the Fragment</a> (i.e., a part of the <a>DID document</a>).</p>
+        <figure id="figure-client-side-dereferencing-2">
+          <img
+            style="
+              margin: auto;
+              display: block;
+              width: 100%;
+              margin-bottom: 20px;
+            "
+            src="diagrams/section-7/client-side-dereferencing-2.svg"
+            alt="Diagram showing client-side dereferencing of a DID URL by a DID resolver and a client"
+          />
+          <figcaption style="text-align: center">
+Client-side dereferencing of a <a>DID URL</a> by a
+<a>DID resolver</a> and a <a>client</a>.
+          </figcaption>
+        </figure>
 
-		<figure id="figure-client-side-dereferencing-1">
-			<img style="display: block; width: 100%; margin-bottom: 20px;" src="diagrams/section-7/client-side-dereferencing-1.svg"
-			alt="Diagram showing client-side dereferencing of a DID URL by a DID resolver and a client">
-			<figcaption style="text-align: center;">
-				Client-side dereferencing of a <a>DID URL</a> by a <a>DID resolver</a> and a <a>client</a>.
-			</figcaption>
-		</figure>
+        <p>
+Given the <a>DID URL</a> <code>did:xyz:1234#keys-1</code>, a <a>DID resolver</a>
+could be invoked via <a>local binding</a>, which invokes
+another <a>DID resolver</a> via <a>remote binding</a> for
+<a href="#dereferencing-algorithm-resource">Dereferencing the Resource</a>
+(i.e., the <a>DID document</a>), and the <a>client</a> could complete the
+<a>DID URL dereferencing</a> algorithm by
+<a href="#dereferencing-algorithm-fragment">Dereferencing the Fragment</a>
+(i.e., a part of the <a>DID document</a>).
+        </p>
 
-		<p>Given the <a>DID URL</a> <code>did:xyz:1234?service=agent&relativeRef=%2Fsome%2Fpath%3Fquery#frag</code>, a <a>DID resolver</a> could be invoked
-			for <a href="#dereferencing-algorithm-resource">Dereferencing the Resource</a> (i.e., a [=DID service endpoint=] URL),
-			and the <a>client</a> could complete the <a>DID URL dereferencing</a> algorithm by
-			<a href="#dereferencing-algorithm-fragment">Dereferencing the Fragment</a> (i.e., a [=DID service endpoint=] URL with a fragment).</p>
+        <figure id="figure-client-side-dereferencing-3">
+          <img
+            style="
+              margin: auto;
+              display: block;
+              width: 100%;
+              margin-bottom: 20px;
+            "
+            src="diagrams/section-7/client-side-dereferencing-3.svg"
+            alt="Diagram showing client-side dereferencing of a DID URL by two DID resolvers and a client"
+          />
+          <figcaption style="text-align: center">
+Client-side dereferencing (in combination with <a href="#resolver-architectures-proxied">Proxied Resolution</a>)
+of a <a>DID URL</a> by two <a>DID resolvers</a> and
+a <a>client</a>.
+          </figcaption>
+        </figure>
+      </section>
+    </section>
 
-		<figure id="figure-client-side-dereferencing-2">
-			<img style="margin: auto; display: block; width: 100%; margin-bottom: 20px;" src="diagrams/section-7/client-side-dereferencing-2.svg"
-				 alt="Diagram showing client-side dereferencing of a DID URL by a DID resolver and a client">
-			<figcaption style="text-align: center;">
-				Client-side dereferencing of a <a>DID URL</a> by a <a>DID resolver</a> and a <a>client</a>.
-			</figcaption>
-		</figure>
+    <section id="did-resolution-result">
+      <h1>DID Resolution Result</h1>
+      <p>
+This section defines a JSON data structure that represents the result of the
+algorithm described in <a href="#resolving"></a>. A
+<a>DID resolution result</a> contains the <a>DID document</a> as
+well as <a href="#did-resolution-metadata">DID resolution metadata</a> and
+<a href="#did-document-metadata">DID document metadata</a>.
+      </p>
 
-		<p>Given the <a>DID URL</a> <code>did:xyz:1234#keys-1</code>, a <a>DID resolver</a> could be invoked via
-		<a>local binding</a>, which invokes another <a>DID resolver</a> via <a>remote binding</a>
-		for <a href="#dereferencing-algorithm-resource">Dereferencing the Resource</a> (i.e., the <a>DID document</a>),
-		and the <a>client</a> could complete the <a>DID URL dereferencing</a> algorithm by
-		<a href="#dereferencing-algorithm-fragment">Dereferencing the Fragment</a> (i.e., a part of the <a>DID document</a>).</p>
+      <p>
+The media type of this data structure is defined to be
+`application/did-resolution`.
+      </p>
 
-		<figure id="figure-client-side-dereferencing-3">
-			<img style="margin: auto; display: block; width: 100%; margin-bottom: 20px;" src="diagrams/section-7/client-side-dereferencing-3.svg"
-			alt="Diagram showing client-side dereferencing of a DID URL by two DID resolvers and a client">
-			<figcaption style="text-align: center;">
-				Client-side dereferencing (in combination with <a href="#resolver-architectures-proxied">Proxied Resolution</a>)
-				of a <a>DID URL</a> by two <a>DID resolvers</a> and a <a>client</a>.
-			</figcaption>
-		</figure>
+      <section>
+        <h2>Example</h2>
 
-	</section>
-
-</section>
-
-<section id="did-resolution-result">
-	<h1>DID Resolution Result</h1>
-	<p>This section defines a JSON data structure that represents the result of the algorithm described
-	in <a href="#resolving"></a>. A <a>DID resolution result</a> contains
-	the <a>DID document</a> as well as
-	<a href="#did-resolution-metadata">DID resolution metadata</a> and <a href="#did-document-metadata">DID
-	document metadata</a>.</p>
-
-	<p>The media type of this data structure is defined to be `application/did-resolution`.</p>
-
-	<section>
-		<h2>Example</h2>
-
-		<pre class="example nohighlight" title="Example DID resolution result">
+<pre class="example nohighlight" title="Example DID resolution result">
 {
 	"didDocument": {
 		"@context": "https://www.w3.org/ns/did/v1",
@@ -2297,26 +2846,32 @@ dereference(didUrl, dereferenceOptions) →
 		}
 	}
 }
-		</pre>
+</pre>
+      </section>
+    </section>
 
-	</section>
+    <section id="did-url-dereferencing-result">
+      <h1>DID URL Dereferencing Result</h1>
+      <p>
+This section defines a JSON data structure that represents the result of the
+algorithm described in <a href="#dereferencing"></a>. A
+<a>DID URL dereferencing result</a> contains the content as well as
+<a href="#did-url-dereferencing-metadata">DID URL dereferencing metadata</a>
+and <a href="#did-url-content-metadata"> DID URL content metadata</a>.
+      </p>
 
-</section>
+      <p>
+The media type of this data structure is defined to be
+`application/did-url-dereferencing`.
+      </p>
 
-<section id="did-url-dereferencing-result">
-	<h1>DID URL Dereferencing Result</h1>
-	<p>This section defines a JSON data structure that represents the result of the algorithm described
-		in <a href="#dereferencing"></a>. A <a>DID URL dereferencing result</a> contains
-		the content as well as
-		<a href="#did-url-dereferencing-metadata">DID URL dereferencing metadata</a> and <a href="#did-url-content-metadata">
-			DID URL content metadata</a>.</p>
+      <section>
+        <h2>Example</h2>
 
-	<p>The media type of this data structure is defined to be `application/did-url-dereferencing`.</p>
-
-	<section>
-		<h2>Example</h2>
-
-		<pre class="example nohighlight" title="Example DID URL dereferencing result">
+<pre
+	class="example nohighlight"
+	title="Example DID URL dereferencing result"
+>
 {
 	"content": {
 		"@context": "https://www.w3.org/ns/did/v1",
@@ -2370,382 +2925,546 @@ dereference(didUrl, dereferenceOptions) →
 	}
 }
 </pre>
+      </section>
+    </section>
 
-	</section>
-</section>
+    <section id="errors">
+      <h1>Errors</h1>
+      <p>
+The algorithms described in this specification throw specific types of errors.
+Implementers might find it useful to convey these errors to other libraries or
+software systems. This section provides specific URLs and descriptions for the
+errors, such that an ecosystem implementing technologies described by this
+specification might interoperate more effectively when errors occur.
+Additionally, this specification uses some errors defined in
+<a data-cite="CID#processing-errors">Section 3.5 Processing Errors</a>
+of the [[CID]] specification.
+      </p>
 
-<section id="errors">
-	<h1>Errors</h1>
-	<p>
-		The algorithms described in this specification throw specific types of errors.
-		Implementers might find it useful to convey these errors to other libraries or
-		software systems. This section provides specific URLs and descriptions for the errors,
-		such that an ecosystem implementing technologies described
-		by this specification might interoperate more effectively when errors occur. Additionally,
-		this specification uses some errors defined in <a data-cite="CID#processing-errors">Section
-		3.5 Processing Errors</a> of the [[CID]] specification.
-	</p>
+      <p>
+Implementers SHOULD use [[RFC9457]] to encode the error data structure. If
+[[RFC9457]] is used:
+      </p>
 
-	<p>
-		Implementers SHOULD use
-		[[RFC9457]] to encode the error data structure. If [[RFC9457]] is used:
-	</p>
-
-	<ul>
-		<li>
-The `type` value of the error object MUST be a URL. Where the values listed
-in the section below do not define a URL, the values MUST be prepended with the
-URL `https://www.w3.org/ns/did#`.
-		</li>
-		<li>
+      <ul>
+        <li>
+The `type` value of the error object MUST be a URL. Where the values listed in
+the section below do not define a URL, the values MUST be prepended with the URL
+`https://www.w3.org/ns/did#`.
+        </li>
+        <li>
 The `title` value SHOULD provide a short but specific human-readable string for
 the error.
-		</li>
-		<li>
+        </li>
+        <li>
 The `detail` value SHOULD provide a longer human-readable string for the error.
-		</li>
-	</ul>
+        </li>
+      </ul>
 
-	<dl>
-		<dt id="INVALID_DID">INVALID_DID</dt>
-		<dd>
-			An invalid DID was detected during <a>DID Resolution</a>. See Section <a href="#resolving-algorithm"></a>.
-			<div><code>https://www.w3.org/ns/did#INVALID_DID</code></div>
-		</dd>
-		<dt id="INVALID_DID_DOCUMENT">INVALID_DID_DOCUMENT</dt>
-		<dd>
-			The [=DID document=] was malformed. See Section <a href="#resolving-algorithm"></a>.
-			<div><code>https://www.w3.org/ns/did#INVALID_DID_DOCUMENT</code></div>
-		</dd>
-		<dt id="NOT_FOUND">NOT_FOUND</dt>
-		<dd>
-			The <a>DID resolver</a> was unable to find the <a>DID document</a>
-			resulting from this resolution request. See Section <a href="#resolving-algorithm"></a>.
-			<div><code>https://www.w3.org/ns/did#NOT_FOUND</code></div>
-		</dd>
-		<dt id="REPRESENTATION_NOT_SUPPORTED">REPRESENTATION_NOT_SUPPORTED</dt>
-		<dd>
-			The <a>representation</a> requested via the <code>accept</code> DID URL dereferencing option
-			is not supported by the <a>DID method</a> and/or <a>DID URL dereferencer</a> implementation.
-			See Section <a href="#dereferencing-algorithm"></a>.
-			<div><code>https://www.w3.org/ns/did#REPRESENTATION_NOT_SUPPORTED</code></div>
-		</dd>
-		<dt id="INVALID_DID_URL">INVALID_DID_URL</dt>
-		<dd>
-			An invalid <a>DID URL</a> was detected during <a>DID URL dereferencing</a>.
-			See Section <a href="#dereferencing-algorithm"></a>
-			<div><code>https://www.w3.org/ns/did#INVALID_DID_URL</code></div>
-		</dd>
-		<dt id="METHOD_NOT_SUPPORTED">METHOD_NOT_SUPPORTED</dt>
-		<dd>
-			The DID method of the DID is not supported by the <a>DID resolver</a>. See Section <a
-				href="#resolving-algorithm"></a>.
-			<div><code>https://www.w3.org/ns/did#METHOD_NOT_SUPPORTED</code></div>
-		</dd>
-		<dt id="INVALID_OPTIONS">INVALID_OPTIONS</dt>
-		<dd>
-			One or more of the options provided for <a>DID Resolution</a> or <a>DID URL dereferencing</a> are invalid.
-			<div><code>https://www.w3.org/ns/did#INVALID_OPTIONS</code></div>
-		</dd>
-		<dt id="INTERNAL_ERROR">INTERNAL_ERROR</dt>
-		<dd>
-			An unexpected error occured during <a>DID Resolution</a> or <a>DID URL dereferencing</a>.
-			<div><code>https://www.w3.org/ns/did#INTERNAL_ERROR</code></div>
-		</dd>
-		<dt id="FEATURE_NOT_SUPPORTED">FEATURE_NOT_SUPPORTED</dt>
-		<dd>
-			The <a>DID resolver</a> does not support the requested feature. The value of the `detail` field
-			SHOULD provide a longer description of the feature that is not supported by the resolver.
-			<div><code>https://www.w3.org/ns/did#FEATURE_NOT_SUPPORTED</code></div>
-		</dd>
-	</dl>
+      <dl>
+        <dt id="INVALID_DID">INVALID_DID</dt>
+        <dd>
+An invalid DID was detected during <a>DID Resolution</a>.
+See Section <a href="#resolving-algorithm"></a>.
+<div><code>https://www.w3.org/ns/did#INVALID_DID</code></div>
+        </dd>
+        <dt id="INVALID_DID_DOCUMENT">INVALID_DID_DOCUMENT</dt>
+        <dd>
+The [=DID document=] was malformed. See Section
+<a href="#resolving-algorithm"></a>.
+<div><code>https://www.w3.org/ns/did#INVALID_DID_DOCUMENT</code></div>
+        </dd>
+        <dt id="NOT_FOUND">NOT_FOUND</dt>
+        <dd>
+The <a>DID resolver</a> was unable to find the
+<a>DID document</a> resulting from this resolution
+request. See Section <a href="#resolving-algorithm"></a>.
+<div><code>https://www.w3.org/ns/did#NOT_FOUND</code></div>
+        </dd>
+        <dt id="REPRESENTATION_NOT_SUPPORTED">REPRESENTATION_NOT_SUPPORTED</dt>
+        <dd>
+The <a>representation</a> requested via the
+<code>accept</code> DID URL dereferencing option is not supported by
+the <a>DID method</a> and/or
+<a>DID URL dereferencer</a> implementation. See Section
+<a href="#dereferencing-algorithm"></a>.
+<div>
+<code>https://www.w3.org/ns/did#REPRESENTATION_NOT_SUPPORTED</code>
+</div>
+        </dd>
+        <dt id="INVALID_DID_URL">INVALID_DID_URL</dt>
+        <dd>
+An invalid <a>DID URL</a> was detected during
+<a>DID URL dereferencing</a>. See Section
+<a href="#dereferencing-algorithm"></a>
+<div><code>https://www.w3.org/ns/did#INVALID_DID_URL</code></div>
+        </dd>
+        <dt id="METHOD_NOT_SUPPORTED">METHOD_NOT_SUPPORTED</dt>
+        <dd>
+The DID method of the DID is not supported by the
+<a>DID resolver</a>. See Section <a href="#resolving-algorithm"></a>.
+<div><code>https://www.w3.org/ns/did#METHOD_NOT_SUPPORTED</code></div>
+        </dd>
+        <dt id="INVALID_OPTIONS">INVALID_OPTIONS</dt>
+        <dd>
+One or more of the options provided for
+<a>DID Resolution</a> or <a>DID URL dereferencing</a> are
+invalid.
+<div><code>https://www.w3.org/ns/did#INVALID_OPTIONS</code></div>
+        </dd>
+        <dt id="INTERNAL_ERROR">INTERNAL_ERROR</dt>
+        <dd>
+An unexpected error occured during <a>DID Resolution</a> or
+<a>DID URL dereferencing</a>.
+<div><code>https://www.w3.org/ns/did#INTERNAL_ERROR</code></div>
+        </dd>
+        <dt id="FEATURE_NOT_SUPPORTED">FEATURE_NOT_SUPPORTED</dt>
+        <dd>
+The <a>DID resolver</a> does not support the requested
+feature. The value of the `detail` field SHOULD provide a longer
+description of the feature that is not supported by the resolver.
+<div>
+<code>https://www.w3.org/ns/did#FEATURE_NOT_SUPPORTED</code>
+</div>
+        </dd>
+      </dl>
+    </section>
 
+    <section id="bindings">
+      <h1>Bindings</h1>
+      <p>
+This section defines bindings for the abstract algorithms in sections
+<a href="#resolving"></a> and <a href="#dereferencing"></a>.
+      </p>
 
-</section>
+      <section id="bindings-https">
+        <h2>HTTP(S) Binding</h2>
+        <p>
+This section defines a <a>DID resolver</a>
+<a>binding</a> which exposes the
+<a>DID resolution</a> and/or <a>DID URL dereferencing</a> functions
+(including all resolution/dereferencing options and metadata) via an HTTP(S)
+endpoint. See <a href="#resolver-architectures"></a>.
+        </p>
 
-<section id="bindings">
-	<h1>Bindings</h1>
-	<p>This section defines bindings for the abstract algorithms in sections <a href="#resolving"></a> and
-	<a href="#dereferencing"></a>.</p>
+        <p class="note">
+Use of an HTTP(S) resolver creates a reliance on a remote party and the privacy
+of the requestor may be reduced through the inclusion of various HTTP headers
+such as `Referer`, `Origin`, `Cookies`, and `Authorization`. Additionally,
+caching by a component between the <a>client</a> and the
+<a>DID resolver</a> may further reduce the privacy of the request.
+        </p>
 
-	<section id="bindings-https">
-		<h2>HTTP(S) Binding</h2>
-		<p>This section defines a <a>DID resolver</a> <a>binding</a> which exposes the
-			<a>DID resolution</a> and/or <a>DID URL dereferencing</a> functions (including all
-			resolution/dereferencing options and metadata) via an HTTP(S) endpoint. See <a href="#resolver-architectures"></a>.</p>
+        <p>
+The HTTP(S) binding requires a known HTTP(S) URL where a
+<a>DID resolver</a> can be invoked. This URL is called the
+<var><a>DID resolver</a> HTTP(S) endpoint</var>.
+        </p>
 
-		<p class="note">
-			Use of an HTTP(S) resolver creates a reliance on a remote party and the
-			privacy of the requestor may be reduced through the inclusion of various
-			HTTP headers such as `Referer`, `Origin`, `Cookies`, and `Authorization`.
-			Additionally, caching by a component between the <a>client</a> and the <a>DID
-			resolver</a> may further reduce the privacy of the request.
-		</p>
+        <p>
+This binding is generally considered a
+<a>remote binding</a>, but could also be a
+<a>local binding</a> if the HTTP(S) endpoint is run in a
+local environment, such as on <code>localhost</code>.
+        </p>
 
-		<p>The HTTP(S) binding requires a known HTTP(S) URL where a <a>DID resolver</a> can be invoked. This URL is called the
-			<var><a>DID resolver</a> HTTP(S) endpoint</var>.</p>
+        <p>
+All <a href="#dfn-conforming-network-based-did-resolver">conforming DID resolvers</a>
+MUST implement the GET version of the <a href="#bindings-https">HTTPS binding</a>
+and MAY implement the POST version. All <a href="#bindings-https">HTTPS bindings</a>
+MUST use TLS. Use of DNS names in certificates is NOT REQUIRED;
+resolvers MAY use TLS certificates issued for IP addresses.
+        </p>
 
-		<p>This binding is generally considered a <a>remote binding</a>, but could
-			also be a <a>local binding</a> if the HTTP(S) endpoint is run in a local environment, such as on <code>localhost</code>.</p>
+        <p>
+Using this binding, the <a>DID resolution</a> function (see
+<a href="#resolving"></a>) and/or <a>DID URL dereferencing</a> function
+(see <a href="#dereferencing"></a>) can be executed as follows:
+        </p>
 
-		<p>
-			All <a href="#dfn-conforming-network-based-did-resolver">conforming DID resolvers</a> MUST implement the GET version of the
-			<a href="#bindings-https">HTTPS binding</a> and MAY implement the POST version.
-			All <a href="#bindings-https">HTTPS bindings</a> MUST use TLS. Use of DNS names
-			in certificates is NOT REQUIRED; resolvers MAY use TLS certificates issued for IP addresses.
-		</p>
-
-		<p>Using this binding, the <a>DID resolution</a> function (see
-			<a href="#resolving"></a>) and/or <a>DID URL dereferencing</a> function (see <a href="#dereferencing"></a>)
-			can be executed as follows:</p>
-
-		<ol class="algorithm">
-			<li>Initialize a <var>request HTTP(S) URL</var> with the <var><a>DID resolver</a> HTTP(S) endpoint</var>.
-			<pre class="example nohighlight">https://resolver.example/1.0/identifiers/</pre></li>
-			<li>For the <a>DID resolution</a> function:
-				<ol class="algorithm">
-					<li>Append the <var>input <a>DID</a></var> to the <var>request HTTP(S) URL</var>.
-					<pre class="example nohighlight">https://resolver.example/1.0/identifiers/did:example:1234</pre></li>
-					<li>Set the <code>Accept</code> <var>HTTP request header</var> to `application/did-resolution`
-						to request a complete <a href="#did-resolution-result"></a>, OR</li>
-					<li>set the <code>Accept</code> <var>HTTP request header</var> to the value of the <b>accept</b> <var>resolution option</var>
-                        to request only the <b>didDocument</b> value of the result.</li>
-				</ol>
-			</li>
-			<li>For the <a>DID URL dereferencing</a> function:
-				<ol class="algorithm">
-					<li>Append the <var>input <a>DID URL</a></var> to the <var>request HTTP(S) URL</var>.
-					<pre class="example nohighlight">https://resolver.example/1.0/identifiers/did:example:1234?service=files&relativeRef=/resume.pdf</pre></li>
-					<li>Set the <code>Accept</code> <var>HTTP request header</var> to `application/did-url-dereferencing`
-						to request a complete <a href="#did-url-dereferencing-result"></a>, OR</li>
-					<li>set the <code>Accept</code> <var>HTTP request header</var> to the value of the <b>accept</b> <var>dereferencing option</var>
-                        to request only the <b>contentStream</b> value of the result.</li>
-				</ol>
-			</li>
-            <li>For the HTTP(S) GET binding:
-                <ol class="algorithm">
-                    <li>If any other <var>resolution options</var> or <var>dereferencing options</var> than <b>accept</b> are provided:
-                        <ol class="algorithm">
-                            <li>The <var>input <a>DID</a></var> MUST be URL-encoded (as specified in <a
-                                    data-cite="RFC3986#section-2.1">RFC3986 Section 2.1</a>).</li>
-                            <li>Encode all <var>resolution options</var> except <b>accept</b> as
-                                query parameters in the <var>request HTTP(S) URL</var>.
-                        </ol>
-                    </li>
-                    <li>Execute an HTTP <code>GET</code> request on the <var>request HTTP(S) URL</var>. This invokes the <a>DID resolution</a> or
-                        <a>DID URL dereferencing</a> function at the remote <a>DID resolver</a>.
-                        <pre class="example nohighlight">GET https://resolver.example/1.0/identifiers/did%3Aexample%3A1234?option1=value1&option2=value2 HTTP/1.1
-Accept: application/did-resolution
+        <ol class="algorithm">
+          <li>
+Initialize a <var>request HTTP(S) URL</var> with the
+<var><a>DID resolver</a> HTTP(S) endpoint</var>.
+<pre class="example nohighlight">
+https://resolver.example/1.0/identifiers/
 </pre>
-                        <pre class="example nohighlight">GET https://resolver.example/1.0/identifiers/did%3Aexample%3A1234%3Fservice%3Dfiles%26relativeRef%3D%2Fresume.pdf?option1=value1&option2=value2 HTTP/1.1
-Accept: application/did-url-dereferencing
+          </li>
+          <li>
+For the <a>DID resolution</a> function:
+<ol class="algorithm">
+<li>
+Append the <var>input <a>DID</a></var> to
+the <var>request HTTP(S) URL</var>.
+<pre class="example nohighlight">
+https://resolver.example/1.0/identifiers/did:example:1234
 </pre>
-                    </li>
-                </ol>
-            </li>
-            <li>For the HTTP(S) POST binding:
-            <ol class="algorithm">
-                <li>If any other <var>resolution options</var> or <var>dereferencing options</var> than <b>accept</b> are provided:
-                    <ol class="algorithm">
-                        <li>Encode all <var>resolution options</var> except <b>accept</b> as
-                            a JSON structure in the HTTP request's POST body.
-                    </ol>
-                </li>
-                <li>Execute an HTTP <code>POST</code> request on the <var>request HTTP(S) URL</var>. This invokes the <a>DID resolution</a> or
-                    <a>DID URL dereferencing</a> function at the remote <a>DID resolver</a>.
-                    <pre class="example nohighlight">POST https://resolver.example/1.0/identifiers/did:example:1234 HTTP/1.1
-Accept: application/did-resolution
-
-{
-    "option1": "value1",
-    "option2": "value2"
-}</pre>
-                    <pre class="example nohighlight">POST https://resolver.example/1.0/identifiers/did:example:1234?service=files&relativeRef=/resume.pdf HTTP/1.1
-Accept: application/did-url-dereferencing
-
-{
-    "option1": "value1",
-    "option2": "value2"
-}</pre>
+              </li>
+              <li>
+Set the <code>Accept</code> <var>HTTP request header</var> to
+`application/did-resolution` to request a complete
+<a href="#did-resolution-result"></a>, OR
+              </li>
+              <li>
+set the <code>Accept</code> <var>HTTP request header</var> to
+the value of the <b>accept</b> <var>resolution option</var> to
+request only the <b>didDocument</b> value of the result.
+              </li>
             </ol>
-            </li>
-						<li>If the <a>DID resolution</a> or <a>DID URL dereferencing</a> function returns an <b>error</b> metadata property in the
-                <b>didResolutionMetadata</b> or <b>dereferencingMetadata</b>,
-                then the HTTP response status code MUST correspond to the <code>type</code> property of the <b>error object</b>,
-                according to the following table:
-                <table class="simple">
-                    <thead>
-                        <tr>
-                            <th>
-                                error <code>type</code> URI
-                            </th>
-                            <th>
-                                HTTP status code
-                            </th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>
-                            <td>
-                                <code><a href="https://www.w3.org/ns/did#INVALID_DID">https://www.w3.org/ns/did#INVALID_DID</a></code>
-                            </td>
-                            <td>
-                                <code>400</code>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>
-                                <code><a href="https://www.w3.org/ns/did#INVALID_DID_URL">https://www.w3.org/ns/did#INVALID_DID_URL</a></code>
-                            </td>
-                            <td>
-                                <code>400</code>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>
-                                <code><a href="https://www.w3.org/ns/did#INVALID_OPTIONS">https://www.w3.org/ns/did#INVALID_OPTIONS</a></code>
-                            </td>
-                            <td>
-                                <code>400</code>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>
-                                <code><a href="https://www.w3.org/ns/did#NOT_FOUND">https://www.w3.org/ns/did#NOT_FOUND</a></code>
-                            </td>
-                            <td>
-                                <code>404</code>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>
-                                <code><a href="https://www.w3.org/ns/did#REPRESENTATION_NOT_SUPPORTED">https://www.w3.org/ns/did#REPRESENTATION_NOT_SUPPORTED</a></code>
-                            </td>
-                            <td>
-                                <code>406</code>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>
-                                <code><a href="https://www.w3.org/ns/did#INVALID_DID_DOCUMENT">https://www.w3.org/ns/did#INVALID_DID_DOCUMENT</a></code>
-                            </td>
-                            <td>
-                                <code>500</code>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>
-                                <code><a href="https://www.w3.org/ns/did#METHOD_NOT_SUPPORTED">https://www.w3.org/ns/did#METHOD_NOT_SUPPORTED</a></code>
-                            </td>
-                            <td>
-                                <code>501</code>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>
-                                <code><a href="https://www.w3.org/ns/did#FEATURE_NOT_SUPPORTED">https://www.w3.org/ns/did#FEATURE_NOT_SUPPORTED</a></code>
-                            </td>
-                            <td>
-                                <code>501</code>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>
-                                <code><a href="https://www.w3.org/ns/did#INTERNAL_ERROR">https://www.w3.org/ns/did#INTERNAL_ERROR</a></code>
-                            </td>
-                            <td>
-                                <code>500</code>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>
-                                (any other error URI)
-                            </td>
-                            <td>
-                                <code>500</code>
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </li>
-			<li>If the <a>DID resolution</a> or <a>DID URL dereferencing</a> function returns a <b>deactivated</b> metadata property with
-				the value <code>true</code> in the <b>didDocumentMetadata</b> or <b>contentMetadata</b>:
-				<ol class="algorithm">
-					<li>The HTTP response status code MUST be <code>410</code>.</li>
-				</ol>
-			</li>
-			<li>For the <a>DID resolution</a> function:
-				<ol class="algorithm">
-					<li>If the value of the <code>Content-Type</code> <var>HTTP response header</var> is `application/did-resolution`:
+          </li>
+          <li>
+For the <a>DID URL dereferencing</a> function:
 						<ol class="algorithm">
-							<li>The <var>HTTP body</var> MUST contain a <a>DID resolution result</a> (see <a href="#did-resolution-result"></a>) that
-								is the result of the <a>DID resolution</a> function.</li>
-						</ol>
-					</li>
-					<li>If the function is successful and returns a <b>didDocument</b>:
+							<li>
+Append the <var>input <a>DID URL</a></var> to
+the <var>request HTTP(S) URL</var>.
+<pre class="example nohighlight">
+https://resolver.example/1.0/identifiers/did:example:1234?service=files&relativeRef=/resume.pdf
+</pre>
+              </li>
+              <li>
+Set the <code>Accept</code> <var>HTTP request header</var> to
+`application/did-url-dereferencing` to request a complete
+<a href="#did-url-dereferencing-result"></a>, OR
+              </li>
+              <li>
+set the <code>Accept</code> <var>HTTP request header</var> to
+the value of the <b>accept</b>
+<var>dereferencing option</var> to request only the
+<b>contentStream</b> value of the result.
+              </li>
+            </ol>
+          </li>
+          <li>
+For the HTTP(S) GET binding:
 						<ol class="algorithm">
-							<li>The HTTP response status code MUST be <code>200</code>.</li>
-							<li>The HTTP response MUST contain a <code>Content-Type</code> <var>HTTP response header</var>. Its value MUST be the value of the
-								<b>contentType</b> metadata property in the <b>didResolutionMetadata</b> (see <a href="#did-resolution-metadata"></a>).</li>
-							<li>The HTTP response body MUST contain the <b>didDocument</b> that is the result of the
-								<a>DID resolution</a> function, in the representation corresponding to the <code>Content-Type</code> <var>HTTP response header</var>.</li>
-						</ol>
-					</li>
-				</ol>
-			</li>
-			<li>For the <a>DID URL dereferencing</a> function:
-				<ol class="algorithm">
-					<li>If the value of the <code>Content-Type</code> <var>HTTP response header</var> is `application/did-url-dereferencing`:
+							<li>
+If any other <var>resolution options</var> or
+<var>dereferencing options</var> than <b>accept</b> are
+provided:
+								<ol class="algorithm">
+									<li>
+The <var>input <a>DID</a></var> MUST be
+URL-encoded (as specified in
+<a data-cite="RFC3986#section-2.1">RFC3986 Section 2.1</a>).
+                  </li>
+                  <li>
+Encode all <var>resolution options</var> except
+<b>accept</b> as query parameters in the
+<var>request HTTP(S) URL</var>.
+                  </li>
+                </ol>
+              </li>
+              <li>
+Execute an HTTP <code>GET</code> request on the
+<var>request HTTP(S) URL</var>. This invokes the
+<a>DID resolution</a> or
+<a>DID URL dereferencing</a> function at the remote
+<a>DID resolver</a>.
+<pre class="example nohighlight">
+GET https://resolver.example/1.0/identifiers/did%3Aexample%3A1234?option1=value1&option2=value2 HTTP/1.1
+Accept: application/did-resolution
+</pre>
+<pre class="example nohighlight">
+GET https://resolver.example/1.0/identifiers/did%3Aexample%3A1234%3Fservice%3Dfiles%26relativeRef%3D%2Fresume.pdf?option1=value1&option2=value2 HTTP/1.1
+Accept: application/did-url-dereferencing
+</pre>
+              </li>
+            </ol>
+          </li>
+          <li>
+For the HTTP(S) POST binding:
 						<ol class="algorithm">
-							<li>The <var>HTTP body</var> MUST contain a <a>DID URL dereferencing result</a> (see <a href="#did-url-dereferencing-result"></a>) that
-								is the result of the <a>DID URL dereferencing</a> function.</li>
-						</ol>
-					</li>
-					<li>If the function is successful and returns a <b>contentStream</b> and a <b>contentType</b> metadata property with the value <code>text/uri-list</code> in the <b>dereferencingMetadata</b>:
-						<ol class="algorithm">
-							<li>The HTTP response status code MUST be <code>303</code>.</li>
-							<li>The HTTP response MUST contain an <code>Location</code> header. The value of this header
-								MUST be the <var>selected [=DID service endpoint=] URL</var>.</li>
-							<li>the HTTP response body MUST be empty.</li>
-						</ol>
-					</li>
-					<li>If the function is successful and returns a <b>contentStream</b> with any other <b>contentType</b>:
-						<ol class="algorithm">
-							<li>The HTTP response status code MUST be <code>200</code>.</li>
-							<li>The HTTP response MUST contain a <code>Content-Type</code> <var>HTTP response header</var>. Its value MUST be the value of the
-								<b>contentType</b> metadata property in the <b>dereferencingMetadata</b> (see <a href="#did-url-dereferencing-metadata"></a>).</li>
-							<li>The HTTP response body MUST contain the <b>contentStream</b> that is the result of the
-								<a>DID URL dereferencing</a> function, in the representation corresponding to the <code>Content-Type</code> <var>HTTP response header</var>.</li>
-						</ol>
-					</li>
-				</ol>
-			</li>
-		</ol>
+							<li>
+If any other <var>resolution options</var> or
+<var>dereferencing options</var> than <b>accept</b> are
+provided:
+								<ol class="algorithm">
+									<li>
+Encode all <var>resolution options</var> except
+<b>accept</b> as a JSON structure in the HTTP request's POST
+body.
+                  </li>
+                </ol>
+              </li>
+              <li>
+Execute an HTTP <code>POST</code> request on the
+<var>request HTTP(S) URL</var>. This invokes the
+<a>DID resolution</a> or
+<a>DID URL dereferencing</a> function at the remote
+<a>DID resolver</a>.
+<pre class="example nohighlight">
+POST https://resolver.example/1.0/identifiers/did:example:1234 HTTP/1.1
+Accept: application/did-resolution
 
-		<p class="note">
-			See <a href="openapi/openapi.yaml">here</a> for an OpenAPI definition corresponding to the HTTP(S) binding.
-		</p>
+{
+"option1": "value1",
+"option2": "value2"
+}
+</pre>
+<pre class="example nohighlight">
+POST https://resolver.example/1.0/identifiers/did:example:1234?service=files&relativeRef=/resume.pdf HTTP/1.1
+Accept: application/did-url-dereferencing
 
-	</section>
+{
+"option1": "value1",
+"option2": "value2"
+}
+</pre>
+              </li>
+            </ol>
+          </li>
+          <li>
+If the <a>DID resolution</a> or
+<a>DID URL dereferencing</a> function returns an
+<b>error</b> metadata property in the
+<b>didResolutionMetadata</b> or <b>dereferencingMetadata</b>, then
+the HTTP response status code MUST correspond to the
+<code>type</code> property of the <b>error object</b>, according to
+the following table:
+<table class="simple">
+		<thead>
+				<tr>
+						<th>
+								error <code>type</code> URI
+						</th>
+						<th>
+								HTTP status code
+						</th>
+				</tr>
+		</thead>
+		<tbody>
+				<tr>
+						<td>
+								<code><a href="https://www.w3.org/ns/did#INVALID_DID">https://www.w3.org/ns/did#INVALID_DID</a></code>
+						</td>
+						<td>
+								<code>400</code>
+						</td>
+				</tr>
+				<tr>
+						<td>
+								<code><a href="https://www.w3.org/ns/did#INVALID_DID_URL">https://www.w3.org/ns/did#INVALID_DID_URL</a></code>
+						</td>
+						<td>
+								<code>400</code>
+						</td>
+				</tr>
+				<tr>
+						<td>
+								<code><a href="https://www.w3.org/ns/did#INVALID_OPTIONS">https://www.w3.org/ns/did#INVALID_OPTIONS</a></code>
+						</td>
+						<td>
+								<code>400</code>
+						</td>
+				</tr>
+				<tr>
+						<td>
+								<code><a href="https://www.w3.org/ns/did#NOT_FOUND">https://www.w3.org/ns/did#NOT_FOUND</a></code>
+						</td>
+						<td>
+								<code>404</code>
+						</td>
+				</tr>
+				<tr>
+						<td>
+								<code><a href="https://www.w3.org/ns/did#REPRESENTATION_NOT_SUPPORTED">https://www.w3.org/ns/did#REPRESENTATION_NOT_SUPPORTED</a></code>
+						</td>
+						<td>
+								<code>406</code>
+						</td>
+				</tr>
+				<tr>
+						<td>
+								<code><a href="https://www.w3.org/ns/did#INVALID_DID_DOCUMENT">https://www.w3.org/ns/did#INVALID_DID_DOCUMENT</a></code>
+						</td>
+						<td>
+								<code>500</code>
+						</td>
+				</tr>
+				<tr>
+						<td>
+								<code><a href="https://www.w3.org/ns/did#METHOD_NOT_SUPPORTED">https://www.w3.org/ns/did#METHOD_NOT_SUPPORTED</a></code>
+						</td>
+						<td>
+								<code>501</code>
+						</td>
+				</tr>
+				<tr>
+						<td>
+								<code><a href="https://www.w3.org/ns/did#FEATURE_NOT_SUPPORTED">https://www.w3.org/ns/did#FEATURE_NOT_SUPPORTED</a></code>
+						</td>
+						<td>
+								<code>501</code>
+						</td>
+				</tr>
+				<tr>
+						<td>
+								<code><a href="https://www.w3.org/ns/did#INTERNAL_ERROR">https://www.w3.org/ns/did#INTERNAL_ERROR</a></code>
+						</td>
+						<td>
+								<code>500</code>
+						</td>
+				</tr>
+				<tr>
+						<td>
+								(any other error URI)
+						</td>
+						<td>
+								<code>500</code>
+						</td>
+				</tr>
+		</tbody>
+</table>
+          </li>
+          <li>
+If the <a>DID resolution</a> or
+<a>DID URL dereferencing</a> function returns a
+<b>deactivated</b> metadata property with the value
+<code>true</code> in the <b>didDocumentMetadata</b> or
+<b>contentMetadata</b>:
+						<ol class="algorithm">
+							<li>The HTTP response status code MUST be <code>410</code>.</li>
+						</ol>
+          </li>
+          <li>
+For the <a>DID resolution</a> function:
+<ol class="algorithm">
+<li>
+If the value of the <code>Content-Type</code>
+<var>HTTP response header</var> is `application/did-resolution`:
+<ol class="algorithm">
+<li>
+The <var>HTTP body</var> MUST contain a
+<a>DID resolution result</a> (see
+<a href="#did-resolution-result"></a>) that is the result of the
+<a>DID resolution</a> function.
+                  </li>
+                </ol>
+              </li>
+              <li>
+If the function is successful and returns a <b>didDocument</b>:
+<ol class="algorithm">
+<li>
+The HTTP response status code MUST be <code>200</code>.
+                  </li>
+                  <li>
+The HTTP response MUST contain a <code>Content-Type</code>
+<var>HTTP response header</var>. Its value MUST be the value
+of the <b>contentType</b> metadata property in the
+<b>didResolutionMetadata</b> (see
+<a href="#did-resolution-metadata"></a>).
+                  </li>
+                  <li>
+The HTTP response body MUST contain the
+<b>didDocument</b> that is the result of the
+<a>DID resolution</a> function, in the
+representation corresponding to the
+<code>Content-Type</code> <var>HTTP response header</var>.
+                  </li>
+                </ol>
+              </li>
+            </ol>
+          </li>
+          <li>
+For the <a>DID URL dereferencing</a> function:
+						<ol class="algorithm">
+							<li>
+If the value of the <code>Content-Type</code> <var>HTTP response header</var>
+is `application/did-url-dereferencing`:
+								<ol class="algorithm">
+									<li>
+The <var>HTTP body</var> MUST contain a
+<a>DID URL dereferencing result</a> (see
+<a href="#did-url-dereferencing-result"></a>) that is the result of the
+<a>DID URL dereferencing</a> function.
+                  </li>
+                </ol>
+              </li>
+              <li>
+If the function is successful and returns a
+<b>contentStream</b> and a <b>contentType</b> metadata property
+with the value <code>text/uri-list</code> in the
+<b>dereferencingMetadata</b>:
+								<ol class="algorithm">
+									<li>
+The HTTP response status code MUST be <code>303</code>.
+                  </li>
+                  <li>
+The HTTP response MUST contain an
+<code>Location</code> header. The value of this header MUST
+be the <var>selected [=DID service endpoint=] URL</var>.
+                  </li>
+                  <li>the HTTP response body MUST be empty.</li>
+                </ol>
+              </li>
+              <li>
+If the function is successful and returns a
+<b>contentStream</b> with any other <b>contentType</b>:
+								<ol class="algorithm">
+									<li>
+The HTTP response status code MUST be <code>200</code>.
+                  </li>
+                  <li>
+The HTTP response MUST contain a <code>Content-Type</code>
+<var>HTTP response header</var>. Its value MUST be the value
+of the <b>contentType</b> metadata property in the
+<b>dereferencingMetadata</b> (see
+<a href="#did-url-dereferencing-metadata"></a>).
+                  </li>
+                  <li>
+The HTTP response body MUST contain the
+<b>contentStream</b> that is the result of the
+<a>DID URL dereferencing</a> function, in the
+representation corresponding to the
+<code>Content-Type</code> <var>HTTP response header</var>.
+                  </li>
+                </ol>
+              </li>
+            </ol>
+          </li>
+        </ol>
 
-	<section>
-		<h2>DID Resolution Examples</h2>
-		<p>Given the following <var><a>DID resolver</a> HTTP(S) endpoint</var>:<p>
-		<p><code>
-https://resolver.example/1.0/identifiers/</code></p>
-		<p>And given the following <var>input <a>DID</a></var>:</p>
-		<p><code>
-did:example:123</code></p>
-		<p>Then the <var>request HTTP(S) URL</var> is:</p>
-		<p><code>
-https://resolver.example/1.0/identifiers/did:example:123</code></p>
-		<h3>Example: Returning a DID Resolution Result</h3>
-		<p>The <code>resolve()</code> function can be invoked over the HTTP(S) binding as follows:</p>
-		<pre class="example nohighlight" title="Example request to a DID resolver via HTTP(S) binding">
+        <p class="note">
+See <a href="openapi/openapi.yaml">here</a> for an OpenAPI definition corresponding to
+the HTTP(S) binding.
+        </p>
+      </section>
+
+      <section>
+        <h2>DID Resolution Examples</h2>
+        <p>
+Given the following
+<var><a>DID resolver</a> HTTP(S) endpoint</var>:
+        </p>
+        <p></p>
+        <p><code> https://resolver.example/1.0/identifiers/</code></p>
+        <p>
+And given the following
+<var>input <a>DID</a></var>:
+        </p>
+        <p><code> did:example:123</code></p>
+        <p>Then the <var>request HTTP(S) URL</var> is:</p>
+        <p>
+<code> https://resolver.example/1.0/identifiers/did:example:123</code>
+        </p>
+        <h3>Example: Returning a DID Resolution Result</h3>
+        <p>
+The <code>resolve()</code> function can be invoked over the HTTP(S)
+binding as follows:
+        </p>
+<pre
+	class="example nohighlight"
+	title="Example request to a DID resolver via HTTP(S) binding"
+>
 GET https://resolver.example/1.0/identifiers/did:example:123 HTTP/1.1
-Accept: application/did-resolution</pre>
-		<p>The response is as follows:</p>
-		<pre class="example nohighlight" title="Example response from a DID resolver via HTTP(S) binding">
+Accept: application/did-resolution
+</pre>
+        <p>The response is as follows:</p>
+<pre
+	class="example nohighlight"
+	title="Example response from a DID resolver via HTTP(S) binding"
+>
 HTTP 200 OK
 Content-Type: application/did-resolution
 
@@ -2766,14 +3485,25 @@ Content-Type: application/did-resolution
 	"didDocumentMetadata": {
 		...
 	}
-}</pre>
-		<h3>Example: Returning a DID Document</h3>
-		<p>The <code>resolve()</code> function can be invoked over the HTTP(S) binding as follows:</p>
-		<pre class="example nohighlight" title="Example request to a DID resolver via HTTP(S) binding">
+}
+</pre>
+        <h3>Example: Returning a DID Document</h3>
+        <p>
+The <code>resolve()</code> function can be invoked over the HTTP(S)
+binding as follows:
+        </p>
+<pre
+	class="example nohighlight"
+	title="Example request to a DID resolver via HTTP(S) binding"
+>
 GET https://resolver.example/1.0/identifiers/did:example:123 HTTP/1.1
-Accept: application/did</pre>
-		<p>The response is as follows:</p>
-		<pre class="example nohighlight" title="Example response from a DID resolver via HTTP(S) binding">
+Accept: application/did
+</pre>
+        <p>The response is as follows:</p>
+<pre
+	class="example nohighlight"
+	title="Example response from a DID resolver via HTTP(S) binding"
+>
 HTTP 200 OK
 Content-Type: application/did
 
@@ -2787,18 +3517,27 @@ Content-Type: application/did
 		...
 	}]
 }</pre>
+      </section>
 
-	</section>
-
-	<section>
-		<h2>DID URL Dereferencing Examples</h2>
-		<h3>Example: Returning a DID URL Dereferencing Result</h3>
-		<p>The <code>dereference()</code> function can be invoked over the HTTP(S) binding as follows:</p>
-		<pre class="example nohighlight" title="Example request to a DID URL dereferencer via HTTP(S) binding">
+      <section>
+        <h2>DID URL Dereferencing Examples</h2>
+        <h3>Example: Returning a DID URL Dereferencing Result</h3>
+        <p>
+The <code>dereference()</code> function can be invoked over the
+HTTP(S) binding as follows:
+        </p>
+<pre
+	class="example nohighlight"
+	title="Example request to a DID URL dereferencer via HTTP(S) binding"
+>
 GET https://resolver.example/1.0/identifiers/did:example:123?versionId=2 HTTP/1.1
-Accept: application/did-url-dereferencing</pre>
-		<p>The response is as follows:</p>
-		<pre class="example nohighlight" title="Example response from a DID URL dereferencer via HTTP(S) binding">
+Accept: application/did-url-dereferencing
+</pre>
+        <p>The response is as follows:</p>
+<pre
+	class="example nohighlight"
+	title="Example response from a DID URL dereferencer via HTTP(S) binding"
+>
 HTTP 200 OK
 Content-Type: application/did-url-dereferencing
 
@@ -2819,14 +3558,26 @@ Content-Type: application/did-url-dereferencing
 	"contentMetadata": {
 		...
 	}
-}</pre>
-		<h3>Example: Returning a resource</h3>
-		<p>The <code>dereference()</code> function can be invoked over the HTTP(S) binding as follows:</p>
-		<pre class="example nohighlight" title="Example request to a DID URL dereferencer via HTTP(S) binding">
+}
+</pre>
+        <h3>Example: Returning a resource</h3>
+        <p>
+The <code>dereference()</code> function can be invoked over the
+HTTP(S) binding as follows:
+        </p>
+<pre
+	class="example nohighlight"
+	title="Example request to a DID URL dereferencer via HTTP(S) binding"
+>
 GET https://resolver.example/1.0/identifiers/did:example:123?versionId=2 HTTP/1.1
-Accept: application/did</pre>
-		<p>The response is as follows:</p>
-		<pre class="example nohighlight" title="Example response from a DID URL dereferencer via HTTP(S) binding">
+Accept: application/did
+</pre>
+
+        <p>The response is as follows:</p>
+<pre
+	class="example nohighlight"
+	title="Example response from a DID URL dereferencer via HTTP(S) binding"
+>
 HTTP 200 OK
 Content-Type: application/did
 
@@ -2839,337 +3590,424 @@ Content-Type: application/did
 	"service": [{
 		...
 	}]
-}</pre>
+}
+</pre>
+      </section>
+    </section>
 
-	</section>
+    <section id="security-considerations">
+      <h1>Security Considerations</h1>
 
-</section>
+      <p>
+This section contains a variety of security considerations that people using DID
+Resolution in production settings are advised to consider. Readers are urged to
+familiarize themselves with the general security advice provided in the
+<a href="https://www.w3.org/TR/did-1.1/#security-considerations">Security Considerations section of the Decentralized Identifiers specification</a>
+before reading this section.
+      </p>
 
-<section id="security-considerations">
-	<h1>Security Considerations</h1>
+      <section id="authentication">
+        <h2>Authentication/Authorization</h2>
+        <p>
+<a>DID resolution</a> and <a>DID URL dereferencing</a> do not
+involve any authentication or authorization functionality. Similar to DNS
+resolution, anybody can perform the process, without requiring any credentials
+or non-public knowledge.
+        </p>
+      </section>
 
-		<p>
-	This section contains a variety of security considerations that people using DID Resolution in production
-	settings are advised to consider.	Readers are urged to familiarize themselves with the general
-	security advice provided in the
-	<a href="https://www.w3.org/TR/did-1.1/#security-considerations">
-	Security Considerations section of the Decentralized Identifiers
-	specification</a> before reading this section.
-	</p>
+      <section id="caching">
+        <h2>Caching</h2>
+        <p>
+A <a>DID resolver</a> may maintain a generic cache of
+<a>DID documents</a>. It may also maintain caches specific to certain
+<a>DID methods</a>.
+        </p>
+        <p>
+The <code>noCache</code> resolution option can be used to request a
+certain kind of caching behavior.
+        </p>
+        <p>This <var>resolution option</var> is OPTIONAL.</p>
+        <p>Possible values of this property are:</p>
+        <ul>
+          <li>
+`"false"` (default value): Caching of <a>DID documents</a> is allowed.
+          </li>
+          <li>
+`"true"`: Request that caching is disabled and a fresh
+<a>DID document</a> is retrieved from the
+<a>verifiable data registry</a>.
+          </li>
+        </ul>
+        <p>
+Caching behavior can be controlled by configuration of the
+<a>DID resolver</a>, by the
+<code>noCache</code> resolution option, or by contents of the DID
+document (e.g., a `cacheMaxTtl` field), or by a combination of these
+properties.
+        </p>
 
-	<section id="authentication">
-		<h2>Authentication/Authorization</h2>
-		<p><a>DID resolution</a> and <a>DID URL dereferencing</a> do not involve any authentication or authorization
-		functionality. Similar to DNS resolution, anybody can perform the process, without requiring any credentials
-		or non-public knowledge.</p>
+        <p>
+Resolvers that implement noCache might be more vulnerable to denial of
+service attacks, as malicious clients can bypass caching to force
+expensive network requests and resource consumption. Clients
+requesting resolution with <code>noCache</code> expect that some
+resolvers will reject resolution requests that bypass caching.
+Resolvers that deny resolution without caching MUST respond with a
+<a href="#FEATURE_NOT_SUPPORTED">FEATURE_NOT_SUPPORTED</a> error that makes it clear that
+bypassing the cache was not permitted so the client can attempt to
+resolve without using <code>noCache</code>.
+        </p>
+      </section>
+      <section id="json-ld-integrity">
+        <h2>JSON-LD Context Integrity</h2>
+        <p>
+If <a href="https://www.w3.org/TR/json-ld11/#the-context">JSON-LD Context</a>
+files are fetched from a remote location, an attacker could alter the context
+file (for example, by compromising the server
+or intercepting the request via a man-in-the-middle attack).
+        </p>
+        <p>
+Therefore, any <a>DID resolver</a> which performs remote retrieval
+of JSON-LD Context URLs is strongly advised to use a registry of context files
+and corresponding hashes (or a functionally equivalent mechanism) to help ensure
+end-to-end security. Implementations are expected to throw errors if the
+cryptographic hash value for a resource does not match the expected hash value.
+        </p>
+      </section>
 
-	</section>
+      <section id="versioning">
+        <h2>Versioning</h2>
+        <p>
+If a <a href="#did-parameters"><code>versionId</code></a> or
+<a href="#did-parameters"><code>versionTime</code></a> DID
+parameter is provided, the <a>DID resolution</a> algorithm returns a
+specific version of the <a>DID document</a>.
+        </p>
+        <p>
+The DID parameters <a href="#did-parameters"><code>versionId</code></a> and
+<a href="#did-parameters"><code>versionTime</code></a> are mutually exclusive.
+        </p>
+        <p>
+The use of the <a href="#did-parameters"><code>versionId</code></a>
+DID parameter is specific to the <a>DID method</a>. Its possible values may
+include sequential numbers, random UUIDs, content hashes, etc..
+        </p>
+        <p>
+DID document metadata MAY contain a <a href="#did-parameters"><code>versionId</code></a> property
+that changes with each <a href="https://www.w3.org/TR/did-core/#method-operations">Update</a>
+operation that is performed on a DID document.
+        </p>
+        <p class="note">
+While most <a>DID methods</a> support the
+<a href="https://www.w3.org/TR/did-core/#method-operations">Update</a>
+operation, there is no requirement for <a>DID methods</a> to keep all previous
+<a>DID document</a> versions, therefore not all <a>DID methods</a>
+support versioning.
+        </p>
+      </section>
 
-	<section id="caching">
-		<h2>Caching</h2>
-		<p>A <a>DID resolver</a> may maintain a generic cache of <a>DID documents</a>. It may also
-			maintain caches specific to certain <a>DID methods</a>.</p>
-		<p>The <code>noCache</code> resolution option can be used to
-			request a certain kind of caching behavior.</p>
-			<p>This <var>resolution option</var> is OPTIONAL.</p>
-			<p>Possible values of this property are:</p>
-			<ul>
-			<li>`"false"` (default value): Caching of <a>DID documents</a> is allowed.</li>
-			<li>`"true"`: Request that caching is disabled and a fresh <a>DID document</a> is retrieved from
-			the <a>verifiable data registry</a>.</li>
-			</ul>
-		<p>Caching behavior can be controlled by configuration of the <a>DID resolver</a>,
-			by the <code>noCache</code> resolution option, or by contents of the DID document
-			(e.g., a `cacheMaxTtl` field), or by a combination of these properties.</p>
+      <section id="vdr-forks">
+        <h2>VDR Network Forks</h2>
+        <p>
+<a>DID methods</a> that use a distributed system (such as a
+distributed ledger) as a VDR (<a>verifiable data registry</a>) need to manage
+the potential that network forks may occur. Therefore, the specification of a
+<a>DID method</a> that uses a distributed system as a VDR SHOULD
+specify a means by which the VDR they are using can be disambiguated from such
+forks.
+        </p>
+      </section>
 
-		<p>Resolvers that implement noCache might be more vulnerable to denial of service attacks,
-			as malicious clients can bypass caching to force expensive network requests and resource consumption.
-			Clients requesting resolution with <code>noCache</code> expect that some resolvers will reject resolution requests that bypass caching.
-			Resolvers that deny resolution without caching MUST respond with a <a href="#FEATURE_NOT_SUPPORTED">FEATURE_NOT_SUPPORTED</a> error that makes it clear that bypassing the cache was not permitted
-			so the client can attempt to resolve without using <code>noCache</code>.</p>
+      <section id="security-cycles-dereferencing">
+        <h2>Dereferencing Cycles</h2>
 
-	</section>
-	<section id="json-ld-integrity">
-		<h2>JSON-LD Context Integrity</h2>
-			<p>If <a href="https://www.w3.org/TR/json-ld11/#the-context">JSON-LD Context</a> files are fetched from a remote location, an attacker could alter the context file (for example, by compromising the server or intercepting the request via a man-in-the-middle attack).
-			</p>
-			<p>Therefore, any <a>DID resolver</a> which performs remote retrieval of JSON-LD Context URLs is strongly advised to use a registry of context files and corresponding hashes (or a functionally equivalent mechanism) to help ensure end-to-end security. Implementations are expected to throw errors if the cryptographic hash value for a resource does not match the expected hash value.</p>
-	</section>
+        <p>
+When a <a>DID URL dereferencer</a> client dereferences identifiers
+and linked resources in a <a>DID document</a> — especially
+fields like <code>verificationMethod</code>, <code>controller</code>,
+or <code>alsoKnownAs</code> — it might encounter a
+<a>dereferencing cycle</a>. These can occur when a
+<a>DID document</a> references another DID (or URL) that
+eventually leads back to a previously dereferenced identifier, forming
+a loop. A <a>DID URL dereferencer</a> can also encounter such a
+situation when dereferencing a <a>DID URL</a> that
+references a [=DID service endpoint=].
+        </p>
 
-	<section id="versioning">
-		<h2>Versioning</h2>
-		<p>If a <a href="#did-parameters"><code>versionId</code></a> or
-			<a href="#did-parameters"><code>versionTime</code></a> DID parameter
-			is provided, the <a>DID resolution</a>
-			algorithm returns a specific version of the <a>DID document</a>.</p>
-		<p>The DID parameters <a href="#did-parameters"><code>versionId</code></a>
-			and <a href="#did-parameters"><code>versionTime</code></a>
-			are mutually exclusive.</p>
-		<p>The use of the <a href="#did-parameters"><code>versionId</code></a> DID parameter is specific to the <a>DID method</a>.
-			Its possible values may include sequential numbers, random UUIDs, content hashes, etc..</p>
-		<p>DID document metadata MAY contain a <a href="#did-parameters"><code>versionId</code></a>
-			property that changes with each  <a href="https://www.w3.org/TR/did-core/#method-operations">Update</a> operation that is performed
-			on a DID document.</p>
-		<p class="note">While most <a>DID methods</a> support the <a href="https://www.w3.org/TR/did-core/#method-operations">Update</a>
-			operation, there is no requirement for <a>DID methods</a> to keep all previous <a>DID document</a> versions, therefore
-			not all <a>DID methods</a> support versioning.</p>
-
-	</section>
-
-	<section id="vdr-forks">
-		<h2>VDR Network Forks</h2>
-		<p><a>DID methods</a> that use a distributed system (such as a distributed ledger) as a
-			VDR (<a>verifiable data registry</a>) need to manage the potential that network forks may occur. Therefore,
-			the specification of a <a>DID method</a> that uses a distributed system as a VDR SHOULD specify a means by which
-			the VDR they are using can be disambiguated from such forks.</p>
-	</section>
-
-	<section id="security-cycles-dereferencing">
-		<h2>Dereferencing Cycles</h2>
-
-		<p>When a <a>DID URL dereferencer</a> client dereferences identifiers and linked resources in a <a>DID document</a> —
-			especially fields like <code>verificationMethod</code>, <code>controller</code>,
-			or <code>alsoKnownAs</code> — it might encounter a <a>dereferencing cycle</a>.
-			These can occur when a <a>DID document</a> references another DID (or URL) that eventually leads
-			back to a previously dereferenced identifier, forming a loop. A <a>DID URL dereferencer</a> can
-			also encounter such a situation when dereferencing a <a>DID URL</a> that references
-			a [=DID service endpoint=].</p>
-
-		<div class="example" title="Cycle Through Controllers">
-			<pre><code>did:example:alice
+        <div class="example" title="Cycle Through Controllers">
+          <pre><code>did:example:alice
 	└── verificationMethod.controller → did:example:bob
 		└── verificationMethod.controller → did:example:alice</code></pre>
-		</div>
+        </div>
 
-		<p><strong><a>DID URL dereferencers</a> and their clients that perform recursive dereferencing
-			are expected to expect, detect, and handle such cycles</strong>.</p>
+        <p>
+<strong
+><a>DID URL dereferencers</a> and their clients that perform
+recursive dereferencing are expected to expect, detect, and handle
+such cycles</strong
+>.
+        </p>
 
-		<p><strong>Security and performance risks:</strong> If cycles are not detected and mitigated,
-			recursive dereferencing could lead to:</p>
-		<ul>
-			<li><strong>Infinite loops</strong> or <strong>stack overflows</strong> in software.</li>
-			<li><strong>Resource exhaustion</strong> (e.g., memory, network, or CPU).</li>
-			<li><strong>Denial-of-service (DoS)</strong> vulnerabilities in clients or intermediaries.</li>
-		</ul>
+        <p>
+<strong>Security and performance risks:</strong> If cycles are not
+detected and mitigated, recursive dereferencing could lead to:
+        </p>
+        <ul>
+          <li>
+<strong>Infinite loops</strong> or
+<strong>stack overflows</strong> in software.
+          </li>
+          <li>
+<strong>Resource exhaustion</strong> (e.g., memory, network, or
+CPU).
+          </li>
+          <li>
+<strong>Denial-of-service (DoS)</strong> vulnerabilities in clients
+or intermediaries.
+          </li>
+        </ul>
 
-		<p><strong>Mitigation guidance:</strong> Components that recursively
-			follow external <a>DID document</a> references are encouraged to
-			track identifiers that have already been dereferenced and to detect when a cycle has
-			occurred and take appropriate action. In addition, developers might wish to limit
-			recursion depth or breadth to reduce the potential attack surface.</p>
-	</section>
+        <p>
+<strong>Mitigation guidance:</strong> Components that recursively
+follow external <a>DID document</a> references are
+encouraged to track identifiers that have already been dereferenced
+and to detect when a cycle has occurred and take appropriate action.
+In addition, developers might wish to limit recursion depth or breadth
+to reduce the potential attack surface.
+        </p>
+      </section>
 
-	<section id="security-query-string-normalization-and-injection-risks" class="informative">
-		<h2>Query String Normalization and Injection Risks</h2>
+      <section
+        id="security-query-string-normalization-and-injection-risks"
+        class="informative"
+      >
+        <h2>Query String Normalization and Injection Risks</h2>
 
-		<p>The query component of a <a>DID URL</a> is used to pass DID
-		parameters that affect resolution and dereferencing behavior (see <a
-		href="#did-parameters"></a>). Several aspects of query string handling
-		carry security implications that implementers are advised to consider
-		carefully.</p>
+        <p>
+The query component of a <a>DID URL</a> is used to pass DID
+parameters that affect resolution and dereferencing behavior (see
+<a href="#did-parameters"></a>). Several aspects of query string handling carry
+security implications that implementers are advised to consider carefully.
+        </p>
 
-		<section id="path-traversal-via-relativeref">
-			<h3>Path Traversal via `relativeRef`</h3>
+        <section id="path-traversal-via-relativeref">
+          <h3>Path Traversal via `relativeRef`</h3>
 
-			<p>The percent-decoded value of the `relativeRef` DID parameter is
-			combined with the `serviceEndpoint` URL as the base URI using the
-			reference resolution algorithm defined in <a
-			data-cite="RFC3986#section-5">RFC3986 Section 5</a>, to construct a
-			final resource URL (see <a
-			href="#dereferencing-algorithm-resource"></a>). If the value of
-			`relativeRef` contains path traversal sequences, an attacker might be
-			able to cause the dereferencer to construct a resource URL that escapes
-			the intended path scope of the service endpoint.</p>
+          <p>
+The percent-decoded value of the `relativeRef` DID parameter is combined with
+the `serviceEndpoint` URL as the base URI using the reference resolution
+algorithm defined in <a data-cite="RFC3986#section-5">RFC3986 Section 5</a>, to construct a final
+resource URL (see <a href="#dereferencing-algorithm-resource"></a>). If the value of
+`relativeRef` contains path traversal sequences, an attacker might be able to
+cause the dereferencer to construct a resource URL that escapes the intended
+path scope of the service endpoint.
+          </p>
 
-			<p>Path traversal could be attempted using a variety of encodings. The
-			following are non-exhaustive examples of sequences an attacker might
-			use:</p>
-			<ul>
-				<li>Literal dot-dot-slash: `../`</li>
-				<li>Percent-encoded variants: `%2E%2E%2F`, `%2E%2E/`, .`%2E/`, `%2E./`</li>
-				<li>Doubly-encoded variants: `%252E%252E%252F`</li>
-				<li>Platform-specific variants (e.g., `..\` on Windows-derived path libraries)</li>
-			</ul>
+          <p>
+Path traversal could be attempted using a variety of encodings. The following
+are non-exhaustive examples of sequences an attacker might use:
+          </p>
+          <ul>
+            <li>Literal dot-dot-slash: `../`</li>
+            <li>
+Percent-encoded variants: `%2E%2E%2F`, `%2E%2E/`, .`%2E/`, `%2E./`
+            </li>
+            <li>Doubly-encoded variants: `%252E%252E%252F`</li>
+            <li>
+Platform-specific variants (e.g., `..\` on Windows-derived path libraries)
+            </li>
+          </ul>
 
-			<p>Implementers are encouraged to:</p>
-			<ul>
-				<li>Normalize the resolved path after applying the <a
-				data-cite="RFC3986#section-5">RFC3986 Section 5</a> Reference
-				Resolution algorithm, and verify that the resulting path does
-				not traverse above the base path of the service endpoint
-				URL.</li>
-				<li>Treat `relativeRef` values that, after normalization, would
-				produce a resource URL whose path is not prefixed by the base
-				path of the `serviceEndpoint` URL as invalid inputs, for example
-				by returning an `INVALID_DID_URL` error (see <a href="#errors"></a>).</li>
-				<li>Apply normalization and validation after full
-				percent-decoding, to guard against encoded traversal variants.
-				Superficial string matching (e.g., checking only for the literal
-				string `../`) is not a reliable traversal detection
-				mechanism.</li>
-			</ul>
-			<p class="note" title="relativeRef Resolution Cycles">This concern is
-			particularly acute when the service endpoint URL is itself a DID URL
-			that will be recursively dereferenced. In such cases, a traversal
-			sequence in `relativeRef` could affect the resolution of a different
-			DID document than intended. See also
-			<a href="#security-cycles-dereferencing"></a>.</p>
+          <p>Implementers are encouraged to:</p>
+          <ul>
+            <li>
+Normalize the resolved path after applying the <a data-cite="RFC3986#section-5">RFC3986 Section 5</a>
+Reference Resolution algorithm, and verify that the resulting path does not
+traverse above the base path of the service endpoint URL.
+            </li>
+            <li>
+Treat `relativeRef` values that, after normalization, would produce a resource
+URL whose path is not prefixed by the base path of the `serviceEndpoint` URL as
+invalid inputs, for example by returning an `INVALID_DID_URL` error (see
+<a href="#errors"></a>).
+            </li>
+            <li>
+Apply normalization and validation after full percent-decoding, to guard against
+encoded traversal variants. Superficial string matching (e.g., checking only for
+the literal string `../`) is not a reliable traversal detection mechanism.
+            </li>
+          </ul>
+          <p class="note" title="relativeRef Resolution Cycles">
+This concern is particularly acute when the service endpoint URL is itself a DID
+URL that will be recursively dereferenced. In such cases, a traversal sequence
+in `relativeRef` could affect the resolution of a different DID document than
+intended. See also <a href="#security-cycles-dereferencing"></a>.
+          </p>
+        </section>
+        <section id="normalization-inconsistency-cache-bypass">
+          <h3>Normalization Inconsistency as a Cache Bypass Vector</h3>
 
-		</section>
-		<section id="normalization-inconsistency-cache-bypass">
-			<h3>Normalization Inconsistency as a Cache Bypass Vector</h3>
+          <p>
+As described in <a href="#query-normalization"></a>, the same logical
+<a>DID URL</a> can be represented by multiple syntactically
+distinct strings. In a proxied or multi-component resolution architecture (see
+<a href="#resolver-architectures-proxied"></a>), different components can apply different
+normalization rules (or no normalization at all).
+          </p>
 
-			<p>As described in <a href="#query-normalization"></a>, the same logical
-			<a>DID URL</a> can be represented by multiple syntactically distinct
-			strings. In a proxied or multi-component resolution architecture
-			(see <a href="#resolver-architectures-proxied"></a>), different
-			components can apply different normalization rules (or no
-			normalization at all).</p>
+          <p>
+An attacker aware of normalization inconsistencies between components could:
+          </p>
+          <ul>
+            <li>
+Construct a <a>DID URL</a> that is served from cache by one
+component but re-dereferenced from the <a>verifiable data registry</a> by
+another, potentially bypassing content integrity checks associated with cached
+responses.
+            </li>
+            <li>
+Cause two logically identical <a>DID URLs</a> to be cached as
+distinct entries, inflating cache size and potentially enabling cache
+exhaustion.
+            </li>
+            <li>
+Exploit differing duplicate-parameter handling between a caching proxy and an
+upstream resolver to inject unexpected parameter values into a resolution
+request.
+            </li>
+          </ul>
+          <p>To mitigate these risks, implementers are encouraged to:</p>
+          <ol>
+            <li>
+Apply query string normalization (per <a href="#query-normalization"></a>) at the
+outermost entry point of the resolution pipeline, before any caching or
+forwarding occurs.
+            </li>
+            <li>
+Use the normalized form of the <a>DID URL</a> as the cache key,
+and document the normalization algorithm applied.
+            </li>
+            <li>
+Avoid assuming that a <a>DID URL</a> received from an upstream
+component has already been normalized; applying independent normalization before
+processing is a safer approach.
+            </li>
+          </ol>
+        </section>
+        <section id="">
+          <h3>Parameter Injection via Concatenation</h3>
 
-			<p>An attacker aware of normalization inconsistencies between
-			components could:</p>
-			<ul>
-				<li>Construct a <a>DID URL</a> that is served from cache by one
-				component but re-dereferenced from the <a>verifiable data registry</a> by
-				another, potentially bypassing content integrity checks
-				associated with cached responses.</li>
-				<li>Cause two logically identical <a>DID URLs</a> to be cached
-				as distinct entries, inflating cache size and potentially
-				enabling cache exhaustion.</li>
-				<li>Exploit differing duplicate-parameter handling between a
-				caching proxy and an upstream resolver to inject unexpected
-				parameter values into a resolution request.</li>
-			</ul>
-			<p>To mitigate these risks, implementers are encouraged to:</p>
-			<ol>
-				<li>Apply query string normalization (per <a
-				href="#query-normalization"></a>) at the outermost entry point
-				of the resolution pipeline, before any caching or forwarding
-				occurs.</li>
-				<li>Use the normalized form of the <a>DID URL</a> as the cache
-				key, and document the normalization algorithm applied.</li>
-				<li>Avoid assuming that a <a>DID URL</a> received from an
-				upstream component has already been normalized; applying
-				independent normalization before processing is a safer
-				approach.</li>
-			</ol>
-		</section>
-		<section id="">
-			<h3>Parameter Injection via Concatenation</h3>
+          <p>
+Implementations that construct <a>DID URLs</a> programmatically
+by string concatenation (for example, appending a caller-supplied value as a DID
+parameter) might be vulnerable to parameter injection if the input is not
+validated and encoded prior to concatenation.
+          </p>
+          <p>
+For example, a caller-supplied `service` value of `files&versionId=2` could, if
+concatenated without encoding, inject an additional `versionId` parameter into
+the <a>DID URL</a>, altering resolution behavior in ways the
+caller might not have intended or authorized. This is analogous to query string
+injection vulnerabilities in HTTP-based systems.
+          </p>
+          <p>
+Implementers are encouraged to percent-encode all caller-supplied parameter
+values before concatenation into a DID URL query string, in accordance with
+<a data-cite="RFC3986#section-2.1">RFC3986 Section 2.1</a>, and to validate that parameter values, after
+decoding, conform to the expected value format for the parameter as defined in
+this specification (see <a href="#did-parameters"></a>), in the applicable DID
+method specification, or in the DID Document Resolution Extensions
+[[?DID-EXTENSIONS-RESOLUTION]].
+          </p>
+        </section>
+      </section>
+    </section>
+    <section id="privacy-considerations">
+      <h1>Privacy Considerations</h1>
 
-			<p>Implementations that construct <a>DID URLs</a> programmatically
-			by string concatenation (for example, appending a caller-supplied
-			value as a DID parameter) might be vulnerable to parameter injection
-			if the input is not validated and encoded prior to
-			concatenation.</p>
-			<p>For example, a caller-supplied `service` value of
-			`files&versionId=2` could, if concatenated without encoding, inject
-			an additional `versionId` parameter into the <a>DID URL</a>,
-			altering resolution behavior in ways the caller might not have
-			intended or authorized. This is analogous to query string injection
-			vulnerabilities in HTTP-based systems.</p>
-			<p>Implementers are encouraged to percent-encode all caller-supplied
-			parameter values before concatenation into a DID URL query string,
-			in accordance with <a data-cite="RFC3986#section-2.1">RFC3986
-			Section 2.1</a>, and to validate that parameter values, after
-			decoding, conform to the expected value format for the parameter as
-			defined in this specification (see <a href="#did-parameters"></a>),
-			in the applicable DID method specification, or in the DID Document
-			Resolution Extensions [[?DID-EXTENSIONS-RESOLUTION]].</p>
-		</section>
-	</section>
-</section>
-<section id="privacy-considerations">
-	<h1>Privacy Considerations</h1>
+      <p>
+This section details the privacy considerations specific to DID Resolution.
+Readers are urged to familiarize themselves with the general privacy advice
+provided in the Privacy Considerations sections of the
+<a href="https://www.w3.org/TR/did-1.1/#privacy-considerations">Decentralized Identifiers specification</a>
+and <a href="https://w3c.github.io/cid/#privacy-considerations">Controlled Identifiers specification</a>
+before reading this section.
+      </p>
 
-	<p>
-	This section details the privacy considerations specific to DID Resolution.
-	Readers are urged to familiarize themselves with the general
-	privacy advice provided in the Privacy Considerations sections of the
-	<a href="https://www.w3.org/TR/did-1.1/#privacy-considerations">Decentralized
-	Identifiers specification</a> and
-	<a href="https://w3c.github.io/cid/#privacy-considerations">
-	Controlled Identifiers specification</a> before reading this section.
-	</p>
+      <section id="profiling-requesters">
+        <h2>Profiling of DID Resolution and Dereferencing Requesters</h2>
+        <p>
+<a>DID resolvers</a> and <a>DID URL dereferencers</a> will be able
+to log requests to their services for resolution and dereferencing. Over time,
+these logs could be used to track and profile the clients making requests for
+these services. To mitigate this privacy risk, clients should make such requests
+to services they trust, for example, because of an existing business
+relationship or because the service is running on infrastructure they control.
+        </p>
+        <p>
+Clients can also take steps to obfuscate their requests to a service to decrease
+the possibilities of correlation and profiling. Techniques for obfuscation
+include Oblivious HTTP, using a trusted proxy to execute the resolution
+requests, and using a trusted cache.
+        </p>
+      </section>
+      <section>
+        <h2>Method specific considerations</h2>
+        <p>
+Different DID methods have different additional privacy implications and
+considerations depending on the design decisions and underlying VDR of the
+method. Implementers are advised to review the privacy considerations of the
+specific DID methods they intend to support. Designers of DID methods are
+encouraged to follow the <a href="https://www.w3.org/TR/threat-modeling-guide/">W3C Threat Modeling Guide</a>
+to produce a threat model, to help implementers understand the privacy
+implications of the method design.
+        </p>
+      </section>
+    </section>
 
-	<section id="profiling-requesters">
-		<h2>Profiling of DID Resolution and Dereferencing Requesters</h2>
-		<p><a>DID resolvers</a> and <a>DID URL dereferencers</a> will be able to log requests
-			to their services for resolution and dereferencing. Over time, these logs could be used to track
-			and profile the clients making requests for these services. To mitigate this privacy risk,
-			clients should make such requests to services they trust, for example,
-			because of an existing business relationship or because the service is running on
-			infrastructure they control.
-		</p>
-		<p>
-			Clients can also take steps to obfuscate their requests to a service to
-			decrease the possibilities of correlation and profiling. Techniques for
-			obfuscation include Oblivious HTTP, using a trusted proxy to execute the
-			resolution requests, and using a trusted cache.
-		</p>
+    <section class="appendix">
+      <h1>Relationship to Other Technologies</h1>
 
-	</section>
-	<section>
-		<h2>Method specific considerations</h2>
-		<p>Different DID methods have different additional privacy implications and
-			considerations depending on the design decisions and underlying VDR of
-			the method. Implementers are advised to review the privacy considerations
-			of the specific DID methods they intend to support. Designers of DID
-			methods are encouraged to follow the
-			<a href="https://www.w3.org/TR/threat-modeling-guide/">W3C Threat
-			Modeling Guide</a> to produce a threat model, to help implementers
-			understand the privacy implications of the method design.
-		</p>
-	</section>
-
-</section>
-
-<section class="appendix">
-	<h1>Relationship to Other Technologies</h1>
-
-	<p>
+      <p>
 One of the most common mechanisms used to resolve an identifier to an address on
 the Internet is the global Domain Name System (DNS) described in [[?RFC1034]].
 The DNS and the processes and systems used to map a Domain Name to an Internet
 Protocol address is a common requirement for hosting a website.
-	</p>
-	<p>
-The [[[DID]]] specification introduced a new type of identifier that lacks
-any dependency on the global Domain Name System and introduced the concept of
-an identifier resolution process that does not require the centralization of
-any part of the architecture. This new architecture allows the decentralized
+      </p>
+      <p>
+The [[[DID]]] specification introduced a new type of identifier that lacks any
+dependency on the global Domain Name System and introduced the concept of an
+identifier resolution process that does not require the centralization of any
+part of the architecture. This new architecture allows the decentralized
 creation and management of globally-resolvable identifiers that combat
-identifier rent-seeking and censorship. It enables individuals to fully
-own and control their identifiers instead of renting the identifiers from a
-third party.
-	</p>
-	<p>
-Individuals that acquire [=DID URLs=] use them in their software much like
-they continue to use DNS-based URLs. The software uses a [=DID resolver=]
-interface (defined in this specification) to determine the location of the
-resources to be retrieved. The process of [=DID resolution=], much like the
-process of DNS resolution, is opaque to the individual and happens within
-the software without needing any direct involvement of the individual.
-	</p>
-	<p>
+identifier rent-seeking and censorship. It enables individuals to fully own and
+control their identifiers instead of renting the identifiers from a third party.
+      </p>
+      <p>
+Individuals that acquire [=DID URLs=] use them in their software much like they
+continue to use DNS-based URLs. The software uses a [=DID resolver=] interface
+(defined in this specification) to determine the location of the resources to be
+retrieved. The process of [=DID resolution=], much like the process of DNS
+resolution, is opaque to the individual and happens within the software without
+needing any direct involvement of the individual.
+      </p>
+      <p>
 The research related to DNS centralization and the corresponding invention of
 [=DIDs=] and [=DID resolution=] is documented by the [[[?DID]]] specification in
-the section related to the
-<a data-cite="DID#acknowledgements">history of DIDs</a>.
-	</p>
-</section>
+the section related to the <a data-cite="DID#acknowledgements">history of DIDs</a>.
+      </p>
+    </section>
 
-<section class="appendix">
-	<h1>DID Resolution Resources</h1>
+    <section class="appendix">
+      <h1>DID Resolution Resources</h1>
 
-	<ol>
-	<li><a href="https://www.w3.org/TR/did-core/#resolution">DID resolvers in DID Core specification</a></li>
-	<li><a href="https://github.com/decentralized-identity/universal-resolver/">Universal Resolver</a></li>
-	<li><a href="https://github.com/digitalbazaar/did-client">did-client</a></li>
-	<li><a href="https://github.com/uport-project/did-resolver">uPort DID resolver</a></li>
-	</ol>
-
-</section>
-
-</body>
+      <ol>
+        <li><a href="https://www.w3.org/TR/did-core/#resolution">DID resolvers in DID Core specification</a></li>
+        <li><a href="https://github.com/decentralized-identity/universal-resolver/">Universal Resolver</a></li>
+        <li><a href="https://github.com/digitalbazaar/did-client">did-client</a></li>
+        <li><a href="https://github.com/uport-project/did-resolver">uPort DID resolver</a></li>
+      </ol>
+    </section>
+  </body>
 </html>


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wip-abramson/did-resolution/pull/330.html" title="Last updated on May 11, 2026, 2:57 PM UTC (49ef4e5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-resolution/330/06afe67...wip-abramson:49ef4e5.html" title="Last updated on May 11, 2026, 2:57 PM UTC (49ef4e5)">Diff</a>