### PR TITLE
Fix language about resolving DID URLs (address concerns with 331)

### DIFF
--- a/index.html
+++ b/index.html
@@ -2146,13 +2146,13 @@ Dereferencing a DID URL to a service endpoint URL.
             <h1>DID URL Dereferencing Algorithm</h1>
 
             <section>
-                <h1>Prepare for resolution</h1>
+                <h1>Prepare for Resolution</h1>
 
                 <p>
-                    The first step in dereferencing a [=DID URL=] is to prepare the DID URL for
+                    The first step in dereferencing a [=DID URL=] is to prepare the DID for
                     resolution. This involves validating the DID URL syntax, selecting an
-                    appropriate [=DID Resolver=], and preparing the DID URL and any accompanying
-                    DID Resolution Options for a resolution request.
+                    appropriate [=DID Resolver=], and preparing the DID and any accompanying
+                    <a href="#did-resolution-options">DID resolution options</a> for a resolution request.
                 </p>
 
             </section>

--- a/index.html
+++ b/index.html
@@ -1311,80 +1311,9 @@ to <code><a href="#INTERNAL_ERROR">https://www.w3.org/ns/did#INTERNAL_ERROR</a><
         </ol>
       </section>
     </section>
-		<section id="dereferencing">
+
+    <section id="dereferencing">
       <h1>DID URL Dereferencing</h1>
-
-			<section id="dereferencing-algorithm">
-				<h1>DID URL Dereferencing Algorithm</h1>
-
-				<section>
-					<h1>Prepare for resolution</h1>
-
-					<p>
-The first step in dereferencing a [=DID URL=] is to prepare the DID URL for
-resolution. This involves validating the DID URL syntax, selecting an
-appropriate [=DID Resolver=], and preparing the DID URL and any accompanying
-DID Resolution Options for a resolution request.
-					</p>
-
-				</section>
-
-				<section>
-					<h1>Execute Resolution Request</h1>
-					<p>
-The next step is to use the selected [=DID Resolver=] to execute a resolution
-request using the prepared inputs. This could involve making a network request
-to an external service, or it could involve a local resolution process,
-depending on the specific implementation of the [=DID Resolver=]. The
-result is a [=DID resolution result=], which includes either the resolved
-DID document and associated metadata, or error information.
-					</p>
-
-				</section>
-
-				<section>
-					<h1>Determine Retrieval Strategy</h1>
-					<p>
-After successfully resolving the DID document and accompanying metadata,
-the next step is to determine the appropriate strategy for retrieving
-the resource identified by the [=DID URL=]. This involves analyzing the
-contents of the [=DID resolution=] result, including the DID document and
-its metadata along with the path and query components of the
-DID URL, to determine the method for retrieving the resource.
-				</p>
-
-
-				</section>
-				<section>
-					<h1>Retrieve the Resource</h1>
-          <p>
-The next step is to retrieve the resource identified by the DID URL, using the
-determined retrieval strategy. Retrieval strategies may be defined in external
-specifications. It is up to the client to determine whether they are able to
-retrieve the resource using the specified strategy.
-          </p>
-
-				</section>
-
-				<section>
-					<h1>Use the Resource</h1>
-          <p>
-The final step is to use the retrieved resource to complete the DID URL
-dereferencing process in the context in which dereferencing was invoked.
-This might involve applying a fragment identifier to the retrieved resource,
-making the resulting resource available to the invoking application process,
-or producing an error if dereferencing cannot be completed.
-          </p>
-
-
-				</section>
-
-			</section>
-
-		</section>
-
-    <section id="dereferencing-old">
-      <h1>DEPRECATED -- DID URL Dereferencing</h1>
 
       <p>
 The <a>DID URL dereferencing</a> function dereferences a <a>DID URL</a> into a
@@ -1701,7 +1630,7 @@ This specification defines no common properties.
         </p>
       </section>
 
-      <section id="old-dereferencing-algorithm">
+      <section id="dereferencing-algorithm">
         <h2>DID URL Dereferencing Algorithm</h2>
         <p>
 A <a>DID URL dereferencer</a> implements the following
@@ -2199,6 +2128,78 @@ Dereferencing a DID URL to a service endpoint URL.
           </figure>
         </section>
       </section>
