### PR TITLE
Correction to CSS Style to not put algorithm numbering on unordered lists

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,7 +117,7 @@
       ol.algorithm li {
         margin: 0.5em 0;
       }
-      ol.algorithm li:before {
+      ol.algorithm > li:before {
         font-weight: bold;
         counter-increment: numsection;
         content: counters(numsection, ".") ") ";


### PR DESCRIPTION
This is an issue that came up in the initial Path Handling PR that I created (#316 ).  In the current style for the "algorithm" class, when there is an unordered list within the algorithm, it is rendered as both a bullet and numbering.  Searching I found this fix that @pchampin confirmed was correct.  However, since that PR is destined to the scrap heap, I'd like to get the change into the document.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-resolution/pull/339.html" title="Last updated on Jun 10, 2026, 6:39 PM UTC (d9473eb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-resolution/339/d008883...d9473eb.html" title="Last updated on Jun 10, 2026, 6:39 PM UTC (d9473eb)">Diff</a>