### PR TITLE
Explain better that function signatures are abstract

### DIFF
--- a/index.html
+++ b/index.html
@@ -753,13 +753,24 @@ All [=conforming DID resolvers=] MUST implement the
       </p>
 
       <p>
-Conforming <a>DID resolver</a> implementations do not alter
-the signature of this function in any way.
+The signature of this function is to be understood as an abstract interface
+for the specified algorithm, with logical named inputs and outputs. Conforming
+<a>DID resolution</a> implementations are not required to
+implement this function using the same names of the inputs, outputs,
+or of the function itself, nor do they need to implement the algorithm in
+any specific form, such as an explicit function call in a programming language,
+a software library, or a protocol endpoint.
+      </p>
+      <p>
+<a>Bindings</a> such as the <a href="#bindings-https">HTTP(S) binding</a>
+can be used to define specific ways of implementing and exposing this function.
+      </p>
+      <p>
 <a>DID resolver</a> implementations might map the
 <code>resolve</code> function to a method-specific internal function to
 perform the actual <a>DID resolution</a> process.
 <a>DID resolver</a> implementations might implement and
-expose additional functions with different signatures in addition to the
+expose additional functions with different signatures than the
 <code>resolve</code> function specified here.
       </p>
 
@@ -1464,9 +1475,7 @@ dereference(didUrl, dereferenceOptions) →
 
       <p>
 All [=conforming DID URL dereferencers=] MUST implement the [=DID URL
-dereferencing=] function for at least one [=DID method=]. All inputs and
-outputs of the <code>dereference</code>
-function apart from [=contentStream=] MUST be serializable to JSON.
+dereferencing=] function for at least one [=DID method=].
       </p>
 
       <p>
@@ -1556,13 +1565,24 @@ structure is further defined in <a href="#did-url-content-metadata"></a>.
       </dl>
 
       <p>
-Conforming <a>DID URL dereferencing</a> implementations do not alter
-the signature of these functions in any way.
+The signature of this function is to be understood as an abstract interface
+for the specified algorithm, with logical named inputs and outputs. Conforming
+<a>DID URL dereferencing</a> implementations are not required to
+implement this function using the same names of the inputs, outputs,
+or of the function itself, nor do they need to implement the algorithm in
+any specific form, such as an explicit function call in a programming language,
+a software library, or a protocol endpoint.
+      </p>
+      <p>
+<a>Bindings</a> such as the <a href="#bindings-https">HTTP(S) binding</a>
+can be used to define specific ways of implementing and exposing this function.
+      </p>
+      <p>
 <a>DID URL dereferencing</a> implementations might map the
 <code>dereference</code> function to a method-specific internal function
 to perform the actual <a>DID URL dereferencing</a> process.
 <a>DID URL dereferencing</a> implementations might implement and
-expose additional functions with different signatures in addition to the
+expose additional functions with different signatures than the
 <code>dereference</code> function specified here.
       </p>
 


### PR DESCRIPTION
In discussions about the DID URL dereferencing algorithm, I keep hearing statements such as:

- _"a browser should not need to expose an endpoint"_
- _"when I dereference a DID URL, I don't need to implement the exact function in the spec, I just implement an algorithm"_
- _"dereferencing should not require a separate library or SDK"_

I fully agree with all these statements, and I think so does everyone else in the WG. Unfortunately, it seems the current DID URL dereferencing algorithm is sometimes misunderstood as requiring any of the above things, which has never been the intention.

I think the source of some of this misunderstanding may be language which says "implementations do not alter the signature of these functions", which currently exists in both the DID Resolution and DID URL Dereferencing sections.

I traced this down to the following commits some years ago:
- https://github.com/w3c/did/commit/78ffa498ffd39aa93da6b0b45c3f2a33ca10528e
- https://github.com/w3c/did/commit/8bfe90e72893f0ab0e8e1bce0dc5ad6b896aece4
- https://github.com/w3c/did/commit/2dc94f3984ef5b2c44dc80173abe06422adace79

It seems this language was a mistake, so here's a PR which emphasizes that `resolve()` and `dereference()` are abstract interfaces for the specified algorithms with logical inputs and outputs, but there is no requirement to implement them in any specific form.

So for example, when you want to verify a proof on a Verifiable Credential and you dereference a DID URL to a verification method, your implementation of the DID Resolution and DID URL Dereferencing algorithms can take any form you want, they don't have to be implemented as a function call, or SDK, or remote API. To me, this has always been clear anyway, but I can see how the current spec language didn't emphasize this sufficiently.

^ @jandrieu


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/peacekeeper/did-resolution/pull/356.html" title="Last updated on Aug 19, 2026, 4:38 PM UTC (371aa9f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-resolution/356/dfb2b95...peacekeeper:371aa9f.html" title="Last updated on Aug 19, 2026, 4:38 PM UTC (371aa9f)">Diff</a>