### PR TITLE
Mark DID URL Deferencing at risk

### DIFF
--- a/index.html
+++ b/index.html
@@ -1322,8 +1322,9 @@ to <code><a href="#INTERNAL_ERROR">https://www.w3.org/ns/did#INTERNAL_ERROR</a><
     <section id="dereferencing">
       <h1>DID URL Dereferencing</h1>
 
-        <p class="issue">
-          The dereferencing algorithm is currently [=at risk=], and is labelled as such as per the W3C Process.
+        <p class="issue atrisk">
+This entire section is currently [=at risk=] and is likely to be heavily modified or removed from the specification. The Working Group is requesting feedback from implementers regarding the value of 
+the section.
         </p>
 
       <p>

--- a/index.html
+++ b/index.html
@@ -2979,9 +2979,6 @@ The media type of this data structure is defined to be
     <section id="did-url-dereferencing-result">
       <h1>DID URL Dereferencing Result</h1>
 
-      <p class="issue">
-          This section is currently marked [=at risk=], as per the W3C Process.
-      </p>
 
       <p class="issue atrisk">
 This section is currently marked as [=at risk=] and may be heavily modified or removed during the Candidate Recommendation phase.

--- a/index.html
+++ b/index.html
@@ -184,6 +184,17 @@ them to <a href="mailto:public-did-wg@w3.org">public-did-wg@w3.org</a>
       </p>
 
       <p>
+        This is a work in progress.
+      </p>
+      <p>
+        The definition of the <a>DID URL dereferencing</a> feature is currently marked 
+        <dfn>at risk</dfn>, 
+        the <a href="#dereferencing-algorithm">dereferencing algorithm</a> is currently under discussion
+         in the working group and may be removed.
+        All references to <a>DID URL dereferencing</a> may be subject to change.
+      </p>
+
+      <p>
 Portions of the work on this specification have been funded by the United States
 Department of Homeland Security's Science and Technology Directorate under
 contracts HSHQDC-17-C-00019. The content of this specification does not
@@ -1315,6 +1326,10 @@ to <code><a href="#INTERNAL_ERROR">https://www.w3.org/ns/did#INTERNAL_ERROR</a><
     <section id="dereferencing">
       <h1>DID URL Dereferencing</h1>
 
+        <p class="issue">
+          The dereferencing algorithm is currently [=at risk=], and is labelled as such as per the W3C Process.
+        </p>
+
       <p>
 The <a>DID URL dereferencing</a> function dereferences a <a>DID URL</a> into a
 <a>resource</a> with contents depending on the <a>DID URL</a>'s components,
@@ -2133,6 +2148,12 @@ Dereferencing a DID URL to a service endpoint URL.
     <section id="dereferencing-provisional">
         <h1>PROVISIONAL - DID URL Dereferencing</h1>
 
+        <p class="issue">
+          The dereferencing algorithm is currently [=at risk=], and is labelled as such as per the W3C Process.
+          One version of the algorithm under discussion can be
+          <a href="https://github.com/w3c/did-resolution/pull/344">seen here</a>.
+        </p>
+
         <div class="note">
             <p>
                 The Working Group is currently exploring this new
@@ -2346,6 +2367,12 @@ This example corresponds to a metadata structure of the following format:
     <section id="architectures">
       <h1>DID Resolution Architectures</h1>
 
+        <p class="issue">
+          This section is currently marked [=at risk=], as per the W3C Process.
+          The content of this section may may be replaced with 
+          the <a href="https://w3c.github.io/did-resolution-threat-model/">DID Resolution Threat Model</a>.
+        </p>
+      
       <section id="method-architectures">
         <h2>Method Architectures</h2>
         <p>
@@ -2953,6 +2980,11 @@ The media type of this data structure is defined to be
 
     <section id="did-url-dereferencing-result">
       <h1>DID URL Dereferencing Result</h1>
+
+      <p class="issue">
+          This section is currently marked [=at risk=], as per the W3C Process.
+      </p>
+
       <p>
 This section defines a JSON data structure that represents the result of the
 algorithm described in <a href="#dereferencing"></a>. A

--- a/index.html
+++ b/index.html
@@ -2986,6 +2986,9 @@ The media type of this data structure is defined to be
           This section is currently marked [=at risk=], as per the W3C Process.
       </p>
 
+      <p class="issue atrisk">
+This section is currently marked as [=at risk=] and may be heavily modified or removed during the Candidate Recommendation phase.
+      </p>
       <p>
 This section defines a JSON data structure that represents the result of the
 algorithm described in <a href="#dereferencing"></a>. A

--- a/index.html
+++ b/index.html
@@ -2369,9 +2369,8 @@ This example corresponds to a metadata structure of the following format:
     <section id="architectures">
       <h1>DID Resolution Architectures</h1>
 
-        <p class="issue">
-          This section is currently marked [=at risk=], as per the W3C Process.
-          The content of this section may may be replaced with 
+        <p class="issue atrisk">
+          This section is currently marked as [=at risk=] and is likely to be replaced with content from the
           the <a href="https://w3c.github.io/did-resolution-threat-model/">DID Resolution Threat Model</a>.
         </p>
       

--- a/index.html
+++ b/index.html
@@ -183,15 +183,11 @@ them to <a href="mailto:public-did-wg@w3.org">public-did-wg@w3.org</a>
 <a href="https://lists.w3.org/Archives/Public/public-did-wg/">archives</a>).
       </p>
 
-      <p>
-        This is a work in progress.
-      </p>
-      <p>
-        The definition of the <a>DID URL dereferencing</a> feature is currently marked 
-        <dfn>at risk</dfn>, 
-        the <a href="#dereferencing-algorithm">dereferencing algorithm</a> is currently under discussion
-         in the working group and may be removed.
-        All references to <a>DID URL dereferencing</a> may be subject to change.
+      <p class="issue atrisk">
+        The definition of the <a>DID URL dereferencing</a> feature is currently marked as
+        <dfn>at risk</dfn> and will likely be changed or removed from the specification.
+        The Working Group is seeking feedback from implementers regarding the feature's
+        value as defined by this specification.
       </p>
 
       <p>

--- a/index.html
+++ b/index.html
@@ -2148,10 +2148,12 @@ Dereferencing a DID URL to a service endpoint URL.
     <section id="dereferencing-provisional">
         <h1>PROVISIONAL - DID URL Dereferencing</h1>
 
-        <p class="issue">
-          The dereferencing algorithm is currently [=at risk=], and is labelled as such as per the W3C Process.
-          One version of the algorithm under discussion can be
-          <a href="https://github.com/w3c/did-resolution/pull/344">seen here</a>.
+        <p class="issue atrisk">
+The dereferencing algorithm in this section is an alternative approach to the one in 
+the previous section and is currently marked as [=at risk=].
+The Working Group is likely to converge on a revision to the dereferencing algorithms in 
+this specification being
+<a href="https://github.com/w3c/did-resolution/pull/344">discussed here</a>.
         </p>
 
         <div class="note">


### PR DESCRIPTION
This PR implements the resolution from the DID wg meeting on 2-july:  https://www.w3.org/2026/07/02-did-minutes.html#0fa3

> RESOLUTION: Focus on moving did-resolution to CR, with DID URL Deferencing marked "At Risk"

This marks related sections as at risk per the W3C Processes for the same: https://www.w3.org/policies/process/#at-risk


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ottomorac/did-resolution/pull/346.html" title="Last updated on Jul 9, 2026, 3:13 PM UTC (593540b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-resolution/346/9e330e0...ottomorac:593540b.html" title="Last updated on Jul 9, 2026, 3:13 PM UTC (593540b)">Diff</a>