### PR TITLE
Minor non-normative text change to address Issue 322 about implementer use of the Test Suite

### DIFF
--- a/index.html
+++ b/index.html
@@ -328,10 +328,10 @@ Further, the specification's <a href="#dereferencing-algorithm">DID URL derefere
 shows how a client can follow a fragment (e.g., `#key-1`) to extract a
 particular <a>verification method</a> from the <a>DID document</a>
 (see <a href="#example-dereferencing-to-verification-method">here for detailed example</a>).
-In practice, implementers validate their resolver against the
-<a href="https://github.com/w3c-ccg/did-resolution-mocha-test-suite">DID Resolution Test Suite</a>
+Implementers are encouraged to validate their resolver against the
+<a href="https://github.com/w3c/did-resolution-test-suite">DID Resolution Test Suite</a>
 which exercises normative MUSTs and error conditions (such as invalid DIDs,
-deactivated DIDs, unsupported methods, relative URL expansion, etc.) to ensure
+deactivated DIDs, unsupported methods, relative URL expansion, etc.) so
 that client applications can reliably depend on correct resolution behavior
 across different DID methods.
         </p>


### PR DESCRIPTION
A minimal text change to address the concern raised in #322 about the use of the test suite by implementers. While implementers can benefit
from using the test suite, its use in that way is not the purpose of the test suite (as noted in #322). That said, running common tests
across implementations is not a bad thing.  

In the process, fixed the link to the test suite following its recent CCG to W3C move.

Also took out the word "ensure" as a pet peeve in this context.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/swcurran/did-resolution/pull/354.html" title="Last updated on Aug 7, 2026, 3:57 PM UTC (10a7c39)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-resolution/354/dfb2b95...swcurran:10a7c39.html" title="Last updated on Aug 7, 2026, 3:57 PM UTC (10a7c39)">Diff</a>