### PR TITLE
fix some pubrules issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -4186,7 +4186,7 @@ the section related to the <a data-cite="DID#acknowledgements">history of DIDs</
         <li><a href="https://github.com/uport-project/did-resolver">uPort DID resolver</a></li>
       </ol>
     </section>
-    <section class="appendix informative" id=""revision-history">
+    <section class="appendix informative" id="revision-history">
       <h1>Revision History</h1>
       <p>This section lists the changes since the publication of this
       specification as a W3C First Public Working Draft.</p>

--- a/transitions/2026/CR1/common.js
+++ b/transitions/2026/CR1/common.js
@@ -1,0 +1,257 @@
+/* globals omitTerms, respecConfig, $, require */
+/* exported linkCrossReferences, restrictReferences, fixIncludes */
+
+var ccg = {
+  // Add as the respecConfig localBiblio variable
+  // Extend or override global respec references
+  localBiblio: {
+    "REST": {
+      title: "Architectural Styles and the Design of Network-based Software Architectures",
+      date: "2000",
+      href: "http://www.ics.uci.edu/~fielding/pubs/dissertation/",
+      authors: [
+        "Fielding, Roy Thomas"
+      ],
+      publisher: "University of California, Irvine."
+    },
+    "HASHLINK": {
+      title: "Cryptographic Hyperlinks",
+      date: "December 2018",
+      href: "https://tools.ietf.org/html/draft-sporny-hashlink-05",
+      authors: [
+          "Manu Sporny"
+      ],
+      status: "Internet-Draft",
+      publisher: "IETF"
+    },
+    "DATA-INTEGRITY": {
+      title: "Verifiable Credential Data Integrity 1.0",
+      href: "https://www.w3.org/TR/vc-data-integrity/",
+      authors: [
+        "Dave Longley",
+        "Manu Sporny"
+      ],
+      status: "CRD",
+      publisher: "W3C Verifiable Credentials Working Group"
+    },
+    "MATRIX-URIS": {
+      title: "Matrix URIs - Ideas about Web Architecture",
+      date: "December 1996",
+      href: "https://www.w3.org/DesignIssues/MatrixURIs.html",
+      authors: [
+        "Tim Berners-Lee"
+      ],
+      status: "Personal View"
+    },
+    "COOL-URIS": {
+      title: "Cool URIs for the Semantic Web",
+      date: "December 2008",
+      href: "https://www.w3.org/TR/cooluris/",
+      authors: [
+        "Leo Sauermann",
+        "Richard Cyganiak"
+      ],
+      status: "Interest Group Note"
+    },
+    "KERI": {
+      title: "Key Event Receipt Infrastructure (KERI)",
+      date: "July 2019",
+      href: "https://arxiv.org/abs/1907.02143",
+      authors: [
+        "Samuel M. Smith"
+      ]
+    },
+    "DID-PEER": {
+      title: "Peer DID Method Specification",
+      subtitle: "blockchain-independent decentralized identifiers",
+      date: "10 July 2020",
+      href: "https://identity.foundation/peer-did-method-spec/",
+      editors: [
+        "Daniel Hardman",
+      ],
+      authors: [
+        "Oskar Deventer",
+        "Christian Lundkvist",
+        "Márton Csernai",
+        "Kyle Den Hartog",
+        "Markus Sabadello",
+        "Sam Curren",
+        "Dan Gisolfi",
+        "Mike Varley",
+        "Sven Hammann",
+        "John Jordan",
+        "Lovesh Harchandani",
+        "Devin Fisher",
+        "Tobias Looker",
+        "Brent Zundel",
+        "Stephen Curran"
+      ],
+      status: "ED"
+    },
+    "DID-KEY": {
+      title: "The did:key Method",
+      subtitle: "A DID Method for Static Cryptographic Keys",
+      date: " 26 March 2025",
+      href: "https://w3c-ccg.github.io/did-key-spec/",
+      editors: [
+        "Manu Sporny",
+        "Dmitri Zagidulin",
+        "Dave Longley"
+      ],
+      authors: [
+        "Manu Sporny",
+        "Dmitri Zagidulin",
+        "Dave Longley"
+      ],
+      status: "CG-DRAFT"
+    }
+  }
+};
+
+
+
+// We should be able to remove terms that are not actually
+// referenced from the common definitions
+//
+// the termlist is in a block of class "termlist", so make sure that
+// has an ID and put that ID into the termLists array so we can
+// interrogate all of the included termlists later.
+var termNames = [] ;
+var termLists = [] ;
+var termsReferencedByTerms = [] ;
+
+function restrictReferences(utils, content) {
+    "use strict";
+    var base = document.createElement("div");
+    base.innerHTML = content;
+
+    // New new logic:
+    //
+    // 1. build a list of all term-internal references
+    // 2. When ready to process, for each reference INTO the terms,
+    // remove any terms they reference from the termNames array too.
+    $.each(base.querySelectorAll("dfn"), function(i, item) {
+        var $t = $(item) ;
+        var titles = $t.getDfnTitles();
+        var dropit = false;
+        // do we have an omitTerms
+        if (window.hasOwnProperty("omitTerms")) {
+            // search for a match
+            $.each(omitTerms, function(j, term) {
+                if (titles.indexOf(term) !== -1) {
+                    dropit = true;
+                }
+            });
+        }
+        // do we have an includeTerms
+        if (window.hasOwnProperty("includeTerms")) {
+            var found = false;
+            // search for a match
+            $.each(includeTerms, function(j, term) {
+                if (titles.indexOf(term) !== -1) {
+                    found = true;
+                }
+            });
+            if (!found) {
+                dropit = true;
+            }
+        }
+        if (dropit) {
+            $t.parent().next().remove();
+            $t.parent().remove();
+        } else {
+            var n = $t.makeID("dfn", titles[0]);
+            if (n) {
+                termNames[n] = $t.parent() ;
+            }
+        }
+    });
+
+    var $container = $(".termlist",base) ;
+    var containerID = $container.makeID("", "terms") ;
+    termLists.push(containerID) ;
+
+    return (base.innerHTML);
+}
+// add a handler to come in after all the definitions are resolved
+//
+// New logic: If the reference is within a 'dl' element of
+// class 'termlist', and if the target of that reference is
+// also within a 'dl' element of class 'termlist', then
+// consider it an internal reference and ignore it.
+
+require(["core/pubsubhub"], function(respecEvents) {
+    "use strict";
+    respecEvents.sub('end', function(message) {
+        if (message === 'core/link-to-dfn') {
+            // all definitions are linked; find any internal references
+            $(".termlist a.internalDFN").each(function() {
+                var $r = $(this);
+                var id = $r.attr('href');
+                var idref = id.replace(/^#/,"") ;
+                if (termNames[idref]) {
+                    // this is a reference to another term
+                    // what is the idref of THIS term?
+                    var $def = $r.closest('dd') ;
+                    if ($def.length) {
+                        var $p = $def.prev('dt').find('dfn') ;
+                        var tid = $p.attr('id') ;
+                        if (tid) {
+                            if (termsReferencedByTerms[tid]) {
+                                termsReferencedByTerms[tid].push(idref);
+                            } else {
+                                termsReferencedByTerms[tid] = [] ;
+                                termsReferencedByTerms[tid].push(idref);
+                            }
+                        }
+                    }
+                }
+            }) ;
+
+            // clearRefs is recursive.  Walk down the tree of
+            // references to ensure that all references are resolved.
+            var clearRefs = function(theTerm) {
+                if ( termsReferencedByTerms[theTerm] ) {
+                    $.each(termsReferencedByTerms[theTerm], function(i, item) {
+                        if (termNames[item]) {
+                            delete termNames[item];
+                            clearRefs(item);
+                        }
+                    });
+                }
+                // make sure this term doesn't get removed
+                if (termNames[theTerm]) {
+                    delete termNames[theTerm];
+                }
+            };
+
+            // now termsReferencedByTerms has ALL terms that
+            // reference other terms, and a list of the
+            // terms that they reference
+            $("a.internalDFN").each(function () {
+                var $item = $(this) ;
+                var t = $item.attr('href');
+                var r = t.replace(/^#/,"") ;
+                // if the item is outside the term list
+                if ( ! $item.closest('dl.termlist').length ) {
+                    clearRefs(r);
+                }
+            });
+
+            // delete any terms that were not referenced.
+            Object.keys(termNames).forEach(function(term) {
+                var $p = $("#"+term) ;
+                if ($p) {
+                    var tList = $p.getDfnTitles();
+                    $p.parent().next().remove();
+                    $p.parent().remove() ;
+                    tList.forEach(function( item ) {
+                        if (respecConfig.definitionMap[item]) {
+                            delete respecConfig.definitionMap[item];
+                        }
+                    });
+                }
+            });
+        }
+    });
+});

--- a/transitions/2026/CR1/index.html
+++ b/transitions/2026/CR1/index.html
@@ -4641,7 +4641,7 @@ the section related to the <a href="https://www.w3.org/TR/did-core/#acknowledgem
         <li><a href="https://github.com/uport-project/did-resolver">uPort DID resolver</a></li>
       </ol>
     </section>
-    <section class="appendix informative" id="revision-history" revision-history"=""><div class="header-wrapper"><h2 id="c-revision-history"><bdi class="secno">C. </bdi>Revision History</h2><a class="self-link" href="#revision-history" aria-label="Permalink for Appendix C."></a></div><p><em>This section is non-normative.</em></p>
+    <section class="appendix informative" id="revision-history"><div class="header-wrapper"><h2 id="c-revision-history"><bdi class="secno">C. </bdi>Revision History</h2><a class="self-link" href="#revision-history" aria-label="Permalink for Appendix C."></a></div><p><em>This section is non-normative.</em></p>
       
       <p>This section lists the changes since the publication of this
       specification as a <abbr title="World Wide Web Consortium">W3C</abbr> First Public Working Draft.</p>


### PR DESCRIPTION
- common.js was missing from the snapshot directory
- a typo in an attribute (two leading quotes) was fixed in both index.html and the generated snapshot

pubrules still complains about the shortname not existing (yet) (did-resolution-1.0, was did-resolution so far)
but I'm negociating with the webmasters about this


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-resolution/pull/352.html" title="Last updated on Jul 23, 2026, 5:09 PM UTC (2baee0b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-resolution/352/cb5c844...2baee0b.html" title="Last updated on Jul 23, 2026, 5:09 PM UTC (2baee0b)">Diff</a>