+    </section>
+
+    <section id="dereferencing-provisional">
+        <h1>PROVISIONAL - DID URL Dereferencing</h1>
+
+        <section id="dereferencing-algorithm-provisional">
+            <h1>DID URL Dereferencing Algorithm</h1>
+
+            <section>
+                <h1>Prepare for resolution</h1>
+
+                <p>
+                    The first step in dereferencing a [=DID URL=] is to prepare the DID URL for
+                    resolution. This involves validating the DID URL syntax, selecting an
+                    appropriate [=DID Resolver=], and preparing the DID URL and any accompanying
+                    DID Resolution Options for a resolution request.
+                </p>
+
+            </section>
+
+            <section>
+                <h1>Execute Resolution Request</h1>
+                <p>
+                    The next step is to use the selected [=DID Resolver=] to execute a resolution
+                    request using the prepared inputs. This could involve making a network request
+                    to an external service, or it could involve a local resolution process,
+                    depending on the specific implementation of the [=DID Resolver=]. The
+                    result is a [=DID resolution result=], which includes either the resolved
+                    DID document and associated metadata, or error information.
+                </p>
+
+            </section>
+
+            <section>
+                <h1>Determine Retrieval Strategy</h1>
+                <p>
+                    After successfully resolving the DID document and accompanying metadata,
+                    the next step is to determine the appropriate strategy for retrieving
+                    the resource identified by the [=DID URL=]. This involves analyzing the
+                    contents of the [=DID resolution=] result, including the DID document and
+                    its metadata along with the path and query components of the
+                    DID URL, to determine the method for retrieving the resource.
+                </p>
+
+
+            </section>
+            <section>
+                <h1>Retrieve the Resource</h1>
+                <p>
+                    The next step is to retrieve the resource identified by the DID URL, using the
+                    determined retrieval strategy. Retrieval strategies may be defined in external
+                    specifications. It is up to the client to determine whether they are able to
+                    retrieve the resource using the specified strategy.
+                </p>
+
+            </section>
+
+            <section>
+                <h1>Use the Resource</h1>
+                <p>
+                    The final step is to use the retrieved resource to complete the DID URL
+                    dereferencing process in the context in which dereferencing was invoked.
+                    This might involve applying a fragment identifier to the retrieved resource,
+                    making the resulting resource available to the invoking application process,
+                    or producing an error if dereferencing cannot be completed.
+                </p>
+
+
+            </section>
+
+        </section>
+
     </section>
 
     <section>

--- a/index.html
+++ b/index.html
@@ -2133,6 +2133,15 @@ Dereferencing a DID URL to a service endpoint URL.
     <section id="dereferencing-provisional">
         <h1>PROVISIONAL - DID URL Dereferencing</h1>
 
+        <div class="note">
+            <p>
+                The Working Group is currently exploring this new
+                DID URL Dereferencing algorithm, which has a more modular
+                approach than the current one, based on "retrieval
+                strategies" or "handling strategies".
+            </p>
+        </div>
+
         <section id="dereferencing-algorithm-provisional">
             <h1>DID URL Dereferencing Algorithm</h1>
 

--- a/index.html
+++ b/index.html
@@ -2168,7 +2168,7 @@ Dereferencing a DID URL to a service endpoint URL.
             <section>
                 <h1>Execute Resolution Request</h1>
                 <p>
-                    The next step is to use the selected [=DID Resolver=] to execute a resolution
+                    The next step is to select a [=DID Resolver=] and use it to execute a resolution
                     request using the prepared inputs. This could involve making a network request
                     to an external service, or it could involve a local resolution process,
                     depending on the specific implementation of the [=DID Resolver=]. The

--- a/index.html
+++ b/index.html
@@ -2155,6 +2155,14 @@ Dereferencing a DID URL to a service endpoint URL.
                     <a href="#did-resolution-options">DID resolution options</a> for a resolution request.
                 </p>
 
+                <div class="note">
+                    <p>
+                        The Working Group is currently discussing whether to change the
+                        input of the <a href="#resolving">DID resolution</a> function
+                        from a <a>DID</a> to a <a>DID URL</a>.
+                    </p>
+                </div>
+
             </section>
 
             <section>

--- a/index.html
+++ b/index.html
@@ -2137,7 +2137,7 @@ Dereferencing a DID URL to a service endpoint URL.
             <p>
                 The Working Group is currently exploring this new
                 DID URL Dereferencing algorithm, which has a more modular
-                approach than the current one, based on "retrieval
+                approach than the previous one, based on "retrieval
                 strategies" or "handling strategies".
             </p>
         </div>

--- a/index.html
+++ b/index.html
@@ -2185,7 +2185,7 @@ Dereferencing a DID URL to a service endpoint URL.
                     the next step is to determine the appropriate strategy for retrieving
                     the resource identified by the [=DID URL=]. This involves analyzing the
                     contents of the [=DID resolution=] result, including the DID document and
-                    its metadata along with the path and query components of the
+                    its metadata, along with the path and query components of the
                     DID URL, to determine the method for retrieving the resource.
                 </p>
 


### PR DESCRIPTION
As discussed in yesterday's DID WG call, I objected to merging https://github.com/w3c/did-resolution/pull/331, and I don't think the WG process for addressing objections was followed.

Rather than reverting the PR 331, we agreed, that I would work on a PR that would remove my objection, so here it is.

This PR:
- Changes "prepare the **DID URL** for resolution" to "prepare the **DID** for resolution"
- Changes "preparing the **DID URL** and any accompanying DID Resolution Options for a resolution request" to "preparing the **DID** and any accompanying DID resolution options for a resolution request"
- Adds a note that the WG is currently discussing changing the input of DID Resolution from DID to DID URL
- Also marks the new algorithm as "provisional" (as opposed to marking the current algorithm as "deprecated"), and adds a note which explains this. I think this makes sense for now, since the new algorithm is not yet consistent with many other parts of the spec.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-resolution/pull/338.html" title="Last updated on Jun 5, 2026, 3:12 PM UTC (2b391d1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-resolution/338/689679d...2b391d1.html" title="Last updated on Jun 5, 2026, 3:12 PM UTC (2b391d1)">Diff</a>